### PR TITLE
feat: Retriever 노드 시작 메시지 스트리밍 추가

### DIFF
--- a/common/sse/constants.py
+++ b/common/sse/constants.py
@@ -7,6 +7,7 @@ class SSEEventType(StrEnum):
     """SSE 이벤트 타입 (event 필드에 사용)"""
 
     CONTENT_BLOCK_DELTA = "content_block_delta"
+    RETRIEVER_STATUS = "retriever_status"
     RETRIEVER_RESULT = "retriever_result"
     MESSAGE_COMPLETE = "message_complete"
     ERROR = "error"
@@ -31,6 +32,7 @@ class LangGraphEventType(StrEnum):
     """LangGraph astream_events에서 사용하는 이벤트 타입"""
 
     ON_CHAT_MODEL_STREAM = "on_chat_model_stream"
+    ON_CHAIN_START = "on_chain_start"
     ON_CHAIN_END = "on_chain_end"
 
 

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -368,6 +368,20 @@ class InterviewService:
                 metadata = event.get("metadata", {})
                 node_name = metadata.get("langgraph_node")
 
+                # retriever 노드 시작 시 상태 메시지 스트리밍
+                if event_type == LangGraphEventType.ON_CHAIN_START and node_name == "retriever":
+                    yield {
+                        "event": SSEEventType.RETRIEVER_STATUS,
+                        "data": json.dumps(
+                            {
+                                "type": SSEEventType.RETRIEVER_STATUS,
+                                "message": "대화 내용을 바탕으로 유사도가 높은 인사이트 로그를 읽었어요.",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+
+                # retriever 노드 완료 시 검색 결과 스트리밍
                 if event_type == LangGraphEventType.ON_CHAIN_END and node_name == "retriever":
                     output = event.get("data", {}).get("output")
                     yield {


### PR DESCRIPTION
## 📝 작업 내용

- Retriever 노드의 시작 이벤트를 감지해서 인사이트 로그 시작 메시지 스트리밍 추가

## 📸 스크린샷

<img width="574" height="421" alt="image" src="https://github.com/user-attachments/assets/53275968-24db-471d-bc8f-d1d6d6e561ed" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams a start status message when the retriever node begins, giving users instant feedback during insight log fetching. Adds SSE and LangGraph event support for this start signal.

- **New Features**
  - Emit RETRIEVER_STATUS via SSE on LangGraph ON_CHAIN_START for node "retriever".
  - Message streamed: "대화 내용을 바탕으로 유사도가 높은 인사이트 로그를 읽었어요."

<sup>Written for commit b1cdb59efe602df69e3a2076d20547b818e88d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

