### PR TITLE
[Fix] 첨삭 프롬프트 단일화 및 검증 규칙 반영 강화

### DIFF
--- a/features/correction/generator.py
+++ b/features/correction/generator.py
@@ -6,8 +6,8 @@ import re
 from common.llm.client import get_llm
 
 from .config import get_correction_llm_config, get_correction_validation_config
-from .prompts.correction_prompt import format_portfolio_for_correction
-from .prompts.generator import correction_generator_prompt, overall_summary_prompt
+from .prompts.correction_prompt import correction_generator_prompt, format_portfolio_for_correction
+from .prompts.generator import overall_summary_prompt
 from .schemas import REQUIRED_CORRECTION_FIELDS, PortfolioCorrectionResult, SingleCorrectionOutput
 
 _generator: "CorrectionGenerator | None" = None

--- a/features/correction/prompts/__init__.py
+++ b/features/correction/prompts/__init__.py
@@ -1,7 +1,11 @@
 """첨삭 프롬프트 패키지"""
 
-from .correction_prompt import format_portfolio_for_correction, get_correction_prompt
-from .generator import correction_generator_prompt, overall_summary_prompt
+from .correction_prompt import (
+    correction_generator_prompt,
+    format_portfolio_for_correction,
+    get_correction_prompt,
+)
+from .generator import overall_summary_prompt
 
 __all__ = [
     "format_portfolio_for_correction",

--- a/features/correction/prompts/correction_prompt.py
+++ b/features/correction/prompts/correction_prompt.py
@@ -30,8 +30,11 @@ CORRECTION_SYSTEM_PROMPT = """
 - portfolioData는 필드별로 번호가 매겨진 줄 목록입니다.
 - 숫자로 시작하는 줄(예: "1. ...")만 첨삭 대상입니다.
 - "[소구분]" 또는 "1) 소구분" 헤더 줄은 첨삭 대상이 아닙니다.
-- 각 필드에서 번호가 매겨진 줄을 누락 없이 정확히 한 번씩 반환하세요.
+- fields에는 description, contributions, achievements, insights를 각각 정확히 1회씩 포함하세요.
+- 각 필드에서 번호가 매겨진 줄을 누락 없이 정확히 한 번씩 반환하세요. 중복 반환이나 일부 누락은 허용되지 않습니다.
 - line_number는 입력에 표시된 숫자를 그대로 사용하세요.
+- line_number는 전체 문서 기준으로 이어서 세지 말고, 각 field 내부에서 1부터 다시 시작하는 번호만 사용하세요.
+- 다른 field의 line_number를 가져오거나 섞지 마세요.
 - original_text는 번호를 제외한 원문을 그대로 넣으세요.
 
 # 첨삭 타입 기준
@@ -54,7 +57,7 @@ CORRECTION_SYSTEM_PROMPT = """
 
 # 출력 제약
 - 출력은 SingleCorrectionOutput 스키마에 정확히 맞춰야 합니다.
-- fields에는 description, contributions, achievements, insights를 모두 포함하세요.
+- 각 field 객체는 반드시 1개씩만 반환하세요.
 - type은 reduce, keep, emphasize만 사용하세요.
 """.strip()
 

--- a/features/correction/prompts/correction_prompt.py
+++ b/features/correction/prompts/correction_prompt.py
@@ -58,6 +58,13 @@ CORRECTION_SYSTEM_PROMPT = """
 - type은 reduce, keep, emphasize만 사용하세요.
 """.strip()
 
+CORRECTION_GENERATOR_SYSTEM_TEMPLATE = f"""
+{CORRECTION_SYSTEM_PROMPT}
+
+# 이전 시도 피드백
+{{validation_feedback}}
+""".strip()
+
 CORRECTION_HUMAN_PROMPT = """
 ## 입력 데이터
 ### 기업명
@@ -171,9 +178,34 @@ def get_correction_prompt() -> ChatPromptTemplate:
     )
 
 
+correction_generator_prompt = ChatPromptTemplate.from_messages(
+    [
+        ("system", CORRECTION_GENERATOR_SYSTEM_TEMPLATE),
+        (
+            "human",
+            "## 입력 데이터\n"
+            "### 기업명\n"
+            "{company_name}\n\n"
+            "### 직무명\n"
+            "{job_title}\n\n"
+            "### Job Description (JD)\n"
+            "{job_description}\n\n"
+            "### 기업 분석 정보\n"
+            "{company_insight}\n\n"
+            "### 첨삭 대상 마스터 포트폴리오\n"
+            "{portfolio_data_text}\n\n"
+            "### 강조 포인트\n"
+            "{emphasis_points}",
+        ),
+    ]
+).partial(validation_feedback="없음")
+
+
 __all__ = [
+    "CORRECTION_GENERATOR_SYSTEM_TEMPLATE",
     "CORRECTION_HUMAN_PROMPT",
     "CORRECTION_SYSTEM_PROMPT",
+    "correction_generator_prompt",
     "format_portfolio_for_correction",
     "get_correction_prompt",
 ]

--- a/features/correction/prompts/generator.py
+++ b/features/correction/prompts/generator.py
@@ -1,32 +1,6 @@
-"""첨삭 생성 프롬프트"""
+"""첨삭 총평 프롬프트"""
 
 from langchain_core.prompts import ChatPromptTemplate
-
-CORRECTION_GENERATOR_SYSTEM_TEMPLATE = """
-# 역할
-당신은 채용 맥락에 맞춰 포트폴리오 문장을 첨삭하는 전문가입니다.
-
-# 입력 정보
-- 회사명: {company_name}
-- 직무명: {job_title}
-- 채용 공고: {job_description}
-- 기업 인사이트: {company_insight}
-- 강조 포인트: {emphasis_points}
-
-# 원본 포트폴리오
-{portfolio_data_text}
-
-# 출력 규칙
-- 반드시 SingleCorrectionOutput 스키마를 준수하세요.
-- field_name은 description, contributions, achievements, insights를 각각 정확히 1회 포함하세요.
-- line_number는 각 필드의 번호가 매겨진 줄 범위를 벗어나지 않게 작성하세요.
-- type은 reduce, keep, emphasize 중 하나만 사용하세요.
-- keep 라인의 comment는 null 허용입니다.
-- reduce/emphasize 라인의 comment는 비어있지 않게 작성하세요.
-
-# 이전 시도 피드백
-{validation_feedback}
-"""
 
 OVERALL_SUMMARY_SYSTEM_TEMPLATE = """
 # 역할
@@ -66,15 +40,6 @@ OVERALL_SUMMARY_HUMAN_TEMPLATE = """
 ### 포트폴리오별 첨삭 결과 요약
 {portfolio_corrections_text}
 """.strip()
-
-
-correction_generator_prompt = ChatPromptTemplate.from_messages(
-    [
-        ("system", CORRECTION_GENERATOR_SYSTEM_TEMPLATE),
-        ("human", "위 지침에 따라 첨삭 결과를 생성해주세요."),
-    ]
-).partial(validation_feedback="없음")
-
 overall_summary_prompt = ChatPromptTemplate.from_messages(
     [
         ("system", OVERALL_SUMMARY_SYSTEM_TEMPLATE),

--- a/tests/test_features/test_correction/test_correction_prompt.py
+++ b/tests/test_features/test_correction/test_correction_prompt.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.prompts import ChatPromptTemplate
 
 from features.correction.prompts import (
+    correction_generator_prompt,
     format_portfolio_for_correction,
     get_correction_prompt,
     overall_summary_prompt,
@@ -48,6 +49,38 @@ def test_correction_prompt_removes_overall_summary_instruction():
     assert "overall_summary" not in messages[0].content
     assert "SingleCorrectionOutput" in messages[0].content
     assert "comment는 null" in messages[0].content
+
+
+def test_correction_generator_prompt_has_required_input_variables():
+    """런타임 첨삭 프롬프트 입력 변수를 검증한다."""
+    expected_vars = {
+        "company_name",
+        "job_title",
+        "job_description",
+        "company_insight",
+        "portfolio_data_text",
+        "emphasis_points",
+    }
+
+    assert expected_vars == set(correction_generator_prompt.input_variables)
+
+
+def test_correction_generator_prompt_includes_field_scoped_validation_rules():
+    """런타임 첨삭 프롬프트가 field 단위 번호 규칙을 명시하는지 테스트"""
+    messages = correction_generator_prompt.format_messages(
+        company_name="테스트 회사",
+        job_title="백엔드 개발자",
+        job_description="Python, FastAPI 기반 서비스 개발",
+        company_insight="데이터 기반 의사결정을 중시",
+        portfolio_data_text="[상세 정보 - description]\n1. 테스트",
+        emphasis_points="문제해결 능력과 협업을 강조",
+    )
+
+    assert len(messages) == 2
+    assert "각 field 내부에서 1부터 다시 시작" in messages[0].content
+    assert "중복 반환이나 일부 누락은 허용되지 않습니다" in messages[0].content
+    assert "각각 정확히 1회씩 포함" in messages[0].content
+    assert "이전 시도 피드백\n없음" in messages[0].content
 
 
 def test_overall_summary_prompt_has_required_input_variables():


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #151

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 첨삭 생성 런타임이 `features/correction/prompts/correction_prompt.py`의 단일 프롬프트를 사용하도록 정리했습니다.
- `features/correction/prompts/generator.py`는 총평 프롬프트만 담당하도록 역할을 분리했습니다.
- 첨삭 프롬프트에 필수 4개 field 1회 포함, field별 `line_number` 재시작, 번호 라인 누락/중복 금지 규칙을 명시적으로 반영했습니다.
- 런타임 첨삭 프롬프트의 입력 변수와 핵심 검증 문구를 확인하는 테스트를 추가했습니다.

## 📸 스크린샷

- 스크린샷 대신 아래 테스트 결과로 검증했습니다.
- `uv run pytest tests/test_features/test_correction tests/test_app/test_api/test_v1/test_correction.py`
- `uv run ruff check .`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 총평 생성 프롬프트는 이번 이슈 범위에서 제외하고 유지했습니다.
- 개선 제안 및 추가 필요 작업: 실제 LLM 실패 로그 기준 회귀를 더 강하게 막으려면, 추후 `line_number` 누적 오류와 field 누락 케이스를 재현하는 통합 테스트를 추가할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 포트폴리오 첨삭 생성 워크플로우 개선으로 더욱 정밀한 피드백 제공
  * 다중 포트폴리오 종합 분석 및 통합 평가 기능 추가
  * 향상된 첨삭 프롬프트로 개선된 평가 시스템 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->