### PR TITLE
[Refactor] 포트폴리오 생성 필드명 개편 (description/contributions/achievements/insights)

### DIFF
--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -38,10 +38,10 @@ def _to_portfolio_result_response(result) -> PortfolioResultResponse:
         experience_name=result.experience_name,
         status=result.status,
         contribution_rate=result.contribution_rate,
-        detail_info=result.output.detail_info,
-        assigned_task=result.output.assigned_task,
-        problem_solving=result.output.problem_solving,
-        lessons_learned=result.output.lessons_learned,
+        description=result.output.description,
+        contributions=result.output.contributions,
+        achievements=result.output.achievements,
+        insights=result.output.insights,
     )
 
 

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -38,10 +38,10 @@ class PortfolioResultResponse(BaseModel):
     experience_name: str = Field(..., description="경험/프로젝트명")
     status: PortfolioStatus = Field(..., description="생성 상태")
     contribution_rate: int | None = Field(None, ge=0, le=100, description="기여도 (0-100%)")
-    detail_info: str = Field(..., description="상세정보")
-    assigned_task: str = Field(..., description="담당업무")
-    problem_solving: str = Field(..., description="문제해결")
-    lessons_learned: str = Field(..., description="배운 점")
+    description: str = Field(..., description="상세정보")
+    contributions: str = Field(..., description="담당업무")
+    achievements: str = Field(..., description="문제해결")
+    insights: str = Field(..., description="배운 점")
 
 
 # ===== 기여도 수정 =====

--- a/features/portfolio/config/portfolio.yaml
+++ b/features/portfolio/config/portfolio.yaml
@@ -2,19 +2,19 @@
 
 # 섹션별 검증 규칙
 sections:
-    detail_info:
-        description: "상세정보 — 프로젝트 배경, 목표, 팀 구성 등을 서술형으로 작성"
+    description:
+        description: "상세정보 — 프로젝트 배경, 목표, 팀 구성을 서술형으로 작성"
         min_length: 100
         required: true
-    assigned_task:
+    contributions:
         description: "담당업무 — 본인이 수행한 핵심 업무와 사용 기술을 서술형으로 작성"
         min_length: 100
         required: true
-    problem_solving:
+    achievements:
         description: "문제해결 — 직면한 문제와 해결 과정, 의사결정 논리를 서술형으로 작성"
         min_length: 100
         required: true
-    lessons_learned:
+    insights:
         description: "배운 점 — 성과, 개인적 성장, 향후 계획을 서술형으로 작성"
         min_length: 100
         required: true
@@ -28,11 +28,11 @@ llm:
 # collected_data → 섹션 매핑 규칙
 # 인터뷰에서 수집된 데이터를 포트폴리오 섹션에 매핑
 section_mapping:
-    detail_info:
+    description:
         - "stage_1" # 프로젝트 개요 및 구조화
-    assigned_task:
+    contributions:
         - "stage_2" # 구체적 실행 과정
-    problem_solving:
+    achievements:
         - "stage_3" # 문제 해결과 논리
-    lessons_learned:
+    insights:
         - "stage_4" # 성과 및 회고

--- a/features/portfolio/generator.py
+++ b/features/portfolio/generator.py
@@ -14,7 +14,7 @@ from .prompts.portfolio_generator import (
 from .schemas import PortfolioOutput
 
 _MAX_ATTEMPTS = 3
-_SECTION_FIELDS = ("detail_info", "assigned_task", "problem_solving", "lessons_learned")
+_SECTION_FIELDS = ("description", "contributions", "achievements", "insights")
 _BULLET_PATTERN = re.compile(r"(?m)^\s*[-*•]\s+")
 
 

--- a/features/portfolio/prompts/portfolio_generator.py
+++ b/features/portfolio/prompts/portfolio_generator.py
@@ -91,21 +91,21 @@ PORTFOLIO_GENERATOR_SYSTEM_TEMPLATE = """
 {collected_data_text}
 
 # 섹션별 매핑 가이드
-- detail_info: stage_1의 project_background, problem_definition, message_or_concept, project_duration, team_composition, target_audience를 바탕으로 작성
-- assigned_task: stage_2의 work_categories를 바탕으로 작성
-- problem_solving: stage_3의 problem_episodes를 바탕으로 작성
-- lessons_learned: stage_4의 final_deliverable, quantitative_results, qualitative_results, personal_growth, insights_gained, future_plans를 바탕으로 작성
+- description: stage_1의 project_background, problem_definition, message_or_concept, project_duration, team_composition, target_audience를 바탕으로 작성
+- contributions: stage_2의 work_categories를 바탕으로 작성
+- achievements: stage_3의 problem_episodes를 바탕으로 작성
+- insights: stage_4의 final_deliverable, quantitative_results, qualitative_results, personal_growth, insights_gained, future_plans를 바탕으로 작성
 
 # 출력 지침
 1. 결과는 마크다운 불릿이 아닌 자연스러운 문장과 문단으로 작성하세요.
 2. 1인칭 시점("저는", "제가")으로 작성하세요.
-3. 각 섹션(detail_info, assigned_task, problem_solving, lessons_learned)은 최소 2~3문장 이상으로 작성하세요.
+3. 각 섹션(description, contributions, achievements, insights)은 최소 2~3문장 이상으로 작성하세요.
 4. 수집되지 않은 필드가 있더라도, 수집된 정보만 활용해 최대한 자연스럽고 완성도 있게 작성하세요.
 5. 각 섹션은 다음 목적을 충족해야 합니다.
-   - detail_info: 경험의 배경/목표/기간/팀 맥락을 명확히 전달
-   - assigned_task: 제가 맡은 핵심 업무와 실행 과정을 구체적으로 설명
-   - problem_solving: 문제 상황, 해결 행동, 판단 근거를 흐름 있게 설명
-   - lessons_learned: 결과, 성장, 인사이트, 향후 계획을 일관되게 정리
+   - description: 경험의 배경/목표/기간/팀 맥락을 명확히 전달
+   - contributions: 제가 맡은 핵심 업무와 실행 과정을 구체적으로 설명
+   - achievements: 문제 상황, 해결 행동, 판단 근거를 흐름 있게 설명
+   - insights: 결과, 성장, 인사이트, 향후 계획을 일관되게 정리
 
 # 이전 시도 피드백
 {validation_feedback}

--- a/features/portfolio/repository.py
+++ b/features/portfolio/repository.py
@@ -15,10 +15,10 @@ CREATE TABLE IF NOT EXISTS portfolios (
     user_id           VARCHAR     NOT NULL,
     experience_name   VARCHAR     NOT NULL,
     status            VARCHAR     NOT NULL DEFAULT 'not_started',
-    detail_info       TEXT,
-    assigned_task     TEXT,
-    problem_solving   TEXT,
-    lessons_learned   TEXT,
+    description       TEXT,
+    contributions     TEXT,
+    achievements      TEXT,
+    insights          TEXT,
     contribution_rate INTEGER     DEFAULT 0,
     error_message     TEXT,
     created_at        TIMESTAMPTZ DEFAULT NOW(),
@@ -122,20 +122,20 @@ class PortfolioRepository:
         await self._pool.execute(
             """
             UPDATE portfolios
-            SET detail_info     = $2,
-                assigned_task   = $3,
-                problem_solving = $4,
-                lessons_learned = $5,
-                status          = 'completed',
-                error_message   = NULL,
-                updated_at      = NOW()
+            SET description   = $2,
+                contributions = $3,
+                achievements  = $4,
+                insights      = $5,
+                status        = 'completed',
+                error_message = NULL,
+                updated_at    = NOW()
             WHERE id = $1::uuid
             """,
             portfolio_id,
-            output.detail_info,
-            output.assigned_task,
-            output.problem_solving,
-            output.lessons_learned,
+            output.description,
+            output.contributions,
+            output.achievements,
+            output.insights,
         )
 
     async def update_status(

--- a/features/portfolio/schemas.py
+++ b/features/portfolio/schemas.py
@@ -13,10 +13,10 @@ class PortfolioOutput(BaseModel):
     LLM의 .with_structured_output() 호출에 직접 사용됩니다.
     """
 
-    detail_info: str = Field(..., description="상세정보, 서술형 문단")
-    assigned_task: str = Field(..., description="담당업무, 서술형 문단")
-    problem_solving: str = Field(..., description="문제해결, 서술형 문단")
-    lessons_learned: str = Field(..., description="배운 점, 서술형 문단")
+    description: str = Field(..., description="상세정보, 서술형 문단")
+    contributions: str = Field(..., description="담당업무, 서술형 문단")
+    achievements: str = Field(..., description="문제해결, 서술형 문단")
+    insights: str = Field(..., description="배운 점, 서술형 문단")
 
 
 class PortfolioStatus(str, Enum):

--- a/features/portfolio/service.py
+++ b/features/portfolio/service.py
@@ -183,13 +183,13 @@ class PortfolioService:
         output: PortfolioOutput | None = None
         if all(
             row.get(key) is not None
-            for key in ["detail_info", "assigned_task", "problem_solving", "lessons_learned"]
+            for key in ["description", "contributions", "achievements", "insights"]
         ):
             output = PortfolioOutput(
-                detail_info=row["detail_info"],
-                assigned_task=row["assigned_task"],
-                problem_solving=row["problem_solving"],
-                lessons_learned=row["lessons_learned"],
+                description=row["description"],
+                contributions=row["contributions"],
+                achievements=row["achievements"],
+                insights=row["insights"],
             )
 
         return PortfolioResult(

--- a/tests/test_app/test_api/test_v1/test_portfolio.py
+++ b/tests/test_app/test_api/test_v1/test_portfolio.py
@@ -140,10 +140,10 @@ def test_update_contribution_rate_returns_200(monkeypatch):
         status=PortfolioStatus.COMPLETED,
         contribution_rate=10,
         output=PortfolioOutput(
-            detail_info="상세",
-            assigned_task="담당",
-            problem_solving="해결",
-            lessons_learned="배운점",
+            description="상세",
+            contributions="담당",
+            achievements="해결",
+            insights="배운점",
         ),
         created_at=datetime.now(UTC),
     )
@@ -191,10 +191,10 @@ def test_get_session_returns_200(monkeypatch):
         status=PortfolioStatus.COMPLETED,
         contribution_rate=50,
         output=PortfolioOutput(
-            detail_info="상세",
-            assigned_task="담당",
-            problem_solving="해결",
-            lessons_learned="배운점",
+            description="상세",
+            contributions="담당",
+            achievements="해결",
+            insights="배운점",
         ),
         created_at=datetime.now(UTC),
     )

--- a/tests/test_features/test_portfolio/test_generator.py
+++ b/tests/test_features/test_portfolio/test_generator.py
@@ -35,19 +35,19 @@ class DummyLLM:
 def _valid_output() -> PortfolioOutput:
     text = "포트폴리오 문단 " * 20
     return PortfolioOutput(
-        detail_info=text,
-        assigned_task=text,
-        problem_solving=text,
-        lessons_learned=text,
+        description=text,
+        contributions=text,
+        achievements=text,
+        insights=text,
     )
 
 
 def _invalid_output() -> PortfolioOutput:
     return PortfolioOutput(
-        detail_info="짧음",
-        assigned_task="- 항목1\n- 항목2",
-        problem_solving="",
-        lessons_learned="짧음",
+        description="짧음",
+        contributions="- 항목1\n- 항목2",
+        achievements="",
+        insights="짧음",
     )
 
 

--- a/tests/test_features/test_portfolio/test_portfolio_prompt.py
+++ b/tests/test_features/test_portfolio/test_portfolio_prompt.py
@@ -72,7 +72,6 @@ def test_portfolio_prompt_formatting_contains_guidelines():
 
     assert len(messages) == 2
     assert "결제 전환율 개선 프로젝트" in messages[0].content
-    assert "detail_info" in messages[0].content
+    assert "description" in messages[0].content
     assert "1인칭" in messages[0].content
     assert "최소 2~3문장" in messages[0].content
-

--- a/tests/test_features/test_portfolio/test_portfolio_service.py
+++ b/tests/test_features/test_portfolio/test_portfolio_service.py
@@ -42,7 +42,9 @@ class DummyRepo:
         }
         return "new-id"
 
-    async def update_status(self, portfolio_id: str, status: str, error_message: str | None = None) -> None:
+    async def update_status(
+        self, portfolio_id: str, status: str, error_message: str | None = None
+    ) -> None:
         self.updated_status = {
             "portfolio_id": portfolio_id,
             "status": status,
@@ -62,10 +64,10 @@ class DummyRepo:
 class DummyGenerator:
     def __init__(self, output: PortfolioOutput | None = None, exc: Exception | None = None):
         default_output = PortfolioOutput(
-            detail_info="상세",
-            assigned_task="담당",
-            problem_solving="해결",
-            lessons_learned="배운점",
+            description="상세",
+            contributions="담당",
+            achievements="해결",
+            insights="배운점",
         )
         self.output = output or default_output
         self.exc = exc
@@ -77,7 +79,9 @@ class DummyGenerator:
 
 
 @pytest.mark.asyncio
-async def test_start_generation_creates_and_schedules_background_task(monkeypatch: pytest.MonkeyPatch):
+async def test_start_generation_creates_and_schedules_background_task(
+    monkeypatch: pytest.MonkeyPatch,
+):
     """완료된 세션이면 generating 레코드를 만들고 background task를 등록한다."""
     state = {
         "all_stages_complete": True,
@@ -112,7 +116,12 @@ async def test_start_generation_creates_and_schedules_background_task(monkeypatc
 @pytest.mark.asyncio
 async def test_start_generation_returns_existing_id_for_duplicate_session():
     """동일 세션의 generating/completed 포트폴리오가 있으면 기존 ID를 반환한다."""
-    state = {"all_stages_complete": True, "collected_data": {}, "experience_name": "x", "user_id": "u"}
+    state = {
+        "all_stages_complete": True,
+        "collected_data": {},
+        "experience_name": "x",
+        "user_id": "u",
+    }
     repo = DummyRepo(row={"id": "existing-id", "status": PortfolioStatus.GENERATING.value})
     service = PortfolioService(
         repository=repo,
@@ -120,7 +129,9 @@ async def test_start_generation_returns_existing_id_for_duplicate_session():
         interview_service=DummyInterviewService(state),
     )
 
-    portfolio_id = await service.start_generation("session-1", "u", background_tasks=DummyBackgroundTasks())
+    portfolio_id = await service.start_generation(
+        "session-1", "u", background_tasks=DummyBackgroundTasks()
+    )
 
     assert portfolio_id == "existing-id"
     assert repo.created_args is None
@@ -156,10 +167,10 @@ async def test_get_status_and_get_result_for_completed_row():
         "experience_name": "exp",
         "status": PortfolioStatus.COMPLETED.value,
         "contribution_rate": 55,
-        "detail_info": "상세",
-        "assigned_task": "담당",
-        "problem_solving": "해결",
-        "lessons_learned": "배운점",
+        "description": "상세",
+        "contributions": "담당",
+        "achievements": "해결",
+        "insights": "배운점",
         "created_at": datetime.now(UTC),
         "error_message": None,
     }
@@ -175,4 +186,4 @@ async def test_get_status_and_get_result_for_completed_row():
     assert status.status == PortfolioStatus.COMPLETED
     assert result is not None
     assert result.output is not None
-    assert result.output.problem_solving == "해결"
+    assert result.output.achievements == "해결"


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #94

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 포트폴리오 4개 섹션의 내부 필드 키를 다음으로 전면 교체했습니다.
  - `detail_info` → `description`
  - `assigned_task` → `contributions`
  - `problem_solving` → `achievements`
  - `lessons_learned` → `insights`
- 스키마/서비스/저장소/API 응답 매핑을 새 필드 키 기준으로 일괄 정렬했습니다.
  - `features/portfolio/schemas.py`
  - `features/portfolio/generator.py`
  - `features/portfolio/repository.py`
  - `features/portfolio/service.py`
  - `app/schemas/portfolio.py`
  - `app/api/v1/portfolio.py`
- 프롬프트/설정 키도 새 필드 키로 교체했습니다.
  - `features/portfolio/prompts/portfolio_generator.py`
  - `features/portfolio/config/portfolio.yaml`
- 사용자 노출 설명 문구는 요청에 따라 기존 도메인 용어를 유지했습니다.
  - "상세정보, 담당업무, 문제해결, 배운 점"
- 테스트 코드의 fixture/expected/assert도 새 필드 키 기준으로 업데이트했습니다.
  - `tests/test_features/test_portfolio/*`
  - `tests/test_app/test_api/test_v1/test_portfolio.py`
- 레거시 필드명 잔존 여부를 전체 검색으로 확인했으며, 잔존 항목이 없습니다.

## 🗄️ DB 마이그레이션 (브레이킹 변경)

- Supabase MCP로 컬럼 rename 마이그레이션을 적용했습니다.
  - migration name: `rename_portfolio_section_columns`
  - version: `20260227025440`
- 적용 SQL:
  - `ALTER TABLE portfolios RENAME COLUMN detail_info TO description;`
  - `ALTER TABLE portfolios RENAME COLUMN assigned_task TO contributions;`
  - `ALTER TABLE portfolios RENAME COLUMN problem_solving TO achievements;`
  - `ALTER TABLE portfolios RENAME COLUMN lessons_learned TO insights;`
- 사후 점검:
  - `information_schema.columns`에서 신규 컬럼명 반영 확인
  - 샘플 데이터 조회 시 값 보존 확인

## 📸 스크린샷

- 없음 (백엔드/스키마 리팩토링)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 브레이킹 변경입니다. 앱 코드와 DB 컬럼명이 동기화되어야 정상 동작합니다.
- 이번 변경은 필드 키 이름 개편이 목적이며, 사용자 노출용 한글 설명 문구는 기존 용어를 유지했습니다.
- 실행 테스트:
  - `pytest tests/test_features/test_portfolio -v` (12 passed)
  - `pytest tests/test_app/test_api/test_v1/test_portfolio.py -v` (9 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 포트폴리오 응답 필드명이 업데이트되었습니다: 상세정보 → 설명, 담당업무 → 기여도, 문제해결 → 성과, 배운 점 → 인사이트로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->