### PR TITLE
[Fix] DB 커넥션 풀 미초기화 시 앱 가동 실패하도록 수정

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,13 +46,16 @@ async def lifespan(app: FastAPI):
     pool = None
     db_url = os.getenv("DATABASE_URL")
 
-    if db_url:
-        try:
-            pool = await create_pool()
-        except Exception:
-            logger.exception("DB 커넥션 풀 생성 실패 - InsightStore/포트폴리오/첨삭 DB 비활성화")
-    else:
-        logger.warning("DATABASE_URL이 설정되지 않음 - InsightStore/포트폴리오/첨삭 DB 비활성화")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL 환경변수가 설정되지 않았습니다. 애플리케이션을 시작할 수 없습니다."
+        )
+
+    try:
+        pool = await create_pool()
+    except Exception:
+        logger.exception("DB 커넥션 풀 생성 실패 - 애플리케이션 시작 중단")
+        raise
 
     # ===== InsightStore 초기화 (임시 pgvector) =====
     if pool is not None:

--- a/features/portfolio/config/portfolio.yaml
+++ b/features/portfolio/config/portfolio.yaml
@@ -17,7 +17,7 @@ sections:
 
 # LLM 호출 설정
 llm:
-    model: "openai/gpt-oss-120b"
+    model: "google/gemini-3.1-pro-preview"
     temperature: 0.7
     max_retries: 3
 


### PR DESCRIPTION
## 📝 문제/원인 및 수정

- 기존에는 DATABASE_URL이 설정되지 않거나 DB 연결에 실패한 경우, 기존 코드는 예외를 조용히 무시하고 `pool = None` 상태로 앱을 기동시켰습니다. 이후 API 요청이 들어오면 `get_pool()`에서 아래 에러가 발생하며 요청이 500으로 실패
`RuntimeError: DB 커넥션 풀이 초기화되지 않았습니다.`

[원인]
- `app/main.py` lifespan의 DB 초기화 블록에서 예외 발생 시 `raise`를 하지 않아 풀 없이 앱이 정상 기동된 것처럼 보였음.

[수정]
- `DATABASE_URL` 미설정 시 즉시 `RuntimeError` raise → 앱 기동 자체 실패
- `create_pool()` 예외 발생 시 로그 후 re-raise → Render에서 기동 실패로 감지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 연결 설정 검증을 강화했습니다. 필수 설정이 누락되면 애플리케이션 시작 시 명확한 오류를 표시합니다.
  * AI 모델 제공자를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->