### PR TITLE
[Feat] Swagger UI에 X-API-Key authorization 추가

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,12 +2,14 @@
 
 import os
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
 
 from app.api import router as api_router
-from app.middleware.auth import ApiKeyAuthMiddleware
+from app.middleware.auth import DOCS_EXEMPT_PATHS, PUBLIC_EXEMPT_PATHS, ApiKeyAuthMiddleware
 from common.checkpointer.factory import get_checkpointer, setup_checkpointer
 from common.logging import setup_logging
 
@@ -15,6 +17,39 @@ from common.logging import setup_logging
 setup_logging()
 
 APP_VERSION = "0.1.0"
+OPENAPI_API_KEY_SCHEME_NAME = "ApiKeyAuth"
+OPENAPI_HTTP_METHODS = {
+    "get",
+    "put",
+    "post",
+    "delete",
+    "options",
+    "head",
+    "patch",
+    "trace",
+}
+
+
+def _attach_api_key_security(schema: dict[str, Any]) -> dict[str, Any]:
+    """OpenAPI 스키마에 `X-API-Key` 보안 스키마를 반영한다."""
+    components = schema.setdefault("components", {})
+    security_schemes = components.setdefault("securitySchemes", {})
+    security_schemes[OPENAPI_API_KEY_SCHEME_NAME] = {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+    }
+
+    for path, path_item in schema.get("paths", {}).items():
+        if path in PUBLIC_EXEMPT_PATHS or path in DOCS_EXEMPT_PATHS:
+            continue
+
+        for method, operation in path_item.items():
+            if method not in OPENAPI_HTTP_METHODS:
+                continue
+            operation["security"] = [{OPENAPI_API_KEY_SCHEME_NAME: []}]
+
+    return schema
 
 
 def _load_allowed_origins() -> list[str]:
@@ -171,6 +206,22 @@ def create_app() -> FastAPI:
 
     # 라우터 등록
     app.include_router(api_router)
+
+    def custom_openapi() -> dict[str, Any]:
+        """Swagger UI에서 `X-API-Key` 입력을 위한 OpenAPI 스키마 생성."""
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+        app.openapi_schema = _attach_api_key_security(schema)
+        return app.openapi_schema
+
+    app.openapi = custom_openapi
 
     return app
 

--- a/tests/test_app/test_main_infra.py
+++ b/tests/test_app/test_main_infra.py
@@ -64,3 +64,47 @@ def test_get_health_returns_unhealthy_when_api_key_missing(monkeypatch):
 
     assert health["status"] == "unhealthy"
     assert health["api_key"] == "missing"
+
+
+def test_openapi_includes_x_api_key_security_scheme():
+    """OpenAPI 스키마에 `X-API-Key` 보안 스키마가 포함된다."""
+    app = main.create_app()
+
+    schema = app.openapi()
+
+    assert schema["components"]["securitySchemes"][main.OPENAPI_API_KEY_SCHEME_NAME] == {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+    }
+
+
+def test_openapi_marks_api_routes_with_api_key_security():
+    """`/api/*` 경로는 OpenAPI에서 API Key 보안 요구사항을 가진다."""
+    app = main.create_app()
+
+    schema = app.openapi()
+    api_operations = []
+
+    for path, path_item in schema["paths"].items():
+        if not path.startswith("/api/"):
+            continue
+        for method in main.OPENAPI_HTTP_METHODS:
+            operation = path_item.get(method)
+            if operation:
+                api_operations.append(operation)
+
+    assert api_operations
+    assert all(
+        operation["security"] == [{main.OPENAPI_API_KEY_SCHEME_NAME: []}]
+        for operation in api_operations
+    )
+
+
+def test_openapi_keeps_health_route_public():
+    """헬스체크 경로는 OpenAPI에서 보안 요구사항이 없다."""
+    app = main.create_app()
+
+    schema = app.openapi()
+
+    assert "security" not in schema["paths"]["/health"]["get"]


### PR DESCRIPTION
## 📌 관련 이슈

- N/A

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- OpenAPI API key 스키마 상수(ApiKeyAuth)와 HTTP 메서드 목록을 추가
- _attach_api_key_security()를 추가해서 OpenAPI에 X-API-Key 헤더 보안 스키마를 등록하고, 공개 경로(/health 등) 제외한 오퍼레이션에 security를 붙이도록 함
- custom_openapi()를 등록해서 Swagger가 위 스키마를 사용하게 함
- 테스트 3개 추가 (`tests/test_app/test_main_infra.py`)

## 📸 스크린샷

<img width="1059" height="410" alt="image" src="https://github.com/user-attachments/assets/a672e4a3-9d9f-49c4-8684-239b66e712bc" />

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 요청 시 X-API-Key 헤더를 통한 인증이 추가되었습니다. 대부분의 API 엔드포인트에서 API 키 검증이 필요하며, /health와 같은 특정 경로는 공개 접근이 가능합니다.

* **테스트**
  * OpenAPI 보안 통합을 검증하기 위한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->