### PR TITLE
[Fix] replace 할 때 메시지 누적 문제 해결

### DIFF
--- a/scripts/replace_completed_interview_state.py
+++ b/scripts/replace_completed_interview_state.py
@@ -55,8 +55,16 @@ def build_replacement_state(existing_state: InterviewState) -> InterviewState:
     return replacement_state
 
 
+async def reset_session_thread(
+    checkpointer: AsyncSqliteSaver,
+    session_id: str,
+) -> None:
+    """기존 session_id에 연결된 모든 체크포인트와 writes를 삭제"""
+    await checkpointer.adelete_thread(session_id)
+
+
 async def replace_session_state(session_id: str) -> dict:
-    """대상 세션을 완료 상태 템플릿으로 교체하고 결과를 반환"""
+    """대상 세션을 완전히 초기화한 뒤 완료 상태 템플릿으로 교체하고 결과를 반환"""
     db_path = os.getenv("CHECKPOINT_DB_PATH", ".data/checkpoints.sqlite")
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
@@ -69,6 +77,7 @@ async def replace_session_state(session_id: str) -> dict:
             raise ValueError(f"세션 상태를 찾을 수 없습니다: {session_id}")
 
         replacement_state = build_replacement_state(snapshot.values)
+        await reset_session_thread(checkpointer, session_id)
         await graph.aupdate_state(config, replacement_state)
 
         updated_snapshot = await graph.aget_state(config)


### PR DESCRIPTION
## 📌 관련 이슈

- N/A

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)

## 📝 작업 내용

- 특정 session_id의 인터뷰 상태를 완료 상태로 교체하는 스크립트 추가
- 기존 user_id, session_id, experience_name 유지
- 기존 checkpoint/writes 삭제 후 완료 상태 재주입으로 누적 없이 완전 대체되도록 수정

## 📸 스크린샷

- 수동 실행으로 확인
- uv run python scripts/replace_completed_interview_state.py --session-id 7c7c2494-dd7c-47be-a06c-f5d991be07af

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 수동 검증을 수행했습니다
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 동일 session_id 유지가 목적이라 thread 삭제 후 재주입 방식 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Infrastructure**
  * 세션 상태 관리 시스템 개선으로 더욱 안정적인 데이터 초기화 프로세스 구현
  * 세션 초기화 시 기존 데이터를 완전히 정리한 후 새로운 상태 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->