### PR TITLE
[Refactor] InsightStore 메인 서버 API 전환 및 포트폴리오 generate 마이그레이션

### DIFF
--- a/app/api/v1/correction.py
+++ b/app/api/v1/correction.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 def _validate_correction_id(correction_id: str) -> None:
-    """correction_id가 유효한 UUID 형식인지 검증한다."""
+    """correction_id가 유효한 숫자 ID 또는 UUID 형식인지 검증한다."""
+    if correction_id.isdigit() and int(correction_id) > 0:
+        return
+
     try:
         _uuid.UUID(correction_id)
     except ValueError as e:
@@ -282,7 +285,12 @@ async def update_emphasis_points(
         await service.update_emphasis_points(correction_id, request.emphasis_points)
         return {"message": "강조 포인트가 수정되었습니다."}
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+        error_status = (
+            status.HTTP_404_NOT_FOUND
+            if "첨삭을 찾을 수 없습니다" in str(e)
+            else status.HTTP_400_BAD_REQUEST
+        )
+        raise HTTPException(status_code=error_status, detail=str(e)) from e
     except HTTPException:
         raise
     except Exception:
@@ -389,7 +397,12 @@ async def delete_correction(correction_id: str) -> Response:
         await service.delete_correction(correction_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+        error_status = (
+            status.HTTP_404_NOT_FOUND
+            if "첨삭을 찾을 수 없습니다" in str(e)
+            else status.HTTP_400_BAD_REQUEST
+        )
+        raise HTTPException(status_code=error_status, detail=str(e)) from e
     except HTTPException:
         raise
     except Exception:

--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -62,14 +62,9 @@ async def generate_portfolio(
     """포트폴리오 생성을 시작합니다."""
     service = get_portfolio_service()
 
-    if await service.has_generating_or_completed(request.session_id):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"이미 생성 중이거나 완료된 포트폴리오가 존재합니다: {request.session_id}",
-        )
-
     try:
         portfolio_id = await service.start_generation(
+            portfolio_id=request.portfolio_id,
             session_id=request.session_id,
             user_id=request.user_id,
             background_tasks=background_tasks,
@@ -81,7 +76,7 @@ async def generate_portfolio(
         )
 
     return GeneratePortfolioResponse(
-        portfolio_id=portfolio_id,
+        portfolio_id=str(portfolio_id),
         status=PortfolioStatus.GENERATING,
     )
 

--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -19,7 +19,10 @@ router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
 
 def _validate_portfolio_id(portfolio_id: str) -> None:
-    """portfolio_id가 유효한 UUID 형식인지 검증한다."""
+    """portfolio_id가 유효한 숫자 ID 또는 UUID 형식인지 검증한다."""
+    if portfolio_id.isdigit() and int(portfolio_id) > 0:
+        return
+
     try:
         _uuid.UUID(portfolio_id)
     except ValueError as e:
@@ -135,7 +138,11 @@ async def update_contribution_rate(
             detail=f"포트폴리오를 찾을 수 없습니다: {portfolio_id}",
         )
 
-    await service.update_contribution_rate(portfolio_id, request.contribution_rate)
+    try:
+        await service.update_contribution_rate(portfolio_id, request.contribution_rate)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
     return {"message": "기여도가 수정되었습니다."}
 
 

--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -52,7 +52,6 @@ def _to_portfolio_result_response(result) -> PortfolioResultResponse:
     summary="포트폴리오 생성 시작",
     responses={
         400: {"model": ErrorResponse, "description": "인터뷰가 완료되지 않은 경우"},
-        409: {"model": ErrorResponse, "description": "이미 생성 중/완료된 포트폴리오가 있는 경우"},
     },
 )
 async def generate_portfolio(

--- a/app/main.py
+++ b/app/main.py
@@ -154,12 +154,18 @@ async def lifespan(app: FastAPI):
             yield
     finally:
         # ===== 종료 시: 리소스 정리 (예외 발생 시에도 실행) =====
-        await close_http_client()
-        logger.info("HTTP 클라이언트 정리 완료")
+        try:
+            await close_http_client()
+            logger.info("HTTP 클라이언트 정리 완료")
+        except Exception:
+            logger.exception("HTTP 클라이언트 정리 실패")
 
-        if pool:
-            await close_pool()
-            logger.info("DB 커넥션 풀 정리 완료")
+        if pool is not None:
+            try:
+                await close_pool()
+                logger.info("DB 커넥션 풀 정리 완료")
+            except Exception:
+                logger.exception("DB 커넥션 풀 정리 실패")
 
 
 def create_app() -> FastAPI:

--- a/app/main.py
+++ b/app/main.py
@@ -99,23 +99,22 @@ async def lifespan(app: FastAPI):
     import logging
 
     from common.db.connection import close_pool, create_pool
+    from common.http_client import close_http_client
     from features.correction.repository import (
         init_correction_repository,
         reset_correction_repository,
     )
-    from features.interview.agents.insight_store.pgvector_store import (
-        PgVectorInsightStore,
-    )
-    from features.interview.agents.insight_store.seed_data import (
-        SEED_INSIGHTS,
-        SEED_USER_ID,
-    )
+    from features.interview.agents.insight_store import MainServerInsightStore
     from features.interview.agents.nodes.retriever import init_insight_store
     from features.portfolio.repository import PortfolioRepository
 
     logger = logging.getLogger(__name__)
 
-    # ===== 공유 DB 커넥션 풀 초기화 (InsightStore + Portfolio + Correction 공용) =====
+    # ===== InsightStore 초기화 (메인 서버 API) =====
+    init_insight_store(MainServerInsightStore())
+    logger.info("InsightStore(MainServer) 초기화 완료")
+
+    # ===== 공유 DB 커넥션 풀 초기화 (Portfolio + Correction 공용) =====
     pool = None
     db_url = os.getenv("DATABASE_URL")
 
@@ -129,21 +128,6 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("DB 커넥션 풀 생성 실패 - 애플리케이션 시작 중단")
         raise
-
-    # ===== InsightStore 초기화 (임시 pgvector) =====
-    if pool is not None:
-        try:
-            insight_store = PgVectorInsightStore(pool=pool)
-            await insight_store.setup_table()
-
-            # 시드 데이터 로드 (테스트용, 이미 있으면 UPSERT)
-            for insight in SEED_INSIGHTS:
-                await insight_store.add_insight(insight, user_id=SEED_USER_ID)
-
-            init_insight_store(insight_store)
-            logger.info("InsightStore(pgvector) 초기화 완료")
-        except Exception:
-            logger.exception("InsightStore 초기화 실패 - 인사이트 검색 비활성화")
 
     # ===== 포트폴리오 DB 초기화 =====
     if pool is not None:
@@ -168,7 +152,10 @@ async def lifespan(app: FastAPI):
     async with setup_checkpointer():
         yield
 
-    # ===== 종료 시: 커넥션 풀 정리 =====
+    # ===== 종료 시: 리소스 정리 =====
+    await close_http_client()
+    logger.info("HTTP 클라이언트 정리 완료")
+
     if pool:
         await close_pool()
         logger.info("DB 커넥션 풀 정리 완료")

--- a/app/main.py
+++ b/app/main.py
@@ -149,16 +149,17 @@ async def lifespan(app: FastAPI):
             logger.exception("첨삭 DB 초기화 실패")
 
     # ===== Checkpointer 초기화 =====
-    async with setup_checkpointer():
-        yield
+    try:
+        async with setup_checkpointer():
+            yield
+    finally:
+        # ===== 종료 시: 리소스 정리 (예외 발생 시에도 실행) =====
+        await close_http_client()
+        logger.info("HTTP 클라이언트 정리 완료")
 
-    # ===== 종료 시: 리소스 정리 =====
-    await close_http_client()
-    logger.info("HTTP 클라이언트 정리 완료")
-
-    if pool:
-        await close_pool()
-        logger.info("DB 커넥션 풀 정리 완료")
+        if pool:
+            await close_pool()
+            logger.info("DB 커넥션 풀 정리 완료")
 
 
 def create_app() -> FastAPI:

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -9,7 +9,7 @@ from features.portfolio.schemas import PortfolioStatus
 class GeneratePortfolioRequest(BaseModel):
     """포트폴리오 생성 요청"""
 
-    portfolio_id: int = Field(..., description="메인 서버에서 생성된 포트폴리오 ID")
+    portfolio_id: int = Field(..., gt=0, description="메인 서버에서 생성된 포트폴리오 ID")
     session_id: str = Field(..., min_length=1, description="인터뷰 세션 ID")
     user_id: str = Field(..., min_length=1, description="사용자 ID")
 

--- a/app/schemas/portfolio.py
+++ b/app/schemas/portfolio.py
@@ -9,6 +9,7 @@ from features.portfolio.schemas import PortfolioStatus
 class GeneratePortfolioRequest(BaseModel):
     """포트폴리오 생성 요청"""
 
+    portfolio_id: int = Field(..., description="메인 서버에서 생성된 포트폴리오 ID")
     session_id: str = Field(..., min_length=1, description="인터뷰 세션 ID")
     user_id: str = Field(..., min_length=1, description="사용자 ID")
 

--- a/common/main_server/correction_client.py
+++ b/common/main_server/correction_client.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from common.http_client import request_with_retry
+from common.http_client import MainServerError, request_with_retry
 from features.correction.schemas import CorrectionOutput
 
 _FIELD_NAME_TO_SERVER = {
@@ -21,19 +21,49 @@ _STATUS_TO_UPPER = {
     "failed": "FAILED",
 }
 
+_FIELD_MAP_SERVER_TO_AI = {
+    "positionName": "job_title",
+    "highlightPoint": "emphasis_points",
+    "companyName": "company_name",
+    "jobDescription": "job_description",
+    "companyInsight": "company_insight",
+    "userId": "user_id",
+    "createdAt": "created_at",
+}
+
+_RAG_FIELD_MAP_SERVER_TO_AI = {
+    "correctionId": "correction_id",
+    "searchQuery": "search_query",
+    "searchResults": "search_results",
+    "createdAt": "created_at",
+}
+
 
 def _transform_get_correction_response(raw: dict[str, Any]) -> dict[str, Any]:
     """메인 서버 응답을 AI 서버 형식으로 변환"""
     result: dict[str, Any] = {}
     for key, value in raw.items():
-        if key == "positionName":
-            result["job_title"] = value
-        elif key == "highlightPoint":
-            result["emphasis_points"] = value
+        if key == "portfolioIds":
+            if isinstance(value, list):
+                portfolio_ids = [str(item) for item in value]
+                result["portfolio_ids"] = portfolio_ids
+                if portfolio_ids:
+                    result["portfolio_id"] = portfolio_ids[0]
+            else:
+                result["portfolio_ids"] = []
         elif key == "status" and isinstance(value, str):
             result["status"] = value.lower()
         else:
-            result[key] = value
+            result[_FIELD_MAP_SERVER_TO_AI.get(key, key)] = value
+
+    return result
+
+
+def _transform_get_rag_data_response(raw: dict[str, Any]) -> dict[str, Any]:
+    """메인 서버 RAG 데이터 응답을 AI 서버 형식으로 변환"""
+    result: dict[str, Any] = {}
+    for key, value in raw.items():
+        result[_RAG_FIELD_MAP_SERVER_TO_AI.get(key, key)] = value
     return result
 
 
@@ -72,10 +102,16 @@ class CorrectionClient:
             positionName->job_title, highlightPoint->emphasis_points,
             status UPPER_CASE->lowercase 변환된 딕셔너리
         """
-        result = await request_with_retry(
-            "GET",
-            f"/corrections/{correction_id}",
-        )
+        try:
+            result = await request_with_retry(
+                "GET",
+                f"/corrections/{correction_id}",
+            )
+        except MainServerError as e:
+            if e.status_code == 404:
+                return {}
+            raise
+
         if not isinstance(result, dict):
             return {}
         return _transform_get_correction_response(result)
@@ -128,7 +164,7 @@ class CorrectionClient:
         self,
         correction_id: int,
         search_query: str,
-        search_results: list[dict],
+        search_results: dict | list[dict],
     ) -> None:
         """
         RAG 검색 데이터 저장
@@ -157,10 +193,16 @@ class CorrectionClient:
         Returns:
             메인 서버 단일 객체 응답 (dict)
         """
-        result = await request_with_retry(
-            "GET",
-            f"/corrections/{correction_id}/rag-data",
-        )
+        try:
+            result = await request_with_retry(
+                "GET",
+                f"/corrections/{correction_id}/rag-data",
+            )
+        except MainServerError as e:
+            if e.status_code == 404:
+                return {}
+            raise
+
         if not isinstance(result, dict):
             return {}
-        return result
+        return _transform_get_rag_data_response(result)

--- a/common/main_server/insight_client.py
+++ b/common/main_server/insight_client.py
@@ -53,9 +53,16 @@ class InsightClient:
                 "threshold": threshold,
             },
         )
-        if not isinstance(result, list):
-            return []
-        return [_to_insight_log(item) for item in result]
+
+        insights: list[dict[str, Any]] = []
+        if isinstance(result, dict):
+            raw_insights = result.get("insights")
+            if isinstance(raw_insights, list):
+                insights = [item for item in raw_insights if isinstance(item, dict)]
+        elif isinstance(result, list):
+            insights = [item for item in result if isinstance(item, dict)]
+
+        return [_to_insight_log(item) for item in insights]
 
     async def get_by_id(self, insight_id: int) -> InsightLog | None:
         """

--- a/common/main_server/portfolio_client.py
+++ b/common/main_server/portfolio_client.py
@@ -2,11 +2,16 @@
 
 from typing import Any
 
-from common.http_client import request_with_retry
+from common.http_client import MainServerError, request_with_retry
 
 _ALLOWED_UPDATE_STATUSES = ("completed", "failed")
 
 FIELD_MAP_SERVER_TO_AI = {
+    "sessionId": "session_id",
+    "userId": "user_id",
+    "experienceName": "experience_name",
+    "contributionRate": "contribution_rate",
+    "errorMessage": "error_message",
     "responsibilities": "contributions",
     "problemSolving": "achievements",
     "learnings": "insights",
@@ -30,10 +35,16 @@ class PortfolioClient:
         Raises:
             MainServerError: API 호출 실패 시
         """
-        result = await request_with_retry(
-            "GET",
-            f"/internal/portfolios/{portfolio_id}",
-        )
+        try:
+            result = await request_with_retry(
+                "GET",
+                f"/internal/portfolios/{portfolio_id}",
+            )
+        except MainServerError as e:
+            if e.status_code == 404:
+                return {}
+            raise
+
         if not isinstance(result, dict):
             return {}
 

--- a/features/correction/service.py
+++ b/features/correction/service.py
@@ -5,6 +5,8 @@ import logging
 
 from fastapi import BackgroundTasks
 
+from common.main_server import CorrectionClient
+
 from .generator import CorrectionGenerator, get_correction_generator
 from .rag import (
     RAGInsightGenerationError,
@@ -13,7 +15,7 @@ from .rag import (
     RAGSearchError,
 )
 from .repository import CorrectionRepository, get_correction_repository
-from .schemas import CorrectionStatus
+from .schemas import CorrectionOutput, CorrectionStatus
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +30,134 @@ class CorrectionService:
         repository: CorrectionRepository,
         generator: CorrectionGenerator,
         rag_pipeline: RAGPipeline,
+        correction_client: CorrectionClient | None = None,
     ) -> None:
         self._repository = repository
         self._generator = generator
         self._rag_pipeline = rag_pipeline
+        self._correction_client = correction_client or CorrectionClient()
+
+    @staticmethod
+    def _parse_numeric_correction_id(correction_id: str) -> int | None:
+        """문자열 correction_id를 숫자형 ID로 변환 시도"""
+        try:
+            numeric_id = int(correction_id)
+        except (ValueError, TypeError):
+            return None
+
+        if numeric_id <= 0:
+            return None
+        return numeric_id
+
+    async def _get_correction_row(self, correction_id: str) -> dict | None:
+        """correction_id 형식에 맞춰 첨삭 데이터를 조회"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            data = await self._correction_client.get_correction(numeric_id)
+            return data or None
+
+        try:
+            return await self._repository.get_by_id(correction_id)
+        except Exception:
+            return None
+
+    async def _update_status(self, correction_id: str, status: str) -> None:
+        """correction_id 형식에 맞춰 상태를 업데이트"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            await self._correction_client.update_status(numeric_id, status)
+            return
+
+        await self._repository.update_status(correction_id, status)
+
+    async def _update_status_if_current(
+        self,
+        correction_id: str,
+        expected_status: str,
+        next_status: str,
+    ) -> bool:
+        """현재 상태가 expected_status인 경우에만 상태 전이"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            correction = await self._get_correction_row(correction_id)
+            if correction is None:
+                return False
+            if correction.get("status") != expected_status:
+                return False
+            await self._correction_client.update_status(numeric_id, next_status)
+            return True
+
+        return await self._repository.update_status_if_current(
+            correction_id,
+            expected_status,
+            next_status,
+        )
+
+    async def _update_company_insight_row(self, correction_id: str, company_insight: str) -> None:
+        """correction_id 형식에 맞춰 company_insight를 저장"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            await self._correction_client.update_company_insight(numeric_id, company_insight)
+            return
+
+        await self._repository.update_company_insight(correction_id, company_insight)
+
+    async def _update_emphasis_points_row(self, correction_id: str, emphasis_points: str) -> None:
+        """correction_id 형식에 맞춰 emphasis_points를 저장"""
+        if self._parse_numeric_correction_id(correction_id) is not None:
+            raise ValueError(
+                "숫자형 correction_id는 현재 강조 포인트 수정을 지원하지 않습니다. "
+                "메인 서버 API를 통해 수정해주세요."
+            )
+
+        await self._repository.update_emphasis_points(correction_id, emphasis_points)
+
+    async def _save_rag_data_row(
+        self,
+        correction_id: str,
+        search_query: str,
+        search_results: dict,
+    ) -> None:
+        """correction_id 형식에 맞춰 RAG 데이터를 저장"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            await self._correction_client.save_rag_data(numeric_id, search_query, search_results)
+            return
+
+        await self._repository.save_rag_data(correction_id, search_query, search_results)
+
+    async def _get_rag_data_rows(self, correction_id: str) -> list[dict]:
+        """correction_id 형식에 맞춰 RAG 데이터를 조회"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            result = await self._correction_client.get_rag_data(numeric_id)
+            if isinstance(result, list):
+                return [item for item in result if isinstance(item, dict)]
+            if isinstance(result, dict) and result:
+                return [result]
+            return []
+
+        return await self._repository.get_rag_data(correction_id)
+
+    async def _update_result_row(self, correction_id: str, result: dict) -> None:
+        """correction_id 형식에 맞춰 생성 결과를 저장"""
+        numeric_id = self._parse_numeric_correction_id(correction_id)
+        if numeric_id is not None:
+            output = CorrectionOutput.model_validate(result)
+            await self._correction_client.update_result(numeric_id, output)
+            return
+
+        await self._repository.update_result(correction_id, result)
+
+    async def _delete_correction_row(self, correction_id: str) -> None:
+        """correction_id 형식에 맞춰 첨삭 데이터를 삭제"""
+        if self._parse_numeric_correction_id(correction_id) is not None:
+            raise ValueError(
+                "숫자형 correction_id는 현재 삭제를 지원하지 않습니다. "
+                "메인 서버 API를 통해 삭제해주세요."
+            )
+
+        await self._repository.delete(correction_id)
 
     async def create_correction(
         self,
@@ -52,20 +178,20 @@ class CorrectionService:
 
     async def start_rag(self, correction_id: str, background_tasks: BackgroundTasks) -> None:
         """RAG 단계를 시작하고 백그라운드 작업을 등록"""
-        correction = await self._repository.get_by_id(correction_id)
+        correction = await self._get_correction_row(correction_id)
         if correction is None:
             raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
 
         if correction.get("status") != CorrectionStatus.NOT_STARTED.value:
             return
 
-        await self._repository.update_status(correction_id, CorrectionStatus.DOING_RAG.value)
+        await self._update_status(correction_id, CorrectionStatus.DOING_RAG.value)
         background_tasks.add_task(self._run_rag, correction_id)
 
     async def _run_rag(self, correction_id: str) -> None:
         """RAG 실행 후 기업 인사이트를 저장"""
         try:
-            correction = await self._repository.get_by_id(correction_id)
+            correction = await self._get_correction_row(correction_id)
             if correction is None:
                 raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
 
@@ -83,7 +209,7 @@ class CorrectionService:
                 if rag_result.keywords
                 else f"{company_name} {job_title}"
             )
-            await self._repository.save_rag_data(
+            await self._save_rag_data_row(
                 correction_id,
                 search_query,
                 {
@@ -91,11 +217,9 @@ class CorrectionService:
                     "results": rag_result.search_results,
                 },
             )
-            await self._repository.update_company_insight(correction_id, rag_result.insight)
+            await self._update_company_insight_row(correction_id, rag_result.insight)
 
-            await self._repository.update_status(
-                correction_id, CorrectionStatus.COMPANY_INSIGHT.value
-            )
+            await self._update_status(correction_id, CorrectionStatus.COMPANY_INSIGHT.value)
         except Exception as exc:
             if isinstance(exc, RAGKeywordExtractionError):
                 logger.exception("RAG 키워드 추출 실패 (correction_id: %s)", correction_id)
@@ -152,7 +276,7 @@ class CorrectionService:
     ) -> None:
         """저장된 RAG 검색 결과로 인사이트만 재생성"""
         try:
-            correction = await self._repository.get_by_id(correction_id)
+            correction = await self._get_correction_row(correction_id)
             if correction is None:
                 raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
 
@@ -162,10 +286,8 @@ class CorrectionService:
                 job_title=correction["job_title"],
                 keywords=keywords,
             )
-            await self._repository.update_company_insight(correction_id, insight)
-            await self._repository.update_status(
-                correction_id, CorrectionStatus.COMPANY_INSIGHT.value
-            )
+            await self._update_company_insight_row(correction_id, insight)
+            await self._update_status(correction_id, CorrectionStatus.COMPANY_INSIGHT.value)
         except Exception:
             logger.exception(
                 "저장된 검색 결과 기반 RAG 재시도 실패 (correction_id: %s)",
@@ -175,7 +297,7 @@ class CorrectionService:
 
     async def retry(self, correction_id: str, background_tasks: BackgroundTasks) -> None:
         """실패한 첨삭을 마지막 단계 기준으로 재시도"""
-        correction = await self._repository.get_by_id(correction_id)
+        correction = await self._get_correction_row(correction_id)
         if correction is None:
             raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
 
@@ -183,7 +305,7 @@ class CorrectionService:
             raise ValueError(f"실패 상태가 아닌 첨삭은 재시도할 수 없습니다: {correction_id}")
 
         if correction.get("company_insight") is not None:
-            transitioned = await self._repository.update_status_if_current(
+            transitioned = await self._update_status_if_current(
                 correction_id,
                 CorrectionStatus.FAILED.value,
                 CorrectionStatus.COMPANY_INSIGHT.value,
@@ -193,13 +315,13 @@ class CorrectionService:
             await self.start_generation(correction_id, background_tasks)
             return
 
-        rag_data_rows = await self._repository.get_rag_data(correction_id)
+        rag_data_rows = await self._get_rag_data_rows(correction_id)
         if rag_data_rows:
             latest_rag_data = rag_data_rows[-1]
             search_results = self._extract_search_results(latest_rag_data)
             if search_results:
                 keywords = self._extract_keywords(latest_rag_data)
-                transitioned = await self._repository.update_status_if_current(
+                transitioned = await self._update_status_if_current(
                     correction_id,
                     CorrectionStatus.FAILED.value,
                     CorrectionStatus.DOING_RAG.value,
@@ -216,7 +338,7 @@ class CorrectionService:
                 )
                 return
 
-        transitioned = await self._repository.update_status_if_current(
+        transitioned = await self._update_status_if_current(
             correction_id,
             CorrectionStatus.FAILED.value,
             CorrectionStatus.NOT_STARTED.value,
@@ -227,26 +349,30 @@ class CorrectionService:
 
     async def start_generation(self, correction_id: str, background_tasks: BackgroundTasks) -> None:
         """첨삭 생성 단계를 시작하고 백그라운드 작업을 등록"""
-        correction = await self._repository.get_by_id(correction_id)
+        correction = await self._get_correction_row(correction_id)
         if correction is None:
             raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
 
         if correction.get("status") != CorrectionStatus.COMPANY_INSIGHT.value:
             return
 
-        await self._repository.update_status(correction_id, CorrectionStatus.GENERATING.value)
+        await self._update_status(correction_id, CorrectionStatus.GENERATING.value)
         background_tasks.add_task(self._run_generation, correction_id)
 
     async def _run_generation(self, correction_id: str) -> None:
         """첨삭 생성기를 호출하고 결과를 저장"""
         try:
-            correction = await self._repository.get_by_id(correction_id)
+            correction = await self._get_correction_row(correction_id)
             if correction is None:
                 raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
 
             from features.portfolio import get_portfolio_service
 
-            portfolio_result = await get_portfolio_service().get_result(correction["portfolio_id"])
+            portfolio_id = correction.get("portfolio_id")
+            if portfolio_id is None:
+                raise ValueError("포트폴리오 ID를 찾을 수 없습니다.")
+
+            portfolio_result = await get_portfolio_service().get_result(str(portfolio_id))
             if portfolio_result is None or portfolio_result.output is None:
                 raise ValueError("포트폴리오 결과를 찾을 수 없습니다.")
 
@@ -272,8 +398,8 @@ class CorrectionService:
                 result_dict = result
             else:
                 raise ValueError("첨삭 결과 형식이 올바르지 않습니다.")
-            await self._repository.update_result(correction_id, result_dict)
-            await self._repository.update_status(correction_id, CorrectionStatus.DONE.value)
+            await self._update_result_row(correction_id, result_dict)
+            await self._update_status(correction_id, CorrectionStatus.DONE.value)
         except Exception:
             logger.exception("첨삭 생성 실패 (correction_id: %s)", correction_id)
             await self._mark_failed(correction_id)
@@ -281,7 +407,7 @@ class CorrectionService:
     async def _mark_failed(self, correction_id: str) -> None:
         """실패 상태 업데이트를 시도하고 실패 시 로깅"""
         try:
-            await self._repository.update_status(correction_id, CorrectionStatus.FAILED.value)
+            await self._update_status(correction_id, CorrectionStatus.FAILED.value)
         except Exception as exc:
             logger.warning(
                 "실패 상태 업데이트를 건너뜁니다 (correction_id: %s): %s",
@@ -291,33 +417,33 @@ class CorrectionService:
 
     async def get_correction(self, correction_id: str) -> dict | None:
         """첨삭 전체 데이터 조회"""
-        return await self._repository.get_by_id(correction_id)
+        return await self._get_correction_row(correction_id)
 
     async def get_status(self, correction_id: str) -> CorrectionStatus:
         """첨삭 상태 조회"""
-        correction = await self._repository.get_by_id(correction_id)
+        correction = await self._get_correction_row(correction_id)
         if correction is None:
             raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
         return CorrectionStatus(correction["status"])
 
     async def get_company_insight(self, correction_id: str) -> str | None:
         """기업 인사이트 조회"""
-        correction = await self._repository.get_by_id(correction_id)
+        correction = await self._get_correction_row(correction_id)
         if correction is None:
             raise ValueError(f"첨삭을 찾을 수 없습니다: {correction_id}")
         return correction.get("company_insight")
 
     async def update_company_insight(self, correction_id: str, company_insight: str) -> None:
         """기업 인사이트 수정"""
-        await self._repository.update_company_insight(correction_id, company_insight)
+        await self._update_company_insight_row(correction_id, company_insight)
 
     async def update_emphasis_points(self, correction_id: str, emphasis_points: str) -> None:
         """강조 포인트 수정"""
-        await self._repository.update_emphasis_points(correction_id, emphasis_points)
+        await self._update_emphasis_points_row(correction_id, emphasis_points)
 
     async def delete_correction(self, correction_id: str) -> None:
         """첨삭 삭제"""
-        await self._repository.delete(correction_id)
+        await self._delete_correction_row(correction_id)
 
 
 def get_correction_service() -> CorrectionService:

--- a/features/interview/agents/insight_store/__init__.py
+++ b/features/interview/agents/insight_store/__init__.py
@@ -1,7 +1,9 @@
 """인사이트 저장소 모듈"""
 
+from .main_server_store import MainServerInsightStore
 from .protocol import InsightStore
 
 __all__ = [
     "InsightStore",
+    "MainServerInsightStore",
 ]

--- a/features/interview/agents/insight_store/main_server_store.py
+++ b/features/interview/agents/insight_store/main_server_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,6 +11,29 @@ if TYPE_CHECKING:
     from features.interview.agents.state import InsightLog
 
 logger = logging.getLogger(__name__)
+
+
+def _to_numeric_identifier(value: str) -> int | None:
+    """문자열 식별자를 숫자 ID로 변환 (예: "user-1" -> 1)"""
+    try:
+        parsed = int(value)
+        if parsed >= 0:
+            return parsed
+        return None
+    except (ValueError, TypeError):
+        pass
+
+    if not isinstance(value, str):
+        return None
+
+    matched_numbers = re.findall(r"\d+", value)
+    if len(matched_numbers) != 1:
+        return None
+
+    try:
+        return int(matched_numbers[0])
+    except (ValueError, TypeError):
+        return None
 
 
 class MainServerInsightStore:
@@ -47,9 +71,8 @@ class MainServerInsightStore:
         Returns:
             유사 인사이트 목록 (유사도 내림차순)
         """
-        try:
-            numeric_user_id = int(user_id)
-        except (ValueError, TypeError):
+        numeric_user_id = _to_numeric_identifier(user_id)
+        if numeric_user_id is None:
             logger.warning("user_id를 int로 변환할 수 없습니다: %s", "<redacted>")
             return []
 
@@ -70,9 +93,8 @@ class MainServerInsightStore:
         Returns:
             인사이트 로그 데이터, 없으면 None
         """
-        try:
-            numeric_id = int(insight_id)
-        except (ValueError, TypeError):
+        numeric_id = _to_numeric_identifier(insight_id)
+        if numeric_id is None:
             logger.warning("insight_id를 int로 변환할 수 없습니다: %s", "<redacted>")
             return None
 

--- a/features/interview/agents/insight_store/main_server_store.py
+++ b/features/interview/agents/insight_store/main_server_store.py
@@ -1,0 +1,70 @@
+"""메인 서버 API 기반 InsightStore 구현"""
+
+import logging
+
+from common.main_server import InsightClient
+from features.interview.agents.state import InsightLog
+
+logger = logging.getLogger(__name__)
+
+
+class MainServerInsightStore:
+    """
+    메인 서버 API를 통한 InsightStore 구현
+
+    InsightClient를 래핑하여 InsightStore 프로토콜을 준수합니다.
+    프로토콜의 user_id(str) -> InsightClient의 user_id(int) 변환을 처리합니다.
+    """
+
+    def __init__(self, client: InsightClient | None = None) -> None:
+        self._client = client or InsightClient()
+
+    async def search_similar(
+        self,
+        query: str,
+        user_id: str,
+        top_k: int = 5,
+        threshold: float = 0.7,
+    ) -> list[InsightLog]:
+        """
+        텍스트 기반 인사이트 로그 검색
+
+        Args:
+            query: 검색 텍스트
+            user_id: 사용자 ID (문자열, 내부에서 int로 변환)
+            top_k: 최대 반환 결과 수
+            threshold: 유사도 임계값
+
+        Returns:
+            유사 인사이트 목록 (유사도 내림차순)
+        """
+        try:
+            numeric_user_id = int(user_id)
+        except (ValueError, TypeError):
+            logger.warning("user_id를 int로 변환할 수 없습니다: %s", user_id)
+            return []
+
+        return await self._client.search_similar(
+            keyword=query,
+            user_id=numeric_user_id,
+            top_k=top_k,
+            threshold=threshold,
+        )
+
+    async def get_by_id(self, insight_id: str) -> InsightLog | None:
+        """
+        인사이트 단건 조회
+
+        Args:
+            insight_id: 인사이트 로그 ID (문자열, 내부에서 int로 변환)
+
+        Returns:
+            인사이트 로그 데이터, 없으면 None
+        """
+        try:
+            numeric_id = int(insight_id)
+        except (ValueError, TypeError):
+            logger.warning("insight_id를 int로 변환할 수 없습니다: %s", insight_id)
+            return None
+
+        return await self._client.get_by_id(numeric_id)

--- a/features/interview/agents/insight_store/main_server_store.py
+++ b/features/interview/agents/insight_store/main_server_store.py
@@ -1,9 +1,13 @@
 """메인 서버 API 기반 InsightStore 구현"""
 
-import logging
+from __future__ import annotations
 
-from common.main_server import InsightClient
-from features.interview.agents.state import InsightLog
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from common.main_server import InsightClient
+    from features.interview.agents.state import InsightLog
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +21,12 @@ class MainServerInsightStore:
     """
 
     def __init__(self, client: InsightClient | None = None) -> None:
-        self._client = client or InsightClient()
+        if client is not None:
+            self._client = client
+        else:
+            from common.main_server import InsightClient as _InsightClient
+
+            self._client = _InsightClient()
 
     async def search_similar(
         self,

--- a/features/interview/agents/insight_store/main_server_store.py
+++ b/features/interview/agents/insight_store/main_server_store.py
@@ -50,7 +50,7 @@ class MainServerInsightStore:
         try:
             numeric_user_id = int(user_id)
         except (ValueError, TypeError):
-            logger.warning("user_id를 int로 변환할 수 없습니다: %s", user_id)
+            logger.warning("user_id를 int로 변환할 수 없습니다: %s", "<redacted>")
             return []
 
         return await self._client.search_similar(
@@ -73,7 +73,7 @@ class MainServerInsightStore:
         try:
             numeric_id = int(insight_id)
         except (ValueError, TypeError):
-            logger.warning("insight_id를 int로 변환할 수 없습니다: %s", insight_id)
+            logger.warning("insight_id를 int로 변환할 수 없습니다: %s", "<redacted>")
             return None
 
         return await self._client.get_by_id(numeric_id)

--- a/features/portfolio/service.py
+++ b/features/portfolio/service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from fastapi import BackgroundTasks
@@ -36,6 +37,29 @@ class PortfolioService:
         self._interview_service = interview_service or get_interview_service()
         self._portfolio_client = portfolio_client or PortfolioClient()
         self._inprocess_tasks: set[asyncio.Task] = set()
+
+    @staticmethod
+    def _parse_numeric_portfolio_id(portfolio_id: str) -> int | None:
+        """문자열 portfolio_id를 숫자형 ID로 변환 시도"""
+        try:
+            numeric_id = int(portfolio_id)
+        except (ValueError, TypeError):
+            return None
+
+        if numeric_id <= 0:
+            return None
+        return numeric_id
+
+    @staticmethod
+    def _build_progress_message(status: PortfolioStatus, error_message: str | None) -> str:
+        """상태 기반 진행 메시지 생성"""
+        return {
+            PortfolioStatus.NOT_STARTED: "포트폴리오 생성을 준비하고 있습니다.",
+            PortfolioStatus.GENERATING: "포트폴리오를 생성하고 있습니다.",
+            PortfolioStatus.COMPLETED: "포트폴리오 생성이 완료되었습니다.",
+            PortfolioStatus.FAILED: error_message
+            or "포트폴리오 생성에 실패했습니다. 잠시 후 다시 시도하거나 관리자에게 문의해주세요.",
+        }[status]
 
     def _get_repository(self) -> PortfolioRepository:
         """기존 CRUD 엔드포인트용 Repository 반환 (지연 초기화)"""
@@ -128,26 +152,83 @@ class PortfolioService:
         """포트폴리오 생성 상태 조회"""
         from app.schemas.portfolio import PortfolioStatusResponse
 
+        numeric_portfolio_id = self._parse_numeric_portfolio_id(portfolio_id)
+        if numeric_portfolio_id is not None:
+            data = await self._portfolio_client.get_portfolio(numeric_portfolio_id)
+            if not data:
+                raise ValueError(f"포트폴리오를 찾을 수 없습니다: {portfolio_id}")
+
+            status_value = str(data.get("status", "")).lower()
+            try:
+                status = PortfolioStatus(status_value)
+            except ValueError as e:
+                raise ValueError(f"알 수 없는 포트폴리오 상태입니다: {status_value}") from e
+
+            return PortfolioStatusResponse(
+                status=status,
+                progress_message=self._build_progress_message(status, data.get("error_message")),
+            )
+
         repo = self._get_repository()
-        row = await repo.get_by_id(portfolio_id)
+        try:
+            row = await repo.get_by_id(portfolio_id)
+        except Exception as e:
+            raise ValueError(f"포트폴리오를 찾을 수 없습니다: {portfolio_id}") from e
+
         if row is None:
             raise ValueError(f"포트폴리오를 찾을 수 없습니다: {portfolio_id}")
 
         status = PortfolioStatus(row["status"])
-        progress_message = {
-            PortfolioStatus.NOT_STARTED: "포트폴리오 생성을 준비하고 있습니다.",
-            PortfolioStatus.GENERATING: "포트폴리오를 생성하고 있습니다.",
-            PortfolioStatus.COMPLETED: "포트폴리오 생성이 완료되었습니다.",
-            PortfolioStatus.FAILED: row.get("error_message")
-            or "포트폴리오 생성에 실패했습니다. 잠시 후 다시 시도하거나 관리자에게 문의해주세요.",
-        }[status]
+        progress_message = self._build_progress_message(status, row.get("error_message"))
 
         return PortfolioStatusResponse(status=status, progress_message=progress_message)
 
     async def get_result(self, portfolio_id: str) -> PortfolioResult | None:
         """완료된 포트폴리오 결과 조회"""
+        numeric_portfolio_id = self._parse_numeric_portfolio_id(portfolio_id)
+        if numeric_portfolio_id is not None:
+            data = await self._portfolio_client.get_portfolio(numeric_portfolio_id)
+            status_value = str(data.get("status", "")).lower() if data else ""
+            if not data or status_value != PortfolioStatus.COMPLETED.value:
+                return None
+
+            output: PortfolioOutput | None = None
+            if all(
+                data.get(key) is not None
+                for key in ["description", "contributions", "achievements", "insights"]
+            ):
+                output = PortfolioOutput(
+                    description=str(data.get("description", "")),
+                    contributions=str(data.get("contributions", "")),
+                    achievements=str(data.get("achievements", "")),
+                    insights=str(data.get("insights", "")),
+                )
+
+            contribution_rate: int | None = None
+            raw_contribution_rate = data.get("contribution_rate")
+            if raw_contribution_rate is not None:
+                try:
+                    contribution_rate = int(raw_contribution_rate)
+                except (ValueError, TypeError):
+                    contribution_rate = None
+
+            return PortfolioResult(
+                portfolio_id=str(data.get("id", numeric_portfolio_id)),
+                session_id=str(data.get("session_id", "")),
+                user_id=str(data.get("user_id", "")),
+                experience_name=str(data.get("experience_name", "")),
+                status=PortfolioStatus(status_value),
+                contribution_rate=contribution_rate,
+                output=output,
+                created_at=datetime.now(UTC),
+            )
+
         repo = self._get_repository()
-        row = await repo.get_by_id(portfolio_id)
+        try:
+            row = await repo.get_by_id(portfolio_id)
+        except Exception:
+            return None
+
         if row is None or row["status"] != PortfolioStatus.COMPLETED.value:
             return None
         return self._to_result(row)
@@ -170,16 +251,35 @@ class PortfolioService:
 
     async def exists(self, portfolio_id: str) -> bool:
         """포트폴리오 존재 여부 확인"""
+        numeric_portfolio_id = self._parse_numeric_portfolio_id(portfolio_id)
+        if numeric_portfolio_id is not None:
+            data = await self._portfolio_client.get_portfolio(numeric_portfolio_id)
+            return bool(data)
+
         repo = self._get_repository()
-        row = await repo.get_by_id(portfolio_id)
+        try:
+            row = await repo.get_by_id(portfolio_id)
+        except Exception:
+            return False
+
         return row is not None
 
     async def update_contribution_rate(self, portfolio_id: str, rate: int) -> None:
         """포트폴리오 기여도 수정"""
         if not 0 <= rate <= 100:
             raise ValueError("기여도는 0에서 100 사이여야 합니다.")
+
+        if self._parse_numeric_portfolio_id(portfolio_id) is not None:
+            raise ValueError(
+                "숫자형 portfolio_id는 현재 기여도 수정을 지원하지 않습니다. "
+                "메인 서버 API를 통해 수정해주세요."
+            )
+
         repo = self._get_repository()
-        await repo.update_contribution_rate(portfolio_id, rate)
+        try:
+            await repo.update_contribution_rate(portfolio_id, rate)
+        except Exception as e:
+            raise ValueError(f"포트폴리오를 찾을 수 없습니다: {portfolio_id}") from e
 
     @staticmethod
     def _to_result(row: dict) -> PortfolioResult:

--- a/features/portfolio/service.py
+++ b/features/portfolio/service.py
@@ -4,10 +4,9 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-import asyncpg
 from fastapi import BackgroundTasks
 
-from common.db import get_pool
+from common.main_server import PortfolioClient
 from features.interview import get_interview_service
 
 from .generator import PortfolioGenerator
@@ -30,19 +29,35 @@ class PortfolioService:
         repository: PortfolioRepository | None = None,
         generator: PortfolioGenerator | None = None,
         interview_service=None,
+        portfolio_client: PortfolioClient | None = None,
     ) -> None:
-        self._repository = repository or PortfolioRepository(get_pool())
+        self._repository = repository
         self._generator = generator or PortfolioGenerator()
         self._interview_service = interview_service or get_interview_service()
+        self._portfolio_client = portfolio_client or PortfolioClient()
         self._inprocess_tasks: set[asyncio.Task] = set()
+
+    def _get_repository(self) -> PortfolioRepository:
+        """기존 CRUD 엔드포인트용 Repository 반환 (지연 초기화)"""
+        if self._repository is None:
+            from common.db import get_pool
+
+            self._repository = PortfolioRepository(get_pool())
+        return self._repository
 
     async def start_generation(
         self,
+        portfolio_id: int,
         session_id: str,
         user_id: str,
         background_tasks: BackgroundTasks | None = None,
-    ) -> str:
-        """포트폴리오 생성을 시작하고 portfolio_id를 반환"""
+    ) -> int:
+        """
+        포트폴리오 생성을 시작하고 portfolio_id를 반환
+
+        메인 서버가 DB 레코드를 생성한 뒤 AI 서버에 위임하는 구조.
+        AI 서버는 LLM 생성 + 완료/실패 콜백만 담당한다.
+        """
         session_state = await self._interview_service.get_session_state(session_id)
         if session_state is None:
             raise ValueError(f"세션을 찾을 수 없습니다: {session_id}")
@@ -55,36 +70,6 @@ class PortfolioService:
 
         collected_data = session_state.get("collected_data") or {}
         experience_name = session_state.get("experience_name") or ""
-
-        existing = await self._repository.get_by_session_id(session_id)
-        if existing and existing["status"] in {
-            PortfolioStatus.GENERATING.value,
-            PortfolioStatus.COMPLETED.value,
-        }:
-            return str(existing["id"])
-
-        if existing:
-            portfolio_id = str(existing["id"])
-            await self._repository.update_status(portfolio_id, PortfolioStatus.GENERATING.value)
-        else:
-            try:
-                portfolio_id = await self._repository.create(
-                    session_id=session_id,
-                    user_id=user_id,
-                    experience_name=experience_name,
-                )
-            except asyncpg.UniqueViolationError:
-                # 동시 요청으로 인한 중복 생성 — 먼저 생성된 레코드 재사용
-                logger.warning(
-                    "session_id 중복 감지 (동시 요청), 기존 레코드 재사용: %s", session_id
-                )
-                row = await self._repository.get_by_session_id(session_id)
-                if row is None:
-                    raise RuntimeError(
-                        f"session_id 충돌 후 기존 레코드를 찾을 수 없습니다: {session_id}"
-                    )
-                return str(row["id"])
-            await self._repository.update_status(portfolio_id, PortfolioStatus.GENERATING.value)
 
         if background_tasks is not None:
             background_tasks.add_task(
@@ -104,34 +89,42 @@ class PortfolioService:
 
     async def _generate_portfolio_background(
         self,
-        portfolio_id: str,
+        portfolio_id: int,
         collected_data: dict,
         experience_name: str,
     ) -> None:
-        """Background Task: 포트폴리오 생성 및 상태 업데이트"""
+        """Background Task: 포트폴리오 생성 후 메인 서버에 콜백"""
         try:
             output = await asyncio.to_thread(
                 self._generator.generate,
                 collected_data,
                 experience_name,
             )
-            await self._repository.update_result(portfolio_id, output)
+            await self._portfolio_client.update_result(
+                portfolio_id,
+                status="completed",
+                description=output.description,
+                contributions=output.contributions,
+                achievements=output.achievements,
+                insights=output.insights,
+            )
         except Exception as exc:
             logger.exception("포트폴리오 생성 실패 (portfolio_id: %s): %s", portfolio_id, exc)
             try:
-                await self._repository.update_status(
+                await self._portfolio_client.update_result(
                     portfolio_id,
-                    PortfolioStatus.FAILED.value,
-                    str(exc),
+                    status="failed",
+                    error_message=str(exc),
                 )
             except Exception:
-                logger.exception("포트폴리오 실패 상태 업데이트 실패: %s", portfolio_id)
+                logger.exception("포트폴리오 실패 콜백 실패: %s", portfolio_id)
 
     async def get_status(self, portfolio_id: str) -> "PortfolioStatusResponse":
         """포트폴리오 생성 상태 조회"""
         from app.schemas.portfolio import PortfolioStatusResponse
 
-        row = await self._repository.get_by_id(portfolio_id)
+        repo = self._get_repository()
+        row = await repo.get_by_id(portfolio_id)
         if row is None:
             raise ValueError(f"포트폴리오를 찾을 수 없습니다: {portfolio_id}")
 
@@ -148,35 +141,40 @@ class PortfolioService:
 
     async def get_result(self, portfolio_id: str) -> PortfolioResult | None:
         """완료된 포트폴리오 결과 조회"""
-        row = await self._repository.get_by_id(portfolio_id)
+        repo = self._get_repository()
+        row = await repo.get_by_id(portfolio_id)
         if row is None or row["status"] != PortfolioStatus.COMPLETED.value:
             return None
         return self._to_result(row)
 
     async def get_by_session(self, session_id: str) -> PortfolioResult | None:
         """세션 ID로 완료된 포트폴리오 결과 조회"""
-        row = await self._repository.get_by_session_id(session_id)
+        repo = self._get_repository()
+        row = await repo.get_by_session_id(session_id)
         if row is None or row["status"] != PortfolioStatus.COMPLETED.value:
             return None
         return self._to_result(row)
 
     async def has_generating_or_completed(self, session_id: str) -> bool:
         """세션에 생성 중/완료 상태의 포트폴리오가 있는지 확인"""
-        row = await self._repository.get_by_session_id(session_id)
+        repo = self._get_repository()
+        row = await repo.get_by_session_id(session_id)
         if row is None:
             return False
         return row["status"] in {PortfolioStatus.GENERATING.value, PortfolioStatus.COMPLETED.value}
 
     async def exists(self, portfolio_id: str) -> bool:
         """포트폴리오 존재 여부 확인"""
-        row = await self._repository.get_by_id(portfolio_id)
+        repo = self._get_repository()
+        row = await repo.get_by_id(portfolio_id)
         return row is not None
 
     async def update_contribution_rate(self, portfolio_id: str, rate: int) -> None:
         """포트폴리오 기여도 수정"""
         if not 0 <= rate <= 100:
             raise ValueError("기여도는 0에서 100 사이여야 합니다.")
-        await self._repository.update_contribution_rate(portfolio_id, rate)
+        repo = self._get_repository()
+        await repo.update_contribution_rate(portfolio_id, rate)
 
     @staticmethod
     def _to_result(row: dict) -> PortfolioResult:

--- a/features/portfolio/service.py
+++ b/features/portfolio/service.py
@@ -57,6 +57,11 @@ class PortfolioService:
 
         메인 서버가 DB 레코드를 생성한 뒤 AI 서버에 위임하는 구조.
         AI 서버는 LLM 생성 + 완료/실패 콜백만 담당한다.
+
+        Note:
+            portfolio_id는 메인 서버의 숫자형 ID(int)를 사용한다.
+            기존 CRUD 메서드(get_status, get_result 등)는 레거시 API용으로
+            portfolio_id를 str(UUID)로 받는다.
         """
         session_state = await self._interview_service.get_session_state(session_id)
         if session_state is None:

--- a/tests/test_app/test_api/test_v1/test_correction.py
+++ b/tests/test_app/test_api/test_v1/test_correction.py
@@ -107,6 +107,15 @@ def test_get_correction_status_returns_404(monkeypatch):
     assert response.status_code == 404
 
 
+def test_get_correction_status_accepts_numeric_id(monkeypatch):
+    """숫자형 correction_id 경로 파라미터를 허용한다."""
+    client = _create_client(monkeypatch, DummyCorrectionService())
+
+    response = client.get("/api/v1/corrections/100/status")
+
+    assert response.status_code == 200
+
+
 def test_start_rag_returns_409_when_status_invalid(monkeypatch):
     """RAG 시작은 not_started 상태가 아니면 409를 반환한다."""
     client = _create_client(

--- a/tests/test_app/test_api/test_v1/test_portfolio.py
+++ b/tests/test_app/test_api/test_v1/test_portfolio.py
@@ -11,44 +11,31 @@ from features.portfolio.schemas import PortfolioOutput, PortfolioResult, Portfol
 PORTFOLIO_UUID = "11111111-1111-1111-1111-111111111111"
 
 
-class DummyRepo:
-    def __init__(self, row: dict | None = None):
-        self._row = row
-
-    async def get_by_session_id(self, _session_id: str) -> dict | None:
-        return self._row
-
-
 class DummyPortfolioService:
     def __init__(
         self,
         *,
-        repo_row: dict | None = None,
         start_generation_error: Exception | None = None,
         result: PortfolioResult | None = None,
         status_error: Exception | None = None,
     ) -> None:
-        self._repository = DummyRepo(repo_row)
         self._start_generation_error = start_generation_error
         self._result = result
         self._status_error = status_error
         self.updated_rate: tuple[str, int] | None = None
 
-    async def has_generating_or_completed(self, _session_id: str) -> bool:
-        row = await self._repository.get_by_session_id(_session_id)
-        generating_statuses = {PortfolioStatus.GENERATING.value, PortfolioStatus.COMPLETED.value}
-        return bool(row and row["status"] in generating_statuses)
-
     async def exists(self, _portfolio_id: str) -> bool:
         return self._result is not None
 
-    async def start_generation(self, session_id: str, user_id: str, background_tasks) -> str:
+    async def start_generation(
+        self, portfolio_id: int, session_id: str, user_id: str, background_tasks=None
+    ) -> int:
         if self._start_generation_error is not None:
             raise self._start_generation_error
         assert session_id
         assert user_id
         assert background_tasks is not None
-        return "portfolio-1"
+        return portfolio_id
 
     async def get_status(self, _portfolio_id: str):
         if self._status_error is not None:
@@ -78,28 +65,11 @@ def test_generate_portfolio_accepted(monkeypatch):
 
     response = client.post(
         "/api/v1/portfolio/generate",
-        json={"session_id": "session-1", "user_id": "user-1"},
+        json={"portfolio_id": 100, "session_id": "session-1", "user_id": "user-1"},
     )
 
     assert response.status_code == 202
-    assert response.json() == {"portfolio_id": "portfolio-1", "status": "generating"}
-
-
-def test_generate_portfolio_returns_409_for_existing(monkeypatch):
-    """동일 세션 생성 중/완료 상태면 409를 반환한다."""
-    client = _create_client(
-        monkeypatch,
-        DummyPortfolioService(
-            repo_row={"id": "existing", "status": PortfolioStatus.GENERATING.value}
-        ),
-    )
-
-    response = client.post(
-        "/api/v1/portfolio/generate",
-        json={"session_id": "session-1", "user_id": "user-1"},
-    )
-
-    assert response.status_code == 409
+    assert response.json() == {"portfolio_id": "100", "status": "generating"}
 
 
 def test_generate_portfolio_returns_400_for_incomplete_interview(monkeypatch):
@@ -115,7 +85,7 @@ def test_generate_portfolio_returns_400_for_incomplete_interview(monkeypatch):
 
     response = client.post(
         "/api/v1/portfolio/generate",
-        json={"session_id": "session-1", "user_id": "user-1"},
+        json={"portfolio_id": 1, "session_id": "session-1", "user_id": "user-1"},
     )
 
     assert response.status_code == 400

--- a/tests/test_app/test_api/test_v1/test_portfolio.py
+++ b/tests/test_app/test_api/test_v1/test_portfolio.py
@@ -18,10 +18,12 @@ class DummyPortfolioService:
         start_generation_error: Exception | None = None,
         result: PortfolioResult | None = None,
         status_error: Exception | None = None,
+        update_rate_error: Exception | None = None,
     ) -> None:
         self._start_generation_error = start_generation_error
         self._result = result
         self._status_error = status_error
+        self._update_rate_error = update_rate_error
         self.updated_rate: tuple[str, int] | None = None
 
     async def exists(self, _portfolio_id: str) -> bool:
@@ -49,6 +51,8 @@ class DummyPortfolioService:
         return self._result
 
     async def update_contribution_rate(self, portfolio_id: str, rate: int) -> None:
+        if self._update_rate_error is not None:
+            raise self._update_rate_error
         self.updated_rate = (portfolio_id, rate)
 
 
@@ -139,6 +143,15 @@ def test_get_portfolio_status_returns_200(monkeypatch):
     assert response.json()["status"] == PortfolioStatus.GENERATING.value
 
 
+def test_get_portfolio_status_accepts_numeric_id(monkeypatch):
+    """숫자형 portfolio_id 경로 파라미터를 허용한다."""
+    client = _create_client(monkeypatch, DummyPortfolioService())
+
+    response = client.get("/api/v1/portfolio/100/status")
+
+    assert response.status_code == 200
+
+
 def test_get_portfolio_status_returns_404(monkeypatch):
     """포트폴리오가 없으면 status 엔드포인트는 404를 반환한다."""
     client = _create_client(
@@ -183,3 +196,38 @@ def test_get_session_returns_404(monkeypatch):
     response = client.get("/api/v1/portfolio/session/session-1")
 
     assert response.status_code == 404
+
+
+def test_update_contribution_rate_returns_400_when_service_rejects(monkeypatch):
+    """서비스가 ValueError를 던지면 400을 반환한다."""
+    result = PortfolioResult(
+        portfolio_id="100",
+        session_id="session-1",
+        user_id="user-1",
+        experience_name="경험",
+        status=PortfolioStatus.COMPLETED,
+        contribution_rate=10,
+        output=PortfolioOutput(
+            description="상세",
+            contributions="담당",
+            achievements="해결",
+            insights="배운점",
+        ),
+        created_at=datetime.now(UTC),
+    )
+    client = _create_client(
+        monkeypatch,
+        DummyPortfolioService(
+            result=result,
+            update_rate_error=ValueError(
+                "숫자형 portfolio_id는 현재 기여도 수정을 지원하지 않습니다."
+            ),
+        ),
+    )
+
+    response = client.patch(
+        "/api/v1/portfolio/100/contribution-rate",
+        json={"contribution_rate": 35},
+    )
+
+    assert response.status_code == 400

--- a/tests/test_common/test_main_server/test_correction_client.py
+++ b/tests/test_common/test_main_server/test_correction_client.py
@@ -4,12 +4,16 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from common.http_client import MainServerError
 from common.main_server.correction_client import (
+    _FIELD_MAP_SERVER_TO_AI,
     _FIELD_NAME_TO_SERVER,
+    _RAG_FIELD_MAP_SERVER_TO_AI,
     _STATUS_TO_UPPER,
     CorrectionClient,
     _correction_output_to_payload,
     _transform_get_correction_response,
+    _transform_get_rag_data_response,
 )
 from features.correction.schemas import CorrectionOutput
 
@@ -32,6 +36,25 @@ class TestFieldNameMapping:
         assert _STATUS_TO_UPPER["done"] == "DONE"
         assert _STATUS_TO_UPPER["failed"] == "FAILED"
 
+    def test_field_map_server_to_ai(self):
+        assert _FIELD_MAP_SERVER_TO_AI == {
+            "positionName": "job_title",
+            "highlightPoint": "emphasis_points",
+            "companyName": "company_name",
+            "jobDescription": "job_description",
+            "companyInsight": "company_insight",
+            "userId": "user_id",
+            "createdAt": "created_at",
+        }
+
+    def test_rag_field_map_server_to_ai(self):
+        assert _RAG_FIELD_MAP_SERVER_TO_AI == {
+            "correctionId": "correction_id",
+            "searchQuery": "search_query",
+            "searchResults": "search_results",
+            "createdAt": "created_at",
+        }
+
 
 class TestTransformGetCorrectionResponse:
     """get_correction 응답 변환 테스트"""
@@ -40,19 +63,48 @@ class TestTransformGetCorrectionResponse:
         """필드명 변환 확인"""
         raw = {
             "id": 1,
+            "companyName": "테스트 회사",
             "positionName": "백엔드 개발자",
+            "jobDescription": "JD",
             "highlightPoint": "성과 중심 기술",
+            "companyInsight": "기업 분석",
+            "userId": 123,
             "status": "COMPANY_INSIGHT",
             "portfolioIds": [1, 2, 3],
         }
         result = _transform_get_correction_response(raw)
 
         assert result["job_title"] == "백엔드 개발자"
+        assert result["company_name"] == "테스트 회사"
+        assert result["job_description"] == "JD"
         assert result["emphasis_points"] == "성과 중심 기술"
+        assert result["company_insight"] == "기업 분석"
+        assert result["user_id"] == 123
         assert result["status"] == "company_insight"
-        assert result["portfolioIds"] == [1, 2, 3]
+        assert result["portfolio_ids"] == ["1", "2", "3"]
+        assert result["portfolio_id"] == "1"
         assert "positionName" not in result
         assert "highlightPoint" not in result
+
+
+class TestTransformGetRagDataResponse:
+    """RAG 데이터 응답 변환 테스트"""
+
+    def test_field_renaming(self):
+        raw = {
+            "id": 10,
+            "correctionId": 3,
+            "searchQuery": "백엔드",
+            "searchResults": [{"title": "결과1"}],
+            "createdAt": "2024-01-01T00:00:00.000Z",
+        }
+
+        result = _transform_get_rag_data_response(raw)
+
+        assert result["correction_id"] == 3
+        assert result["search_query"] == "백엔드"
+        assert result["search_results"] == [{"title": "결과1"}]
+        assert result["created_at"] == "2024-01-01T00:00:00.000Z"
 
     def test_status_lowercase_conversion(self):
         """상태값 대소문자 변환"""
@@ -164,10 +216,13 @@ class TestCorrectionClientGetCorrection:
         """첨삭 조회 및 필드 변환"""
         mock_result = {
             "id": 10,
+            "companyName": "회사",
             "positionName": "프론트엔드 개발자",
+            "jobDescription": "JD",
             "highlightPoint": "UI/UX 개선 성과",
+            "companyInsight": "기업 분석",
+            "portfolioIds": [100],
             "status": "DONE",
-            "portfolioIds": [1],
         }
 
         client = CorrectionClient()
@@ -179,8 +234,24 @@ class TestCorrectionClientGetCorrection:
             result = await client.get_correction(10)
 
             assert result["job_title"] == "프론트엔드 개발자"
+            assert result["company_name"] == "회사"
+            assert result["job_description"] == "JD"
             assert result["emphasis_points"] == "UI/UX 개선 성과"
+            assert result["company_insight"] == "기업 분석"
+            assert result["portfolio_id"] == "100"
             assert result["status"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_get_correction_returns_empty_dict_for_404(self):
+        """404 응답은 빈 딕셔너리로 처리한다."""
+        client = CorrectionClient()
+        with patch(
+            "common.main_server.correction_client.request_with_retry",
+            new_callable=AsyncMock,
+            side_effect=MainServerError(status_code=404, message="Not Found"),
+        ):
+            result = await client.get_correction(10)
+            assert result == {}
 
 
 class TestCorrectionClientUpdateStatus:
@@ -259,7 +330,7 @@ class TestCorrectionClientGetRagData:
     @pytest.mark.asyncio
     async def test_returns_dict(self):
         """RAG 데이터 조회 시 dict 반환"""
-        mock_result = {"searchQuery": "test", "searchResults": []}
+        mock_result = {"searchQuery": "test", "searchResults": [], "correctionId": 3}
 
         client = CorrectionClient()
         with patch(
@@ -268,4 +339,20 @@ class TestCorrectionClientGetRagData:
             return_value=mock_result,
         ):
             result = await client.get_rag_data(3)
-            assert result == {"searchQuery": "test", "searchResults": []}
+            assert result == {
+                "search_query": "test",
+                "search_results": [],
+                "correction_id": 3,
+            }
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_for_404(self):
+        """404 응답은 빈 딕셔너리로 처리한다."""
+        client = CorrectionClient()
+        with patch(
+            "common.main_server.correction_client.request_with_retry",
+            new_callable=AsyncMock,
+            side_effect=MainServerError(status_code=404, message="Not Found"),
+        ):
+            result = await client.get_rag_data(3)
+            assert result == {}

--- a/tests/test_common/test_main_server/test_insight_client.py
+++ b/tests/test_common/test_main_server/test_insight_client.py
@@ -76,24 +76,26 @@ class TestInsightClientSearchSimilar:
     @pytest.mark.asyncio
     async def test_search_returns_list(self):
         """정상 검색 결과 리스트 반환"""
-        mock_result = [
-            {
-                "id": 1,
-                "title": "인사이트1",
-                "description": "내용1",
-                "activityNames": ["활동A"],
-                "category": "문제해결",
-                "similarityScore": 0.9,
-            },
-            {
-                "id": 2,
-                "title": "인사이트2",
-                "description": "내용2",
-                "activityNames": ["활동B"],
-                "category": "학습",
-                "similarityScore": 0.8,
-            },
-        ]
+        mock_result = {
+            "insights": [
+                {
+                    "id": 1,
+                    "title": "인사이트1",
+                    "description": "내용1",
+                    "activityNames": ["활동A"],
+                    "category": "문제해결",
+                    "similarityScore": 0.9,
+                },
+                {
+                    "id": 2,
+                    "title": "인사이트2",
+                    "description": "내용2",
+                    "activityNames": ["활동B"],
+                    "category": "학습",
+                    "similarityScore": 0.8,
+                },
+            ]
+        }
 
         client = InsightClient()
         with patch(

--- a/tests/test_common/test_main_server/test_portfolio_client.py
+++ b/tests/test_common/test_main_server/test_portfolio_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from common.http_client import MainServerError
 from common.main_server.portfolio_client import FIELD_MAP_SERVER_TO_AI, PortfolioClient
 
 
@@ -13,6 +14,11 @@ class TestFieldMapping:
     def test_server_to_ai_mapping(self):
         """서버 -> AI 서버 필드 매핑"""
         assert FIELD_MAP_SERVER_TO_AI == {
+            "sessionId": "session_id",
+            "userId": "user_id",
+            "experienceName": "experience_name",
+            "contributionRate": "contribution_rate",
+            "errorMessage": "error_message",
             "responsibilities": "contributions",
             "problemSolving": "achievements",
             "learnings": "insights",
@@ -27,10 +33,14 @@ class TestPortfolioClientGetPortfolio:
         """포트폴리오 조회 시 필드명 변환"""
         mock_result = {
             "id": 1,
+            "sessionId": "session-1",
+            "userId": 101,
+            "experienceName": "프로젝트",
             "description": "프로젝트 설명",
             "responsibilities": "팀 리딩, API 개발",
             "problemSolving": "성능 최적화 50% 달성",
             "learnings": "아키텍처 설계의 중요성",
+            "contributionRate": 70,
             "status": "completed",
         }
 
@@ -46,6 +56,10 @@ class TestPortfolioClientGetPortfolio:
             assert result["achievements"] == "성능 최적화 50% 달성"
             assert result["insights"] == "아키텍처 설계의 중요성"
             assert result["description"] == "프로젝트 설명"
+            assert result["session_id"] == "session-1"
+            assert result["user_id"] == 101
+            assert result["experience_name"] == "프로젝트"
+            assert result["contribution_rate"] == 70
             assert "responsibilities" not in result
             assert "problemSolving" not in result
             assert "learnings" not in result
@@ -60,6 +74,18 @@ class TestPortfolioClientGetPortfolio:
             "common.main_server.portfolio_client.request_with_retry",
             new_callable=AsyncMock,
             return_value=None,
+        ):
+            result = await client.get_portfolio(1)
+            assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_portfolio_returns_empty_dict_for_404(self):
+        """404 응답은 빈 딕셔너리로 처리한다."""
+        client = PortfolioClient()
+        with patch(
+            "common.main_server.portfolio_client.request_with_retry",
+            new_callable=AsyncMock,
+            side_effect=MainServerError(status_code=404, message="Not Found"),
         ):
             result = await client.get_portfolio(1)
             assert result == {}

--- a/tests/test_features/test_interview/test_main_server_insight_store.py
+++ b/tests/test_features/test_interview/test_main_server_insight_store.py
@@ -60,6 +60,18 @@ class TestSearchSimilar:
         assert call_kwargs.kwargs["user_id"] == 123
 
     @pytest.mark.asyncio
+    async def test_converts_user_id_with_prefix_to_int(self):
+        """user-1 같은 문자열 user_id를 int로 변환"""
+        mock_client = AsyncMock()
+        mock_client.search_similar.return_value = []
+
+        store = MainServerInsightStore(client=mock_client)
+        await store.search_similar(query="test", user_id="user-1")
+
+        call_kwargs = mock_client.search_similar.call_args
+        assert call_kwargs.kwargs["user_id"] == 1
+
+    @pytest.mark.asyncio
     async def test_invalid_user_id_returns_empty_list(self):
         """int로 변환 불가능한 user_id는 빈 리스트 반환"""
         mock_client = AsyncMock()
@@ -116,6 +128,17 @@ class TestGetById:
 
         store = MainServerInsightStore(client=mock_client)
         await store.get_by_id("99")
+
+        mock_client.get_by_id.assert_called_once_with(99)
+
+    @pytest.mark.asyncio
+    async def test_converts_prefixed_insight_id_to_int(self):
+        """insight-99 같은 문자열도 숫자 ID로 변환"""
+        mock_client = AsyncMock()
+        mock_client.get_by_id.return_value = None
+
+        store = MainServerInsightStore(client=mock_client)
+        await store.get_by_id("insight-99")
 
         mock_client.get_by_id.assert_called_once_with(99)
 

--- a/tests/test_features/test_interview/test_main_server_insight_store.py
+++ b/tests/test_features/test_interview/test_main_server_insight_store.py
@@ -1,0 +1,142 @@
+"""MainServerInsightStore 단위 테스트"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from features.interview.agents.insight_store import InsightStore, MainServerInsightStore
+
+
+class TestMainServerInsightStoreProtocol:
+    """프로토콜 준수 테스트"""
+
+    def test_implements_insight_store_protocol(self):
+        """MainServerInsightStore가 InsightStore 프로토콜을 구현하는지 확인"""
+        store = MainServerInsightStore()
+        assert isinstance(store, InsightStore)
+
+
+class TestSearchSimilar:
+    """search_similar 메서드 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_insight_client(self):
+        """InsightClient.search_similar에 올바른 파라미터를 전달"""
+        expected = [
+            {
+                "id": "1",
+                "title": "인사이트",
+                "content": "내용",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "similarity_score": 0.9,
+            }
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.search_similar.return_value = expected
+
+        store = MainServerInsightStore(client=mock_client)
+        result = await store.search_similar(
+            query="백엔드 개발", user_id="42", top_k=5, threshold=0.7
+        )
+
+        assert result == expected
+        mock_client.search_similar.assert_called_once_with(
+            keyword="백엔드 개발", user_id=42, top_k=5, threshold=0.7
+        )
+
+    @pytest.mark.asyncio
+    async def test_converts_user_id_str_to_int(self):
+        """user_id 문자열을 int로 변환"""
+        mock_client = AsyncMock()
+        mock_client.search_similar.return_value = []
+
+        store = MainServerInsightStore(client=mock_client)
+        await store.search_similar(query="test", user_id="123")
+
+        mock_client.search_similar.assert_called_once()
+        call_kwargs = mock_client.search_similar.call_args
+        assert call_kwargs.kwargs["user_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_invalid_user_id_returns_empty_list(self):
+        """int로 변환 불가능한 user_id는 빈 리스트 반환"""
+        mock_client = AsyncMock()
+        store = MainServerInsightStore(client=mock_client)
+
+        result = await store.search_similar(query="test", user_id="not-a-number")
+
+        assert result == []
+        mock_client.search_similar.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_default_parameters(self):
+        """기본 top_k, threshold 파라미터 전달"""
+        mock_client = AsyncMock()
+        mock_client.search_similar.return_value = []
+
+        store = MainServerInsightStore(client=mock_client)
+        await store.search_similar(query="test", user_id="1")
+
+        call_kwargs = mock_client.search_similar.call_args
+        assert call_kwargs.kwargs["top_k"] == 5
+        assert call_kwargs.kwargs["threshold"] == 0.7
+
+
+class TestGetById:
+    """get_by_id 메서드 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_insight_client(self):
+        """InsightClient.get_by_id에 올바른 파라미터를 전달"""
+        expected = {
+            "id": "42",
+            "title": "인사이트",
+            "content": "내용",
+            "activity_name": "활동",
+            "category": "대인관계",
+            "similarity_score": None,
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get_by_id.return_value = expected
+
+        store = MainServerInsightStore(client=mock_client)
+        result = await store.get_by_id("42")
+
+        assert result == expected
+        mock_client.get_by_id.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_converts_insight_id_str_to_int(self):
+        """insight_id 문자열을 int로 변환"""
+        mock_client = AsyncMock()
+        mock_client.get_by_id.return_value = None
+
+        store = MainServerInsightStore(client=mock_client)
+        await store.get_by_id("99")
+
+        mock_client.get_by_id.assert_called_once_with(99)
+
+    @pytest.mark.asyncio
+    async def test_invalid_insight_id_returns_none(self):
+        """int로 변환 불가능한 insight_id는 None 반환"""
+        mock_client = AsyncMock()
+        store = MainServerInsightStore(client=mock_client)
+
+        result = await store.get_by_id("abc")
+
+        assert result is None
+        mock_client.get_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_not_found(self):
+        """존재하지 않는 인사이트는 None 반환"""
+        mock_client = AsyncMock()
+        mock_client.get_by_id.return_value = None
+
+        store = MainServerInsightStore(client=mock_client)
+        result = await store.get_by_id("999")
+
+        assert result is None

--- a/tests/test_features/test_portfolio/test_portfolio_service.py
+++ b/tests/test_features/test_portfolio/test_portfolio_service.py
@@ -1,6 +1,7 @@
 """포트폴리오 서비스 테스트"""
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -24,43 +25,6 @@ class DummyBackgroundTasks:
         self.calls.append({"fn": fn, "args": args})
 
 
-class DummyRepo:
-    def __init__(self, row: dict | None = None):
-        self.row = row
-        self.created_args = None
-        self.updated_status = None
-        self.updated_result = None
-
-    async def get_by_session_id(self, _session_id: str) -> dict | None:
-        return self.row
-
-    async def create(self, session_id: str, user_id: str, experience_name: str) -> str:
-        self.created_args = {
-            "session_id": session_id,
-            "user_id": user_id,
-            "experience_name": experience_name,
-        }
-        return "new-id"
-
-    async def update_status(
-        self, portfolio_id: str, status: str, error_message: str | None = None
-    ) -> None:
-        self.updated_status = {
-            "portfolio_id": portfolio_id,
-            "status": status,
-            "error_message": error_message,
-        }
-
-    async def update_result(self, portfolio_id: str, output: PortfolioOutput) -> None:
-        self.updated_result = {"portfolio_id": portfolio_id, "output": output}
-
-    async def get_by_id(self, _portfolio_id: str) -> dict | None:
-        return self.row
-
-    async def update_contribution_rate(self, _portfolio_id: str, _rate: int) -> None:
-        return None
-
-
 class DummyGenerator:
     def __init__(self, output: PortfolioOutput | None = None, exc: Exception | None = None):
         default_output = PortfolioOutput(
@@ -78,83 +42,142 @@ class DummyGenerator:
         return self.output
 
 
+class DummyRepo:
+    """기존 CRUD 엔드포인트용 DummyRepo (get_status, get_result 등)"""
+
+    def __init__(self, row: dict | None = None):
+        self.row = row
+
+    async def get_by_session_id(self, _session_id: str) -> dict | None:
+        return self.row
+
+    async def get_by_id(self, _portfolio_id: str) -> dict | None:
+        return self.row
+
+    async def update_contribution_rate(self, _portfolio_id: str, _rate: int) -> None:
+        return None
+
+
 @pytest.mark.asyncio
-async def test_start_generation_creates_and_schedules_background_task(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """완료된 세션이면 generating 레코드를 만들고 background task를 등록한다."""
+async def test_start_generation_schedules_background_task():
+    """완료된 세션이면 background task를 등록하고 portfolio_id를 반환한다."""
     state = {
         "all_stages_complete": True,
         "collected_data": {"stage_1": {}},
         "experience_name": "프로젝트A",
         "user_id": "user-1",
     }
-    repo = DummyRepo()
     service = PortfolioService(
-        repository=repo,
         generator=DummyGenerator(),
         interview_service=DummyInterviewService(state),
+        portfolio_client=AsyncMock(),
     )
 
     tasks = DummyBackgroundTasks()
-    portfolio_id = await service.start_generation("session-1", "user-1", background_tasks=tasks)
+    portfolio_id = await service.start_generation(
+        portfolio_id=123,
+        session_id="session-1",
+        user_id="user-1",
+        background_tasks=tasks,
+    )
 
-    assert portfolio_id == "new-id"
-    assert repo.created_args == {
-        "session_id": "session-1",
-        "user_id": "user-1",
-        "experience_name": "프로젝트A",
-    }
-    assert repo.updated_status == {
-        "portfolio_id": "new-id",
-        "status": PortfolioStatus.GENERATING.value,
-        "error_message": None,
-    }
+    assert portfolio_id == 123
     assert len(tasks.calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_start_generation_returns_existing_id_for_duplicate_session():
-    """동일 세션의 generating/completed 포트폴리오가 있으면 기존 ID를 반환한다."""
+async def test_start_generation_raises_for_incomplete_interview():
+    """인터뷰 미완료 시 ValueError를 발생시킨다."""
     state = {
-        "all_stages_complete": True,
+        "all_stages_complete": False,
         "collected_data": {},
         "experience_name": "x",
         "user_id": "u",
     }
-    repo = DummyRepo(row={"id": "existing-id", "status": PortfolioStatus.GENERATING.value})
     service = PortfolioService(
-        repository=repo,
         generator=DummyGenerator(),
         interview_service=DummyInterviewService(state),
+        portfolio_client=AsyncMock(),
     )
 
-    portfolio_id = await service.start_generation(
-        "session-1", "u", background_tasks=DummyBackgroundTasks()
-    )
-
-    assert portfolio_id == "existing-id"
-    assert repo.created_args is None
+    with pytest.raises(ValueError, match="인터뷰가 완료되지 않아"):
+        await service.start_generation(
+            portfolio_id=1,
+            session_id="session-1",
+            user_id="u",
+            background_tasks=DummyBackgroundTasks(),
+        )
 
 
 @pytest.mark.asyncio
-async def test_background_generation_failure_updates_failed_status():
-    """Background Task 실패 시 예외를 전파하지 않고 failed 상태를 저장한다."""
-    repo = DummyRepo()
+async def test_start_generation_raises_for_user_mismatch():
+    """세션 사용자와 요청 사용자가 불일치하면 ValueError를 발생시킨다."""
+    state = {
+        "all_stages_complete": True,
+        "collected_data": {},
+        "experience_name": "x",
+        "user_id": "user-a",
+    }
     service = PortfolioService(
-        repository=repo,
-        generator=DummyGenerator(exc=RuntimeError("boom")),
-        interview_service=DummyInterviewService(None),
+        generator=DummyGenerator(),
+        interview_service=DummyInterviewService(state),
+        portfolio_client=AsyncMock(),
     )
 
-    await service._generate_portfolio_background("pid", {}, "exp")
+    with pytest.raises(ValueError, match="사용자가 일치하지 않습니다"):
+        await service.start_generation(
+            portfolio_id=1,
+            session_id="session-1",
+            user_id="user-b",
+            background_tasks=DummyBackgroundTasks(),
+        )
 
-    assert repo.updated_result is None
-    assert repo.updated_status == {
-        "portfolio_id": "pid",
-        "status": PortfolioStatus.FAILED.value,
-        "error_message": "boom",
-    }
+
+@pytest.mark.asyncio
+async def test_background_generation_success_calls_update_result():
+    """Background Task 성공 시 portfolio_client.update_result을 호출한다."""
+    mock_client = AsyncMock()
+    output = PortfolioOutput(
+        description="설명",
+        contributions="기여",
+        achievements="성과",
+        insights="인사이트",
+    )
+    service = PortfolioService(
+        generator=DummyGenerator(output=output),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=mock_client,
+    )
+
+    await service._generate_portfolio_background(42, {}, "exp")
+
+    mock_client.update_result.assert_called_once_with(
+        42,
+        status="completed",
+        description="설명",
+        contributions="기여",
+        achievements="성과",
+        insights="인사이트",
+    )
+
+
+@pytest.mark.asyncio
+async def test_background_generation_failure_calls_failed_callback():
+    """Background Task 실패 시 failed 콜백을 전송한다."""
+    mock_client = AsyncMock()
+    service = PortfolioService(
+        generator=DummyGenerator(exc=RuntimeError("boom")),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=mock_client,
+    )
+
+    await service._generate_portfolio_background(42, {}, "exp")
+
+    mock_client.update_result.assert_called_once_with(
+        42,
+        status="failed",
+        error_message="boom",
+    )
 
 
 @pytest.mark.asyncio
@@ -178,6 +201,7 @@ async def test_get_status_and_get_result_for_completed_row():
         repository=DummyRepo(row=row),
         generator=DummyGenerator(),
         interview_service=DummyInterviewService(None),
+        portfolio_client=AsyncMock(),
     )
 
     status = await service.get_status("pid")

--- a/tests/test_features/test_portfolio/test_portfolio_service.py
+++ b/tests/test_features/test_portfolio/test_portfolio_service.py
@@ -86,6 +86,24 @@ async def test_start_generation_schedules_background_task():
 
 
 @pytest.mark.asyncio
+async def test_start_generation_raises_for_none_session():
+    """세션을 찾을 수 없으면 ValueError를 발생시킨다."""
+    service = PortfolioService(
+        generator=DummyGenerator(),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=AsyncMock(),
+    )
+
+    with pytest.raises(ValueError, match="세션을 찾을 수 없습니다"):
+        await service.start_generation(
+            portfolio_id=1,
+            session_id="nonexistent",
+            user_id="user-1",
+            background_tasks=DummyBackgroundTasks(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_start_generation_raises_for_incomplete_interview():
     """인터뷰 미완료 시 ValueError를 발생시킨다."""
     state = {
@@ -158,6 +176,44 @@ async def test_background_generation_success_calls_update_result():
         contributions="기여",
         achievements="성과",
         insights="인사이트",
+    )
+
+
+@pytest.mark.asyncio
+async def test_background_generation_success_callback_failure_attempts_failed():
+    """성공 콜백이 실패하면 failed 콜백을 시도한다."""
+    mock_client = AsyncMock()
+    mock_client.update_result.side_effect = [
+        RuntimeError("메인 서버 연결 실패"),  # completed 콜백 실패
+        None,  # failed 콜백 성공
+    ]
+    output = PortfolioOutput(
+        description="d",
+        contributions="c",
+        achievements="a",
+        insights="i",
+    )
+    service = PortfolioService(
+        generator=DummyGenerator(output=output),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=mock_client,
+    )
+
+    await service._generate_portfolio_background(42, {}, "exp")
+
+    assert mock_client.update_result.call_count == 2
+    mock_client.update_result.assert_any_call(
+        42,
+        status="completed",
+        description="d",
+        contributions="c",
+        achievements="a",
+        insights="i",
+    )
+    mock_client.update_result.assert_any_call(
+        42,
+        status="failed",
+        error_message="메인 서버 연결 실패",
     )
 
 

--- a/tests/test_features/test_portfolio/test_portfolio_service.py
+++ b/tests/test_features/test_portfolio/test_portfolio_service.py
@@ -267,3 +267,67 @@ async def test_get_status_and_get_result_for_completed_row():
     assert result is not None
     assert result.output is not None
     assert result.output.achievements == "해결"
+
+
+@pytest.mark.asyncio
+async def test_get_status_uses_main_server_for_numeric_portfolio_id():
+    """숫자형 portfolio_id는 메인 서버 조회를 사용한다."""
+    mock_client = AsyncMock()
+    mock_client.get_portfolio.return_value = {
+        "id": 100,
+        "status": PortfolioStatus.GENERATING.value,
+    }
+    service = PortfolioService(
+        generator=DummyGenerator(),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=mock_client,
+    )
+
+    response = await service.get_status("100")
+
+    assert response.status == PortfolioStatus.GENERATING
+    mock_client.get_portfolio.assert_called_once_with(100)
+
+
+@pytest.mark.asyncio
+async def test_get_result_uses_main_server_for_numeric_portfolio_id():
+    """숫자형 portfolio_id 완료 데이터는 메인 서버 결과를 반환한다."""
+    mock_client = AsyncMock()
+    mock_client.get_portfolio.return_value = {
+        "id": 100,
+        "session_id": "session-1",
+        "user_id": 101,
+        "experience_name": "프로젝트",
+        "status": PortfolioStatus.COMPLETED.value,
+        "description": "상세",
+        "contributions": "담당",
+        "achievements": "해결",
+        "insights": "배운점",
+        "contribution_rate": 30,
+    }
+    service = PortfolioService(
+        generator=DummyGenerator(),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=mock_client,
+    )
+
+    result = await service.get_result("100")
+
+    assert result is not None
+    assert result.portfolio_id == "100"
+    assert result.user_id == "101"
+    assert result.output is not None
+    assert result.output.contributions == "담당"
+
+
+@pytest.mark.asyncio
+async def test_update_contribution_rate_raises_for_numeric_portfolio_id():
+    """숫자형 portfolio_id는 기여도 수정을 지원하지 않는다."""
+    service = PortfolioService(
+        generator=DummyGenerator(),
+        interview_service=DummyInterviewService(None),
+        portfolio_client=AsyncMock(),
+    )
+
+    with pytest.raises(ValueError, match="기여도 수정을 지원하지 않습니다"):
+        await service.update_contribution_rate("100", 50)


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #129

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

### InsightStore 메인 서버 API 전환
- `MainServerInsightStore` 구현 (InsightClient 래핑 어댑터, str↔int 변환 처리)
- `app/main.py` lifespan에서 PgVectorInsightStore → MainServerInsightStore 교체
- 시드 데이터 로드 로직 제거, HTTP 클라이언트 종료 추가
- MainServerInsightStore 단위 테스트 9개 추가

### 포트폴리오 generate 메인 서버 위임 전환
- `GeneratePortfolioRequest`에 `portfolio_id: int` 필드 추가
- `PortfolioService.start_generation()`: DB 레코드 생성 제거, PortfolioClient 콜백 방식 전환
- 생성 완료/실패 시 `PATCH /internal/portfolios/{portfolioId}` 호출
- 기존 CRUD 엔드포인트용 PortfolioRepository 지연 초기화 유지

### Opus 리뷰 반영
- 포트폴리오 generate API의 409 응답 문서 제거 (메인 서버 담당으로 변경)
- lifespan 리소스 정리를 try/finally로 감싸 예외 시에도 정리 보장
- `portfolio_id` int/str 타입 혼재 독스트링 명시
- 테스트 추가: 세션 None 케이스, 성공 콜백 실패 시 failed 콜백 시도 검증

## 📸 스크린샷

- `pytest` 240개 통과

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우) - N/A
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

### Depends on #128
- httpx 클라이언트 인프라 및 메인 서버 API 클라이언트(InsightClient, PortfolioClient) 구축 완료된 상태에서 진행

### 향후 별도 작업 검토 사항
- **순환 import 근본 해결**: InsightLog TypedDict를 `common/` 레벨 공유 타입으로 분리
- **성공 콜백 실패 시**: completed + failed 콜백 모두 실패 시 재시도/DLQ 도입 검토


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포트폴리오 생성 전 불필요한 충돌 응답 제거로 요청 흐름 간소화
  * 기여율 업데이트 시 발생하는 입력 오류를 400으로 명확히 반환

* **기능 개선**
  * 포트폴리오/첨삭 API가 숫자 ID(정수) 경로를 허용하도록 확장
  * 포트폴리오 생성 응답에서 ID를 문자열로 일관되게 반환
  * 메인 서버 기반 인사이트 연동으로 검색 및 동기화 개선

* **리팩터링**
  * 서버 시작/종료 시 리소스 정리 및 통신 클라이언트 관리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->