### PR TITLE
[Feat] Retriever 재활성화 및 메인 백엔드 인사이트 조회 연동 복구

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -119,16 +119,14 @@ async def lifespan(app: FastAPI):
         reset_portfolio_client,
     )
     from common.http_client import close_http_client, get_http_client
-    # 임시 비활성화: retriever 개발 완료 전까지 InsightStore 초기화 제외
-    # from features.interview.agents.insight_store import MainServerInsightStore
-    # from features.interview.agents.nodes.retriever import init_insight_store
+    from features.interview.agents.insight_store import MainServerInsightStore
+    from features.interview.agents.nodes.retriever import init_insight_store
 
     logger = logging.getLogger(__name__)
 
     # ===== InsightStore 초기화 (메인 서버 API) =====
-    # 임시 비활성화: retriever 개발 완료 후 재활성화
-    # init_insight_store(MainServerInsightStore())
-    # logger.info("InsightStore(MainServer) 초기화 완료")
+    init_insight_store(MainServerInsightStore())
+    logger.info("InsightStore(MainServer) 초기화 완료")
 
     try:
         get_http_client()

--- a/app/schemas/interview.py
+++ b/app/schemas/interview.py
@@ -139,6 +139,7 @@ class SSERetrieverInsight(BaseModel):
 
     id: str = Field(..., description="인사이트 ID")
     title: str = Field(..., description="인사이트 제목")
+    activity_name: str = Field(default="", description="관련 활동명")
     category: str = Field(..., description="인사이트 카테고리")
     content: str = Field(..., description="인사이트 본문 내용")
     similarity: float | None = Field(None, description="유사도 점수")

--- a/common/main_server/insight_client.py
+++ b/common/main_server/insight_client.py
@@ -1,15 +1,24 @@
 """인사이트 메인 서버 API 클라이언트"""
 
+from collections.abc import Iterable
 from typing import Any
 
 from common.http_client import MainServerError, request_with_retry
 from features.interview.agents.state import InsightLog
 
 
-def _to_insight_log(raw: dict[str, Any]) -> InsightLog:
+def _to_insight_log(raw: dict[str, Any], *, source: str | None = None) -> InsightLog:
     """메인 서버 응답 객체를 InsightLog로 변환"""
-    activity_names = raw.get("activityNames") or []
-    activity_name = ", ".join(str(a) for a in activity_names)
+    activity_names = raw.get("activityNames")
+    if isinstance(activity_names, str):
+        activity_name = activity_names
+    elif isinstance(activity_names, Iterable):
+        activity_name = ", ".join(str(a) for a in activity_names)
+    else:
+        activity_name = str(raw.get("activityName", ""))
+
+    similarity_score = raw.get("similarityScore")
+    insight_source = source or ("search" if similarity_score is not None else "mention")
 
     return {
         "id": str(raw["id"]),
@@ -17,8 +26,25 @@ def _to_insight_log(raw: dict[str, Any]) -> InsightLog:
         "activity_name": activity_name,
         "category": raw.get("category", "기타"),
         "content": str(raw.get("description", "")),
-        "similarity_score": raw.get("similarityScore"),
+        "similarity_score": similarity_score,
+        "source": insight_source,
     }
+
+
+def _extract_search_items(result: Any) -> list[dict[str, Any]]:
+    """검색 응답에서 인사이트 목록을 추출"""
+    if isinstance(result, list):
+        return [item for item in result if isinstance(item, dict)]
+
+    if not isinstance(result, dict):
+        return []
+
+    for key in ("insights", "content", "items"):
+        raw_items = result.get(key)
+        if isinstance(raw_items, list):
+            return [item for item in raw_items if isinstance(item, dict)]
+
+    return []
 
 
 class InsightClient:
@@ -54,15 +80,8 @@ class InsightClient:
             },
         )
 
-        insights: list[dict[str, Any]] = []
-        if isinstance(result, dict):
-            raw_insights = result.get("insights")
-            if isinstance(raw_insights, list):
-                insights = [item for item in raw_insights if isinstance(item, dict)]
-        elif isinstance(result, list):
-            insights = [item for item in result if isinstance(item, dict)]
-
-        return [_to_insight_log(item) for item in insights]
+        insights = _extract_search_items(result)
+        return [_to_insight_log(item, source="search") for item in insights]
 
     async def get_by_id(self, insight_id: int) -> InsightLog | None:
         """
@@ -85,4 +104,4 @@ class InsightClient:
             raise
         if result is None:
             return None
-        return _to_insight_log(result)
+        return _to_insight_log(result, source="mention")

--- a/features/interview/agents/graph.py
+++ b/features/interview/agents/graph.py
@@ -3,7 +3,7 @@
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph import END, StateGraph
 
-from .nodes import analyst, file_processor, question_generator, router
+from .nodes import analyst, file_processor, question_generator, retriever, router
 from .state import InterviewState
 
 
@@ -19,9 +19,9 @@ def build_graph(checkpointer: BaseCheckpointSaver | None = None):
     [첫 턴]
     Router (초기 감지) → QuestionGenerator → END
     [이후 턴 - 파일 있음]
-    Router → FileProcessor → Analyst → QuestionGenerator → END
+    Router → FileProcessor → Retriever → Analyst → QuestionGenerator → END
     [이후 턴 - 파일 없음]
-    Router → Analyst → QuestionGenerator → END
+    Router → Retriever → Analyst → QuestionGenerator → END
 
     Returns:
         CompiledStateGraph: 컴파일된 그래프
@@ -33,8 +33,7 @@ def build_graph(checkpointer: BaseCheckpointSaver | None = None):
     # 노드 추가
     graph.add_node("router", router.run)
     graph.add_node("file_processor", file_processor.run)
-    # 임시 비활성화: retriever 개발 완료 전까지 그래프에서 제외
-    # graph.add_node("retriever", retriever.run)
+    graph.add_node("retriever", retriever.run)
     graph.add_node("question_generator", question_generator.run)
     graph.add_node("analyst", analyst.run)
 
@@ -45,14 +44,13 @@ def build_graph(checkpointer: BaseCheckpointSaver | None = None):
         {
             "question_generator": "question_generator",  # 첫 턴
             "file_processor": "file_processor",  # 파일 있음
-            "analyst": "analyst",  # 파일 없음
+            "retriever": "retriever",  # 파일 없음
         },
     )
 
-    # FileProcessor -> Analyst
-    graph.add_edge("file_processor", "analyst")
-    # 임시 비활성화: Retriever -> Analyst 엣지 제거
-    # graph.add_edge("retriever", "analyst")
+    # FileProcessor -> Retriever -> Analyst
+    graph.add_edge("file_processor", "retriever")
+    graph.add_edge("retriever", "analyst")
     # Analyst -> 조건부 분기 (단계 진행 또는 인터뷰 종료)
     graph.add_conditional_edges(
         "analyst",

--- a/features/interview/agents/nodes/__init__.py
+++ b/features/interview/agents/nodes/__init__.py
@@ -1,10 +1,11 @@
 """에이전트 노드 모듈"""
 
-from . import analyst, file_processor, question_generator, router
+from . import analyst, file_processor, question_generator, retriever, router
 
 __all__ = [
     "router",
     "file_processor",
+    "retriever",
     "question_generator",
     "analyst",
 ]

--- a/features/interview/agents/nodes/file_processor.py
+++ b/features/interview/agents/nodes/file_processor.py
@@ -16,10 +16,9 @@ def run(state: InterviewState) -> InterviewState:
     - 문서 텍스트 추출
     """
 
-    # 파일 처리 후 Analyst 노드로 전환 (Retriever 임시 비활성화)
+    # 파일 처리 후 Retriever 노드로 전환
     return {
         **state,
-        "processed_files": [],  # 처리된 파일 정보 저장
-        "file_context": {},  # 추출된 텍스트 저장
-        "next_node": "analyst",
+        "file_contexts": state.get("file_contexts", []),
+        "next_node": "retriever",
     }

--- a/features/interview/agents/nodes/retriever.py
+++ b/features/interview/agents/nodes/retriever.py
@@ -8,9 +8,36 @@ from ..state import InsightLog, InterviewState
 
 logger = logging.getLogger(__name__)
 
+
+def _get_env_int(name: str, default: int) -> int:
+    """환경 변수를 int로 안전하게 변환"""
+    value = os.getenv(name)
+    if value is None:
+        return default
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning("%s 값이 올바르지 않아 기본값 %d를 사용합니다.", name, default)
+        return default
+
+
+def _get_env_float(name: str, default: float) -> float:
+    """환경 변수를 float로 안전하게 변환"""
+    value = os.getenv(name)
+    if value is None:
+        return default
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning("%s 값이 올바르지 않아 기본값 %.1f를 사용합니다.", name, default)
+        return default
+
+
 # 환경 변수에서 검색 설정 로드
-_DEFAULT_TOP_K = int(os.getenv("INSIGHT_SEARCH_TOP_K", "3"))
-_DEFAULT_THRESHOLD = float(os.getenv("INSIGHT_SEARCH_THRESHOLD", "0.6"))
+_DEFAULT_TOP_K = _get_env_int("INSIGHT_SEARCH_TOP_K", 3)
+_DEFAULT_THRESHOLD = _get_env_float("INSIGHT_SEARCH_THRESHOLD", 0.6)
 
 # 모듈 레벨 InsightStore 싱글톤
 _store: InsightStore | None = None

--- a/features/interview/agents/nodes/retriever.py
+++ b/features/interview/agents/nodes/retriever.py
@@ -9,8 +9,8 @@ from ..state import InsightLog, InterviewState
 logger = logging.getLogger(__name__)
 
 # 환경 변수에서 검색 설정 로드
-_DEFAULT_TOP_K = int(os.getenv("INSIGHT_SEARCH_TOP_K", "5"))
-_DEFAULT_THRESHOLD = float(os.getenv("INSIGHT_SEARCH_THRESHOLD", "0.7"))
+_DEFAULT_TOP_K = int(os.getenv("INSIGHT_SEARCH_TOP_K", "3"))
+_DEFAULT_THRESHOLD = float(os.getenv("INSIGHT_SEARCH_THRESHOLD", "0.6"))
 
 # 모듈 레벨 InsightStore 싱글톤
 _store: InsightStore | None = None
@@ -64,6 +64,31 @@ def _merge_and_deduplicate(*insight_lists: list[InsightLog]) -> list[InsightLog]
     return list(seen.values())
 
 
+def _with_source(insight: InsightLog, source: str) -> InsightLog:
+    """인사이트에 source 정보를 보강"""
+    return {
+        **insight,
+        "source": source,
+    }
+
+
+def _filter_search_results(
+    insights: list[InsightLog],
+    *,
+    threshold: float,
+    top_k: int,
+) -> list[InsightLog]:
+    """threshold 이상 검색 결과만 남기고 최대 개수로 제한"""
+    filtered = [
+        insight
+        for insight in insights
+        if (insight.get("similarity_score") is not None)
+        and float(insight["similarity_score"]) >= threshold
+    ]
+    filtered.sort(key=lambda insight: float(insight.get("similarity_score") or 0.0), reverse=True)
+    return filtered[:top_k]
+
+
 async def run(state: InterviewState) -> InterviewState:
     """
     인사이트 로그 벡터 검색
@@ -99,17 +124,23 @@ async def run(state: InterviewState) -> InterviewState:
     last_message = messages[-1].content
 
     try:
+        top_k = max(0, min(_DEFAULT_TOP_K, 3))
         similar_insights = await store.search_similar(
             query=last_message,
             user_id=state["user_id"],
-            top_k=_DEFAULT_TOP_K,
+            top_k=top_k,
             threshold=_DEFAULT_THRESHOLD,
+        )
+        similar_insights = _filter_search_results(
+            [_with_source(insight, "search") for insight in similar_insights],
+            threshold=_DEFAULT_THRESHOLD,
+            top_k=top_k,
         )
         logger.info(
             "🔎 유사 인사이트 %d건 검색됨 (user_id=%s, top_k=%d, threshold=%.2f)",
             len(similar_insights),
             state["user_id"],
-            _DEFAULT_TOP_K,
+            top_k,
             _DEFAULT_THRESHOLD,
         )
         # 각 인사이트의 유사도 수치 로그
@@ -131,7 +162,7 @@ async def run(state: InterviewState) -> InterviewState:
         try:
             insight = await store.get_by_id(insight_id)
             if insight is not None:
-                mentioned_insights.append(insight)
+                mentioned_insights.append(_with_source(insight, "mention"))
                 logger.info(f"멘션 인사이트 조회 성공: {insight_id}")
             else:
                 logger.warning(f"멘션 인사이트를 찾을 수 없음: {insight_id}")

--- a/features/interview/agents/nodes/router.py
+++ b/features/interview/agents/nodes/router.py
@@ -7,12 +7,7 @@ def run(state: InterviewState) -> InterviewState:
     """
     초기 상태 감지 및 사용자 입력 라우팅
     - 첫 턴: 바로 QuestionGenerator로 (초기 질문 생성)
-    - 이후 턴: 파일 첨부 여부 확인 후 라우팅
-
-    TODO: 실제 라우팅 로직은 후속 이슈에서 구현
-    - 초기 상태 감지
-    - 파일 첨부 여부 확인
-    - 조건부 라우팅
+    - 이후 턴: 파일 첨부 여부 확인 후 retriever 경유 라우팅
     """
 
     # 초기 상태 확인 (messages가 비어있는지 여부로 판단)
@@ -23,20 +18,16 @@ def run(state: InterviewState) -> InterviewState:
         # 첫 턴: 바로 초기 질문 생성
         next_node = "question_generator"
     else:
-        # 파일 첨부 여부 확인 (임시로 항상 False로 설정)
-        has_file_attachment = False  # TODO: 실제 파일 첨부 확인 로직 구현
+        current_turn_files = state.get("current_turn_files") or []
+        has_file_attachment = len(current_turn_files) > 0
 
         if has_file_attachment:
             next_node = "file_processor"
         else:
-            # 임시 비활성화: retriever 개발 완료 전까지 analyst로 우회
-            next_node = "analyst"
+            next_node = "retriever"
 
     return {
         **state,
         "is_first_turn": is_first_turn,
         "next_node": next_node,
-        # Retriever 임시 비활성화: 매 턴 retrieved_insights를 직접 초기화
-        # 원래 Retriever가 매 턴 덮어쓰던 필드로, 우회 시 이전 턴 값이 누적되는 것을 방지
-        "retrieved_insights": [],
     }

--- a/features/interview/agents/state.py
+++ b/features/interview/agents/state.py
@@ -1,6 +1,6 @@
 """인터뷰 에이전트의 공유 state 정의"""
 
-from typing import Annotated, Literal, TypedDict
+from typing import Annotated, Literal, NotRequired, TypedDict
 
 from langgraph.graph.message import add_messages
 
@@ -16,6 +16,7 @@ class InsightLog(TypedDict):
     category: Literal["대인관계", "문제해결", "학습", "레퍼런스", "기타"]
     content: str
     similarity_score: float | None  # Retriever가 검색 시 계산한 유사도
+    source: NotRequired[Literal["mention", "search"]]
 
 
 class FileAttachment(TypedDict):

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -453,14 +453,9 @@ class InterviewService:
         # 입력 상태 구성
         input_state: dict = {
             "messages": [HumanMessage(content=message)],
+            "current_turn_files": file_ids or [],
+            "mentioned_insight_ids": mentioned_insight_ids or [],
         }
-
-        # 파일 ID가 있으면 추가
-        if file_ids:
-            input_state["current_turn_files"] = file_ids
-
-        # @ 멘션된 인사이트 ID (매 턴 초기화 필요)
-        input_state["mentioned_insight_ids"] = mentioned_insight_ids or []
 
         # 그래프 비동기 실행 (Checkpointer가 이전 상태 자동 로드)
         result = await self._graph.ainvoke(
@@ -572,10 +567,9 @@ class InterviewService:
         # 2. 입력 상태 구성
         input_state: dict = {
             "messages": [HumanMessage(content=message)],
+            "current_turn_files": file_ids or [],
             "mentioned_insight_ids": mentioned_insight_ids or [],
         }
-        if file_ids:
-            input_state["current_turn_files"] = file_ids
 
         config = {"configurable": {"thread_id": session_id}}
         accumulated_text = ""

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -585,28 +585,27 @@ class InterviewService:
                 metadata = event.get("metadata", {})
                 node_name = metadata.get("langgraph_node")
 
-                # 임시 비활성화: retriever 노드 개발 완료 전까지 SSE 이벤트 미송출
-                # if event_type == LangGraphEventType.ON_CHAIN_START and node_name == "retriever":
-                #     yield {
-                #         "event": SSEEventType.RETRIEVER_STATUS,
-                #         "data": json.dumps(
-                #             {
-                #                 "type": SSEEventType.RETRIEVER_STATUS,
-                #                 "message": "대화 내용을 바탕으로 유사도가 높은 인사이트 로그를 읽었어요.",
-                #             },
-                #             ensure_ascii=False,
-                #         ),
-                #     }
+                if event_type == LangGraphEventType.ON_CHAIN_START and node_name == "retriever":
+                    yield {
+                        "event": SSEEventType.RETRIEVER_STATUS,
+                        "data": json.dumps(
+                            {
+                                "type": SSEEventType.RETRIEVER_STATUS,
+                                "message": "대화 내용을 바탕으로 유사도가 높은 인사이트 로그를 읽었어요.",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
 
-                # if event_type == LangGraphEventType.ON_CHAIN_END and node_name == "retriever":
-                #     output = event.get("data", {}).get("output")
-                #     yield {
-                #         "event": SSEEventType.RETRIEVER_RESULT,
-                #         "data": json.dumps(
-                #             self._build_retriever_result_payload(output),
-                #             ensure_ascii=False,
-                #         ),
-                #     }
+                if event_type == LangGraphEventType.ON_CHAIN_END and node_name == "retriever":
+                    output = event.get("data", {}).get("output")
+                    yield {
+                        "event": SSEEventType.RETRIEVER_RESULT,
+                        "data": json.dumps(
+                            self._build_retriever_result_payload(output),
+                            ensure_ascii=False,
+                        ),
+                    }
 
                 # 스트리밍 대상 노드의 LLM 토큰 스트리밍 이벤트만 처리
                 if (

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -515,10 +515,12 @@ class InterviewService:
                 {
                     "id": insight.get("id"),
                     "title": insight.get("title"),
+                    "activity_name": insight.get("activity_name", ""),
                     "category": insight.get("category"),
                     "content": insight.get("content", ""),
                     "similarity": similarity,
-                    "source": "search" if similarity is not None else "mention",
+                    "source": insight.get("source")
+                    or ("search" if similarity is not None else "mention"),
                 }
             )
 

--- a/tests/test_app/test_main_infra.py
+++ b/tests/test_app/test_main_infra.py
@@ -105,6 +105,8 @@ async def test_lifespan_initializes_and_closes_http_client(monkeypatch):
     import common.clients.correction_client as correction_client_module
     import common.clients.portfolio_client as portfolio_client_module
     import common.http_client as http_client
+    import features.interview.agents.insight_store as insight_store_module
+    import features.interview.agents.nodes.retriever as retriever_module
 
     class _DummyClient:
         async def close(self):
@@ -124,11 +126,15 @@ async def test_lifespan_initializes_and_closes_http_client(monkeypatch):
     monkeypatch.setattr(correction_client_module, "reset_correction_client", lambda: None)
     monkeypatch.setattr(portfolio_client_module, "init_portfolio_client", lambda: _DummyClient())
     monkeypatch.setattr(portfolio_client_module, "reset_portfolio_client", lambda: None)
+    init_insight_store_mock = MagicMock()
+    monkeypatch.setattr(insight_store_module, "MainServerInsightStore", lambda: object())
+    monkeypatch.setattr(retriever_module, "init_insight_store", init_insight_store_mock)
 
     async with main.lifespan(FastAPI()):
         pass
 
     get_http_client_mock.assert_called_once()
+    init_insight_store_mock.assert_called_once()
     close_http_client_mock.assert_awaited_once()
 
 

--- a/tests/test_common/test_main_server/test_insight_client.py
+++ b/tests/test_common/test_main_server/test_insight_client.py
@@ -28,6 +28,7 @@ class TestToInsightLog:
         assert result["activity_name"] == "해커톤, 사이드 프로젝트"
         assert result["category"] == "문제해결"
         assert result["similarity_score"] == 0.85
+        assert result["source"] == "search"
 
     def test_empty_activity_names(self):
         """activityNames가 빈 배열인 경우"""
@@ -68,6 +69,20 @@ class TestToInsightLog:
         result = _to_insight_log(raw)
 
         assert result["activity_name"] == "인턴십"
+
+    def test_falls_back_to_single_activity_name_field(self):
+        """activityName 단일 필드도 activity_name으로 변환한다."""
+        raw = {
+            "id": 7,
+            "title": "제목",
+            "description": "설명",
+            "activityName": "공모전",
+        }
+
+        result = _to_insight_log(raw, source="mention")
+
+        assert result["activity_name"] == "공모전"
+        assert result["source"] == "mention"
 
 
 class TestInsightClientSearchSimilar:
@@ -141,6 +156,35 @@ class TestInsightClientSearchSimilar:
             results = await client.search_similar(keyword="test", user_id=1)
             assert results == []
 
+    @pytest.mark.asyncio
+    async def test_search_extracts_content_list_shape(self):
+        """content 리스트 형태 응답도 파싱한다."""
+        mock_result = {
+            "content": [
+                {
+                    "id": 3,
+                    "title": "인사이트3",
+                    "description": "내용3",
+                    "activityName": "활동C",
+                    "category": "대인관계",
+                    "similarityScore": 0.77,
+                }
+            ]
+        }
+
+        client = InsightClient()
+        with patch(
+            "common.main_server.insight_client.request_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            results = await client.search_similar(keyword="협업", user_id=1)
+
+        assert len(results) == 1
+        assert results[0]["id"] == "3"
+        assert results[0]["activity_name"] == "활동C"
+        assert results[0]["source"] == "search"
+
 
 class TestInsightClientGetById:
     """InsightClient.get_by_id 테스트"""
@@ -168,6 +212,7 @@ class TestInsightClientGetById:
             assert result is not None
             assert result["id"] == "42"
             assert result["content"] == "상세 내용"
+            assert result["source"] == "mention"
 
     @pytest.mark.asyncio
     async def test_get_not_found(self):

--- a/tests/test_features/test_interview/test_graph.py
+++ b/tests/test_features/test_interview/test_graph.py
@@ -52,15 +52,29 @@ def test_supervisor_routing(initial_state):
 
 
 def test_interviewer_routing(initial_state):
-    """Router가 후속 턴에 analyst로 라우팅하는지 확인"""
+    """Router가 후속 턴에 retriever로 라우팅하는지 확인"""
     from features.interview.agents.nodes import router
 
     state = {**initial_state, "messages": [AIMessage(content="이전 질문")]}
     result = router.run(state)
-    assert result["next_node"] == "analyst"
+    assert result["next_node"] == "retriever"
 
 
-def test_graph_with_end_condition(initial_state, monkeypatch):
+def test_interviewer_routing_with_file_attachment(initial_state):
+    """파일이 있으면 Router가 file_processor로 라우팅하는지 확인"""
+    from features.interview.agents.nodes import router
+
+    state = {
+        **initial_state,
+        "messages": [AIMessage(content="이전 질문")],
+        "current_turn_files": ["file-1"],
+    }
+    result = router.run(state)
+    assert result["next_node"] == "file_processor"
+
+
+@pytest.mark.asyncio
+async def test_graph_with_end_condition(initial_state, monkeypatch):
     """Analyst가 end를 반환하면 QG를 거치지 않고 종료한다."""
     from features.interview.agents.nodes import analyst, question_generator
 
@@ -83,7 +97,7 @@ def test_graph_with_end_condition(initial_state, monkeypatch):
         "messages": [AIMessage(content="이전 질문")],
     }  # Router가 analyst로 분기
     graph = build_graph()
-    result = graph.invoke(state)
+    result = await graph.ainvoke(state)
     assert result is not None
     assert result["all_stages_complete"] is True
     assert result["overall_completion_percentage"] == 100.0

--- a/tests/test_features/test_interview/test_graph_analyst_routing.py
+++ b/tests/test_features/test_interview/test_graph_analyst_routing.py
@@ -1,14 +1,20 @@
 """Analyst 조건부 라우팅 그래프 테스트"""
 
+import pytest
+
 from features.interview.agents.graph import build_graph
 from features.interview.agents.nodes import analyst, question_generator, router
 from features.interview.agents.state import get_initial_interview_state
 
 
-def test_graph_routes_to_end_when_analyst_sets_end(monkeypatch):
+@pytest.mark.asyncio
+async def test_graph_routes_to_end_when_analyst_sets_end(monkeypatch):
     """Analyst가 end를 반환하면 question_generator를 거치지 않고 종료한다."""
 
     def _router_run(state):
+        return {**state, "next_node": "retriever"}
+
+    async def _retriever_run(state):
         return {**state, "next_node": "analyst"}
 
     def _analyst_run(state):
@@ -18,6 +24,9 @@ def test_graph_routes_to_end_when_analyst_sets_end(monkeypatch):
         raise AssertionError("analyst가 end를 반환한 경우 question_generator가 호출되면 안 됩니다.")
 
     monkeypatch.setattr(router, "run", _router_run)
+    from features.interview.agents.nodes import retriever
+
+    monkeypatch.setattr(retriever, "run", _retriever_run)
     monkeypatch.setattr(analyst, "run", _analyst_run)
     monkeypatch.setattr(question_generator, "run", _question_generator_run)
 
@@ -28,6 +37,6 @@ def test_graph_routes_to_end_when_analyst_sets_end(monkeypatch):
         experience_name="테스트 경험",
     )
 
-    result = graph.invoke(state)
+    result = await graph.ainvoke(state)
 
     assert result["all_stages_complete"] is True

--- a/tests/test_features/test_interview/test_retriever.py
+++ b/tests/test_features/test_interview/test_retriever.py
@@ -1,0 +1,169 @@
+"""Retriever 노드 테스트"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from features.interview.agents.nodes import retriever
+
+
+def test_merge_and_deduplicate_prefers_search_source_with_higher_score():
+    """동일 ID가 겹치면 더 높은 유사도와 search source를 유지한다."""
+    merged = retriever._merge_and_deduplicate(
+        [
+            {
+                "id": "insight-1",
+                "title": "검색 결과",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "검색 내용",
+                "similarity_score": 0.91,
+                "source": "search",
+            }
+        ],
+        [
+            {
+                "id": "insight-1",
+                "title": "멘션 결과",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "멘션 내용",
+                "similarity_score": None,
+                "source": "mention",
+            }
+        ],
+    )
+
+    assert len(merged) == 1
+    assert merged[0]["title"] == "검색 결과"
+    assert merged[0]["source"] == "search"
+
+
+def test_filter_search_results_applies_threshold_and_top_k():
+    """threshold 이상 결과만 남기고 최대 3개로 제한한다."""
+    filtered = retriever._filter_search_results(
+        [
+            {
+                "id": "1",
+                "title": "a",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "a",
+                "similarity_score": 0.61,
+                "source": "search",
+            },
+            {
+                "id": "2",
+                "title": "b",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "b",
+                "similarity_score": 0.59,
+                "source": "search",
+            },
+            {
+                "id": "3",
+                "title": "c",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "c",
+                "similarity_score": 0.95,
+                "source": "search",
+            },
+            {
+                "id": "4",
+                "title": "d",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "d",
+                "similarity_score": 0.88,
+                "source": "search",
+            },
+            {
+                "id": "5",
+                "title": "e",
+                "activity_name": "활동",
+                "category": "문제해결",
+                "content": "e",
+                "similarity_score": 0.75,
+                "source": "search",
+            },
+        ],
+        threshold=0.6,
+        top_k=3,
+    )
+
+    assert [item["id"] for item in filtered] == ["3", "4", "5"]
+
+
+@pytest.mark.asyncio
+async def test_run_limits_search_results_and_merges_mentions(monkeypatch):
+    """Retriever가 검색 결과를 3건으로 제한하고 멘션 결과를 병합한다."""
+    mock_store = AsyncMock()
+    mock_store.search_similar.return_value = [
+        {
+            "id": "search-1",
+            "title": "s1",
+            "activity_name": "활동1",
+            "category": "문제해결",
+            "content": "내용1",
+            "similarity_score": 0.93,
+        },
+        {
+            "id": "search-2",
+            "title": "s2",
+            "activity_name": "활동2",
+            "category": "문제해결",
+            "content": "내용2",
+            "similarity_score": 0.88,
+        },
+        {
+            "id": "mention-1",
+            "title": "duplicate",
+            "activity_name": "활동3",
+            "category": "문제해결",
+            "content": "내용3",
+            "similarity_score": 0.81,
+        },
+        {
+            "id": "search-4",
+            "title": "below-threshold",
+            "activity_name": "활동4",
+            "category": "문제해결",
+            "content": "내용4",
+            "similarity_score": 0.4,
+        },
+    ]
+    mock_store.get_by_id.return_value = {
+        "id": "mention-1",
+        "title": "mention",
+        "activity_name": "활동3",
+        "category": "문제해결",
+        "content": "멘션 내용",
+        "similarity_score": None,
+    }
+
+    monkeypatch.setattr(retriever, "_DEFAULT_TOP_K", 5)
+    monkeypatch.setattr(retriever, "_DEFAULT_THRESHOLD", 0.6)
+    monkeypatch.setattr(retriever, "get_insight_store", lambda: mock_store)
+
+    result = await retriever.run(
+        {
+            "user_id": "user-1",
+            "messages": [HumanMessage(content="문제 해결 경험")],
+            "mentioned_insight_ids": ["mention-1"],
+        }
+    )
+
+    retrieved = result["retrieved_insights"]
+    assert [item["id"] for item in retrieved] == ["search-1", "search-2", "mention-1"]
+    assert retrieved[0]["source"] == "search"
+    assert retrieved[-1]["source"] == "search"
+    assert result["next_node"] == "analyst"
+    mock_store.search_similar.assert_awaited_once_with(
+        query="문제 해결 경험",
+        user_id="user-1",
+        top_k=3,
+        threshold=0.6,
+    )

--- a/tests/test_features/test_interview/test_retriever.py
+++ b/tests/test_features/test_interview/test_retriever.py
@@ -1,11 +1,27 @@
 """Retriever 노드 테스트"""
 
+import importlib
 from unittest.mock import AsyncMock
 
 import pytest
 from langchain_core.messages import HumanMessage
 
 from features.interview.agents.nodes import retriever
+
+
+def test_env_defaults_fallback_on_invalid_values(monkeypatch):
+    """잘못된 환경 변수 값이면 기본값으로 fallback한다."""
+    monkeypatch.setenv("INSIGHT_SEARCH_TOP_K", "invalid")
+    monkeypatch.setenv("INSIGHT_SEARCH_THRESHOLD", "bad")
+
+    reloaded = importlib.reload(retriever)
+
+    assert reloaded._DEFAULT_TOP_K == 3
+    assert reloaded._DEFAULT_THRESHOLD == 0.6
+
+    monkeypatch.delenv("INSIGHT_SEARCH_TOP_K", raising=False)
+    monkeypatch.delenv("INSIGHT_SEARCH_THRESHOLD", raising=False)
+    importlib.reload(retriever)
 
 
 def test_merge_and_deduplicate_prefers_search_source_with_higher_score():

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -172,6 +172,34 @@ async def test_process_message_returns_none_when_all_complete(monkeypatch):
     assert result["ai_response"] is None
     assert result["all_complete"] is True
     assert result["is_extended_mode"] is False
+    invocation = dummy_graph.invocations[0]
+    assert invocation["state"]["current_turn_files"] == []
+
+
+@pytest.mark.asyncio
+async def test_process_message_resets_current_turn_files_when_no_files(monkeypatch):
+    """파일이 없는 턴에도 current_turn_files를 빈 리스트로 초기화한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={"session_id": "session_1", "current_turn_files": ["old_file"]}
+    )
+    dummy_graph.invoke_result = {
+        "messages": [AIMessage(content="응답")],
+        "current_stage": 2,
+        "stage_progress": {"fixed_q_used": 2},
+        "overall_completion_percentage": 40.0,
+        "all_stages_complete": False,
+    }
+
+    service = _build_service(monkeypatch, dummy_graph)
+
+    await service.process_message(
+        session_id="session_1",
+        message="파일 없는 답변입니다.",
+    )
+
+    invocation = dummy_graph.invocations[0]
+    assert invocation["state"]["current_turn_files"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -200,6 +200,46 @@ async def test_process_message_stream_emits_retriever_events(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_process_message_stream_resets_current_turn_files_when_no_files(monkeypatch):
+    """스트리밍 턴에서도 current_turn_files를 빈 리스트로 초기화한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "messages": [AIMessage(content="최종 응답")],
+            "current_stage": 1,
+            "stage_progress": {
+                "fixed_q_used": 0,
+                "fixed_q_total": 1,
+                "generated_q_used": 0,
+                "generated_q_max": 0,
+                "force_all_generated_q": False,
+                "is_complete": False,
+            },
+            "overall_completion_percentage": 25.0,
+            "all_stages_complete": False,
+            "current_turn_files": ["old-file"],
+        }
+    )
+    dummy_graph.stream_events = []
+
+    monkeypatch.setattr(
+        "features.interview.service.build_graph", lambda checkpointer=None: dummy_graph
+    )
+    monkeypatch.setattr("features.interview.service.get_checkpointer", lambda: object())
+    service = InterviewService()
+
+    _ = [
+        event
+        async for event in service.process_message_stream(
+            session_id="session-1",
+            message="사용자 답변",
+        )
+    ]
+
+    assert dummy_graph.astream_calls[0]["state"]["current_turn_files"] == []
+
+
+@pytest.mark.anyio
 async def test_process_message_stream_returns_none_when_all_complete(monkeypatch):
     """모든 단계 완료 상태면 message_complete의 ai_response는 null이다."""
     dummy_graph = DummyGraph()

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -113,10 +113,8 @@ def test_extend_session_stream_route_exists():
 
 
 @pytest.mark.anyio
-async def test_process_message_stream_ignores_retriever_events_when_temporarily_disabled(
-    monkeypatch,
-):
-    """Retriever 이벤트가 와도 retriever_result를 전송하지 않고 일반 스트림만 유지한다."""
+async def test_process_message_stream_emits_retriever_events(monkeypatch):
+    """Retriever 시작/결과 이벤트를 SSE로 전송한다."""
     dummy_graph = DummyGraph()
     dummy_graph.state_snapshot = DummyStateSnapshot(
         values={
@@ -135,6 +133,11 @@ async def test_process_message_stream_ignores_retriever_events_when_temporarily_
         }
     )
     dummy_graph.stream_events = [
+        {
+            "event": LangGraphEventType.ON_CHAIN_START,
+            "metadata": {"langgraph_node": "retriever"},
+            "data": {},
+        },
         {
             "event": LangGraphEventType.ON_CHAIN_END,
             "metadata": {"langgraph_node": "retriever"},
@@ -179,8 +182,16 @@ async def test_process_message_stream_ignores_retriever_events_when_temporarily_
     ]
 
     assert len(events) > 0
-    assert all(event["event"] != SSEEventType.RETRIEVER_RESULT for event in events)
-    assert events[0]["event"] == SSEEventType.CONTENT_BLOCK_DELTA
+    assert events[0]["event"] == SSEEventType.RETRIEVER_STATUS
+    status_payload = json.loads(events[0]["data"])
+    assert status_payload["type"] == SSEEventType.RETRIEVER_STATUS
+
+    assert events[1]["event"] == SSEEventType.RETRIEVER_RESULT
+    retriever_payload = json.loads(events[1]["data"])
+    assert retriever_payload["insights"][0]["source"] == "search"
+    assert retriever_payload["insights"][1]["source"] == "mention"
+
+    assert events[2]["event"] == SSEEventType.CONTENT_BLOCK_DELTA
 
 
 @pytest.mark.anyio

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -147,14 +147,18 @@ async def test_process_message_stream_emits_retriever_events(monkeypatch):
                         {
                             "id": "insight-1",
                             "title": "문제 해결 경험",
+                            "activity_name": "프로젝트 A",
                             "category": "문제해결",
                             "similarity_score": 0.91,
+                            "source": "search",
                         },
                         {
                             "id": "insight-2",
                             "title": "멘션 인사이트",
+                            "activity_name": "프로젝트 B",
                             "category": "기타",
                             "similarity_score": None,
+                            "source": "mention",
                         },
                     ]
                 }
@@ -188,6 +192,7 @@ async def test_process_message_stream_emits_retriever_events(monkeypatch):
 
     assert events[1]["event"] == SSEEventType.RETRIEVER_RESULT
     retriever_payload = json.loads(events[1]["data"])
+    assert retriever_payload["insights"][0]["activity_name"] == "프로젝트 A"
     assert retriever_payload["insights"][0]["source"] == "search"
     assert retriever_payload["insights"][1]["source"] == "mention"
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #159
- Parent: #158

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- Retriever 노드를 인터뷰 그래프에 다시 연결하고, 후속 턴이 `router -> retriever -> analyst` 흐름을 타도록 복구했습니다.
- 파일 첨부 턴도 `file_processor -> retriever -> analyst`로 이어지도록 조정하고, 앱 시작 시 `MainServerInsightStore` 초기화를 다시 활성화했습니다.
- 메인 백엔드 인사이트 응답 파싱을 보강해 `insights`, `content`, `items` 형태를 처리하고, `activity_name`/`source` 필드를 유지하도록 정리했습니다.
- similarity search 결과를 threshold 이상, 최대 3개까지만 반영하고 mention 결과와 병합/중복 제거하도록 Retriever 로직을 보강했습니다.
- Retriever SSE status/result 이벤트를 다시 노출하고, 관련 그래프/클라이언트/store/service 테스트를 복구 및 추가했습니다.

## 📸 스크린샷

- CLI 환경에서 작업하여 스크린샷 대신 테스트 결과로 검증했습니다.
- `uv run pytest` -> `319 passed`

## ✅ 체크리스트
- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- `InsightLog`에 `source`를 포함해 search/mention 출처를 유지하도록 했고, SSE payload에도 `activity_name`을 함께 전달합니다.

## 개선 제안 및 추가 필요 작업

- 부모 이슈 #158 범위인 `turn_number`, `insight_turn_history`, 과거 턴 카드 복원은 이번 PR에 포함하지 않았습니다.
- 메인 백엔드 실환경 응답 샘플 기준으로 `/internal/insights/search` 응답 계약을 한 번 더 검증하면 안정성을 높일 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 검색 기반 인사이트 검색기 활성화 및 시작 시 인사이트 스토어 초기화 복원
  * 인터뷰 흐름에 Retriever 노드 통합 (라우팅 경로에 포함)

* **Enhancements**
  * 인사이트에 activity_name(활동명) 필드 추가 및 출처(source) 표기 강화
  * 검색 결과 유사도 기반 필터링·상위 결과 제한 및 기본값 조정(톱K/임계치)
  * 실시간 리트리버 상태·결과 SSE 이벤트 재활성화

* **Tests**
  * 관련 단위/통합 테스트 및 스트림 테스트 업데이트 및 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->