### PR TITLE
[Refactor] turn_number 도입 및 insight_turn_history 기반 세션 복원 구조 정리

### DIFF
--- a/app/api/v1/interview.py
+++ b/app/api/v1/interview.py
@@ -18,6 +18,8 @@ from app.schemas.interview import (
     CreateSessionResponse,
     ErrorResponse,
     ExtendSessionResponse,
+    InsightLogSchema,
+    InsightTurnRecordSchema,
     MessageSchema,
     SessionStateResponse,
     StageProgressSchema,
@@ -360,6 +362,7 @@ async def get_session_state(session_id: str) -> SessionStateResponse:
         session_id=state["session_id"],
         user_id=state["user_id"],
         experience_name=state["experience_name"],
+        turn_number=state["turn_number"],
         current_stage=state["current_stage"],
         stage_progress=StageProgressSchema(**state["stage_progress"]),
         overall_completion=state["overall_completion_percentage"],
@@ -367,6 +370,15 @@ async def get_session_state(session_id: str) -> SessionStateResponse:
         message_count=len(state["messages"]),
         is_extended_mode=state["is_extended_mode"],
         collected_data=collected_data,
+        insight_turn_history=[
+            InsightTurnRecordSchema(
+                turn_number=record["turn_number"],
+                user_message=record["user_message"],
+                mentioned_insight_ids=record["mentioned_insight_ids"],
+                insights=[InsightLogSchema(**insight) for insight in record["insights"]],
+            )
+            for record in state["insight_turn_history"]
+        ],
         messages=messages,
     )
 

--- a/app/schemas/interview.py
+++ b/app/schemas/interview.py
@@ -36,6 +36,33 @@ class MessageSchema(BaseModel):
     id: str | None = Field(None, description="메시지 ID")
 
 
+class InsightLogSchema(BaseModel):
+    """인사이트 로그 스키마"""
+
+    id: str = Field(..., description="인사이트 ID")
+    title: str = Field(..., description="인사이트 제목")
+    activity_name: str = Field(default="", description="관련 활동명")
+    category: str = Field(..., description="인사이트 카테고리")
+    content: str = Field(..., description="인사이트 내용")
+    similarity_score: float | None = Field(None, description="유사도 점수")
+    source: str | None = Field(None, description="검색 소스 (search 또는 mention)")
+
+
+class InsightTurnRecordSchema(BaseModel):
+    """턴별 인사이트 복원 기록 스키마"""
+
+    turn_number: int = Field(..., ge=1, description="사용자 턴 번호")
+    user_message: str = Field(..., description="해당 턴의 사용자 메시지")
+    mentioned_insight_ids: list[str] = Field(
+        default_factory=list,
+        description="해당 턴에서 멘션된 인사이트 ID 목록",
+    )
+    insights: list[InsightLogSchema] = Field(
+        default_factory=list,
+        description="해당 턴에서 조회된 인사이트 카드 목록",
+    )
+
+
 # ===== 세션 생성 =====
 class CreateSessionRequest(BaseModel):
     """세션 생성 요청"""
@@ -100,6 +127,7 @@ class SessionStateResponse(BaseModel):
     session_id: str = Field(..., description="세션 ID")
     user_id: str = Field(..., description="사용자 ID")
     experience_name: str = Field(..., description="경험/프로젝트 이름")
+    turn_number: int = Field(..., ge=0, description="현재 사용자 턴 번호")
     current_stage: int = Field(..., ge=1, le=4, description="현재 단계")
     stage_progress: StageProgressSchema = Field(..., description="단계 진행 상황")
     overall_completion: float = Field(..., ge=0.0, le=100.0, description="전체 완료율 (%)")
@@ -108,6 +136,10 @@ class SessionStateResponse(BaseModel):
     is_extended_mode: bool = Field(..., description="추가 대화 모드 여부")
     collected_data: dict[str, dict[str, CollectedFieldSchema]] = Field(
         ..., description="수집된 포트폴리오 데이터"
+    )
+    insight_turn_history: list[InsightTurnRecordSchema] = Field(
+        default_factory=list,
+        description="과거 사용자 턴별 인사이트 복원 이력",
     )
     messages: list[MessageSchema] = Field(..., description="전체 대화 기록")
 

--- a/features/interview/agents/nodes/question_generator.py
+++ b/features/interview/agents/nodes/question_generator.py
@@ -18,7 +18,7 @@ from ..prompts import (
     first_turn_prompt,
     generated_question_prompt,
 )
-from ..state import InterviewState
+from ..state import InterviewState, ensure_interview_state_defaults
 from .utils import (
     _format_global_incomplete_fields,
     _format_incomplete_fields,
@@ -254,15 +254,17 @@ def run(state: InterviewState) -> InterviewState:
     - 질문 소진: 안전한 fallback 질문 생성
     """
 
-    if state["is_extended_mode"]:
-        return _run_extended_mode(state)
+    normalized_state = ensure_interview_state_defaults(state)
+
+    if normalized_state["is_extended_mode"]:
+        return _run_extended_mode(normalized_state)
 
     # 1. 현재 단계 설정 로드
-    stage_config = load_stage_config(state["current_stage"])
-    progress = state["stage_progress"]
+    stage_config = load_stage_config(normalized_state["current_stage"])
+    progress = normalized_state["stage_progress"]
 
-    # 2. 첫 턴 여부 판단
-    is_first_turn = len(state["messages"]) == 0
+    # 2. 첫 질문 생성 여부 판단
+    is_first_turn = normalized_state["turn_number"] == 0
 
     question: str
     llm_error: str | None
@@ -270,7 +272,7 @@ def run(state: InterviewState) -> InterviewState:
 
     if is_first_turn:
         # ===== 첫 턴 질문 생성 =====
-        question, llm_error = _generate_first_turn_question(state, stage_config)
+        question, llm_error = _generate_first_turn_question(normalized_state, stage_config)
         updated_progress = {
             **progress,
             "fixed_q_used": 1,
@@ -282,7 +284,7 @@ def run(state: InterviewState) -> InterviewState:
         fixed_question_raw = stage_config.fixed_questions[next_fixed_question_idx]
 
         question, llm_error = _generate_contextual_fixed_question(
-            state=state,
+            state=normalized_state,
             fixed_question_content=fixed_question_raw,
         )
 
@@ -293,7 +295,7 @@ def run(state: InterviewState) -> InterviewState:
 
     elif progress["generated_q_used"] < progress["generated_q_max"]:
         # ===== 생성 질문 생성 =====
-        question, llm_error = _generate_dynamic_question(state, stage_config)
+        question, llm_error = _generate_dynamic_question(normalized_state, stage_config)
         updated_progress = {
             **progress,
             "generated_q_used": progress["generated_q_used"] + 1,
@@ -303,7 +305,7 @@ def run(state: InterviewState) -> InterviewState:
         # ===== 질문 소진 (방어 로직) =====
         logger.warning(
             "Stage %s: QuestionGenerator가 질문 소진 상태로 호출되어 fallback 질문을 생성합니다.",
-            state["current_stage"],
+            normalized_state["current_stage"],
         )
         question = "혹시 더 추가하고 싶은 내용이 있으신가요?"
         llm_error = None
@@ -313,7 +315,7 @@ def run(state: InterviewState) -> InterviewState:
 
     # 4. 공통 반환 처리
     result_state: InterviewState = {
-        **state,
+        **normalized_state,
         "messages": [AIMessage(content=question)],
         "stage_progress": updated_progress,
         "next_node": "end",

--- a/features/interview/agents/nodes/retriever.py
+++ b/features/interview/agents/nodes/retriever.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 from ..insight_store import InsightStore
-from ..state import InsightLog, InterviewState
+from ..state import InsightLog, InsightTurnRecord, InterviewState, ensure_interview_state_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +99,36 @@ def _with_source(insight: InsightLog, source: str) -> InsightLog:
     }
 
 
+def _get_latest_user_message(state: InterviewState) -> str | None:
+    """현재 실행을 시작한 최신 사용자 메시지 내용 추출"""
+
+    messages = state.get("messages") or []
+    for message in reversed(messages):
+        if getattr(message, "type", None) == "human":
+            content = getattr(message, "content", None)
+            if isinstance(content, str):
+                return content
+            if content is None:
+                return None
+            return str(content)
+    return None
+
+
+def _build_insight_turn_record(
+    state: InterviewState,
+    insights: list[InsightLog],
+    user_message: str,
+) -> InsightTurnRecord:
+    """현재 사용자 턴의 인사이트 복원 레코드 생성"""
+
+    return {
+        "turn_number": state["turn_number"],
+        "user_message": user_message,
+        "mentioned_insight_ids": list(state.get("mentioned_insight_ids") or []),
+        "insights": list(insights),
+    }
+
+
 def _filter_search_results(
     insights: list[InsightLog],
     *,
@@ -128,33 +158,45 @@ async def run(state: InterviewState) -> InterviewState:
         dict: { "retrieved_insights": [...], "next_node": "analyst" }
     """
 
+    normalized_state = ensure_interview_state_defaults(state)
+    user_message = _get_latest_user_message(normalized_state)
+
     try:
         store = get_insight_store()
     except RuntimeError:
         logger.warning("InsightStore가 초기화되지 않음. 인사이트 검색을 건너뜁니다.")
+        if user_message is None:
+            return {
+                **normalized_state,
+                "retrieved_insights": [],
+                "next_node": "analyst",
+            }
+
         return {
-            **state,
+            **normalized_state,
             "retrieved_insights": [],
+            "insight_turn_history": [
+                *normalized_state["insight_turn_history"],
+                _build_insight_turn_record(normalized_state, [], user_message),
+            ],
             "next_node": "analyst",
         }
 
     # 1. 유사도 검색
     similar_insights: list[InsightLog] = []
-    messages = state.get("messages") or []
-    if not messages:
+    if user_message is None:
         logger.warning("메시지가 비어있어 인사이트 검색을 건너뜁니다.")
         return {
-            **state,
+            **normalized_state,
             "retrieved_insights": [],
             "next_node": "analyst",
         }
-    last_message = messages[-1].content
 
     try:
         top_k = max(0, min(_DEFAULT_TOP_K, 3))
         similar_insights = await store.search_similar(
-            query=last_message,
-            user_id=state["user_id"],
+            query=user_message,
+            user_id=normalized_state["user_id"],
             top_k=top_k,
             threshold=_DEFAULT_THRESHOLD,
         )
@@ -166,7 +208,7 @@ async def run(state: InterviewState) -> InterviewState:
         logger.info(
             "🔎 유사 인사이트 %d건 검색됨 (user_id=%s, top_k=%d, threshold=%.2f)",
             len(similar_insights),
-            state["user_id"],
+            normalized_state["user_id"],
             top_k,
             _DEFAULT_THRESHOLD,
         )
@@ -183,7 +225,7 @@ async def run(state: InterviewState) -> InterviewState:
 
     # 2. @ 멘션 인사이트 강제 포함
     mentioned_insights: list[InsightLog] = []
-    mentioned_ids = state.get("mentioned_insight_ids", [])
+    mentioned_ids = normalized_state.get("mentioned_insight_ids", [])
 
     for insight_id in mentioned_ids:
         try:
@@ -198,6 +240,7 @@ async def run(state: InterviewState) -> InterviewState:
 
     # 3. 병합 및 중복 제거 (해당 턴의 인사이트만 / 누적하지 않음)
     all_insights = _merge_and_deduplicate(similar_insights, mentioned_insights)
+    insight_turn_record = _build_insight_turn_record(normalized_state, all_insights, user_message)
 
     logger.info(
         "✅ 인사이트 병합 완료: 유사=%d, 멘션=%d → 최종=%d",
@@ -208,7 +251,11 @@ async def run(state: InterviewState) -> InterviewState:
 
     # 검색 후 Analyst 노드로 전환
     return {
-        **state,
+        **normalized_state,
         "retrieved_insights": all_insights,
+        "insight_turn_history": [
+            *normalized_state["insight_turn_history"],
+            insight_turn_record,
+        ],
         "next_node": "analyst",
     }

--- a/features/interview/agents/nodes/retriever.py
+++ b/features/interview/agents/nodes/retriever.py
@@ -129,6 +129,17 @@ def _build_insight_turn_record(
     }
 
 
+def _upsert_insight_turn_history(
+    history: list[InsightTurnRecord],
+    new_record: InsightTurnRecord,
+) -> list[InsightTurnRecord]:
+    """같은 turn_number 기록을 교체하면서 히스토리를 갱신"""
+
+    turn_number = new_record["turn_number"]
+    filtered_history = [record for record in history if record["turn_number"] != turn_number]
+    return [*filtered_history, new_record]
+
+
 def _filter_search_results(
     insights: list[InsightLog],
     *,
@@ -172,13 +183,15 @@ async def run(state: InterviewState) -> InterviewState:
                 "next_node": "analyst",
             }
 
+        insight_turn_record = _build_insight_turn_record(normalized_state, [], user_message)
+
         return {
             **normalized_state,
             "retrieved_insights": [],
-            "insight_turn_history": [
-                *normalized_state["insight_turn_history"],
-                _build_insight_turn_record(normalized_state, [], user_message),
-            ],
+            "insight_turn_history": _upsert_insight_turn_history(
+                normalized_state["insight_turn_history"],
+                insight_turn_record,
+            ),
             "next_node": "analyst",
         }
 
@@ -253,9 +266,9 @@ async def run(state: InterviewState) -> InterviewState:
     return {
         **normalized_state,
         "retrieved_insights": all_insights,
-        "insight_turn_history": [
-            *normalized_state["insight_turn_history"],
+        "insight_turn_history": _upsert_insight_turn_history(
+            normalized_state["insight_turn_history"],
             insight_turn_record,
-        ],
+        ),
         "next_node": "analyst",
     }

--- a/features/interview/agents/nodes/router.py
+++ b/features/interview/agents/nodes/router.py
@@ -1,6 +1,6 @@
 """Router 노드 - 입력 라우팅 및 초기 상태 감지"""
 
-from ..state import InterviewState
+from ..state import InterviewState, ensure_interview_state_defaults, get_turn_number_from_messages
 
 
 def run(state: InterviewState) -> InterviewState:
@@ -10,15 +10,24 @@ def run(state: InterviewState) -> InterviewState:
     - 이후 턴: 파일 첨부 여부 확인 후 retriever 경유 라우팅
     """
 
-    # 초기 상태 확인 (messages가 비어있는지 여부로 판단)
-    messages = state.get("messages", [])
-    is_first_turn = len(messages) == 0
+    normalized_state = ensure_interview_state_defaults(state)
+    current_turn_number = get_turn_number_from_messages(normalized_state.get("messages", []))
+    has_new_user_message = current_turn_number > normalized_state["turn_number"]
+    is_session_bootstrap = normalized_state["turn_number"] == 0 and current_turn_number == 0
+    turn_number = normalized_state["turn_number"]
 
-    if is_first_turn:
-        # 첫 턴: 바로 초기 질문 생성
+    if (
+        is_session_bootstrap
+        or normalized_state.get("is_extended_mode", False)
+        and not has_new_user_message
+    ):
+        # 세션 생성 직후/연장 시작 직후에는 이번 실행의 사용자 답변이 없어 turn_number를 유지한다.
         next_node = "question_generator"
     else:
-        current_turn_files = state.get("current_turn_files") or []
+        if has_new_user_message:
+            turn_number += 1
+
+        current_turn_files = normalized_state.get("current_turn_files") or []
         has_file_attachment = len(current_turn_files) > 0
 
         if has_file_attachment:
@@ -27,7 +36,7 @@ def run(state: InterviewState) -> InterviewState:
             next_node = "retriever"
 
     return {
-        **state,
-        "is_first_turn": is_first_turn,
+        **normalized_state,
+        "turn_number": turn_number,
         "next_node": next_node,
     }

--- a/features/interview/agents/state.py
+++ b/features/interview/agents/state.py
@@ -19,6 +19,15 @@ class InsightLog(TypedDict):
     source: NotRequired[Literal["mention", "search"]]
 
 
+class InsightTurnRecord(TypedDict):
+    """사용자 턴별 인사이트 복원 기록"""
+
+    turn_number: int
+    user_message: str
+    mentioned_insight_ids: list[str]
+    insights: list[InsightLog]
+
+
 class FileAttachment(TypedDict):
     """업로드된 파일 정보"""
 
@@ -63,7 +72,7 @@ class InterviewState(TypedDict):
     user_id: str  # 사용자 고유 ID
     session_id: str  # 세션 고유 ID
     experience_name: str  # 사용자가 정리하려는 경험/프로젝트명 (세션 생성 시 입력)
-    # turn_number: int  # 현재 턴 번호 (1부터 시작, Router가 매 턴마다 증가시킴)
+    turn_number: int  # 현재 사용자 턴 번호 (세션 생성 직후 0, 사용자 메시지 처리 시 1부터 증가)
 
     # ===== 대화 기록 (LangGraph 메시지 리듀서 사용) =====
     messages: Annotated[list, add_messages]
@@ -104,6 +113,10 @@ class InterviewState(TypedDict):
     #   2. @멘션된 인사이트 강제 포함
     #   3. 병합 & 중복 제거 후 해당 턴의 결과만 반환
     # 이전 턴의 인사이트는 messages 히스토리를 통해 자연스럽게 context에 포함됨
+
+    insight_turn_history: list[InsightTurnRecord]
+    # 사용자 턴별 인사이트 카드 복원 이력
+    # retrieved_insights와 별개로 과거 턴 전체를 누적 저장
 
     # ===== 파일 업로드 =====
     uploaded_files: list[FileAttachment]
@@ -172,6 +185,7 @@ def get_initial_interview_state(
         "user_id": user_id,
         "session_id": session_id,
         "experience_name": experience_name,
+        "turn_number": 0,
         # 대화 기록
         "messages": [],
         # 단계 관리
@@ -192,6 +206,7 @@ def get_initial_interview_state(
         # 인사이트
         "mentioned_insight_ids": [],
         "retrieved_insights": [],
+        "insight_turn_history": [],
         # 파일 업로드
         "uploaded_files": [],
         "current_turn_files": [],
@@ -208,4 +223,24 @@ def get_initial_interview_state(
         "extension_turns_max": global_config.extension_turns_per_session,
         # 에러 추적
         "llm_error": None,
+    }
+
+
+def get_turn_number_from_messages(messages: list) -> int:
+    """메시지 목록에서 사용자 턴 수를 계산"""
+
+    return sum(1 for message in messages if getattr(message, "type", None) == "human")
+
+
+def ensure_interview_state_defaults(state: InterviewState | dict) -> InterviewState:
+    """구버전 세션 state에도 신규 기본값을 보강"""
+
+    messages = list(state.get("messages") or [])
+
+    return {
+        **state,
+        "turn_number": state.get("turn_number", get_turn_number_from_messages(messages)),
+        "mentioned_insight_ids": list(state.get("mentioned_insight_ids") or []),
+        "retrieved_insights": list(state.get("retrieved_insights") or []),
+        "insight_turn_history": list(state.get("insight_turn_history") or []),
     }

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -17,6 +17,7 @@ from common.sse import (
 from features.interview.agents.graph import build_graph
 from features.interview.agents.state import (
     InterviewState,
+    ensure_interview_state_defaults,
     get_initial_interview_state,
 )
 from features.interview.config.loader import get_global_config
@@ -494,7 +495,7 @@ class InterviewService:
         if state_snapshot is None or not state_snapshot.values:
             return None
 
-        return state_snapshot.values
+        return ensure_interview_state_defaults(state_snapshot.values)
 
     @staticmethod
     def _build_retriever_result_payload(output: dict | None) -> dict:

--- a/tests/test_app/test_api/test_v1/test_interview.py
+++ b/tests/test_app/test_api/test_v1/test_interview.py
@@ -13,6 +13,48 @@ class DummyInterviewService:
         assert experience_name
         yield {"event": "message_complete", "data": "{}"}
 
+    async def get_session_state(self, session_id: str):
+        return {
+            "session_id": session_id,
+            "user_id": "user-1",
+            "experience_name": "프로젝트",
+            "turn_number": 2,
+            "current_stage": 1,
+            "stage_progress": {
+                "fixed_q_used": 1,
+                "fixed_q_total": 3,
+                "generated_q_used": 0,
+                "generated_q_max": 2,
+                "force_all_generated_q": False,
+                "is_complete": False,
+            },
+            "overall_completion_percentage": 25.0,
+            "all_stages_complete": False,
+            "is_extended_mode": False,
+            "collected_data": {"stage_1": {}},
+            "insight_turn_history": [
+                {
+                    "turn_number": 1,
+                    "user_message": "첫 답변",
+                    "mentioned_insight_ids": ["insight-1"],
+                    "insights": [
+                        {
+                            "id": "insight-1",
+                            "title": "문제 해결 경험",
+                            "activity_name": "해커톤",
+                            "category": "문제해결",
+                            "content": "문제를 해결했습니다.",
+                            "similarity_score": 0.91,
+                            "source": "search",
+                        }
+                    ],
+                }
+            ],
+            "messages": [],
+            "mentioned_insight_ids": [],
+            "retrieved_insights": [],
+        }
+
 
 def _create_client(monkeypatch) -> TestClient:
     monkeypatch.setattr(interview_api, "get_interview_service", lambda: DummyInterviewService())
@@ -50,3 +92,17 @@ def test_extend_routes_exist():
     assert "POST" in extend_methods
     assert extend_stream_methods is not None
     assert "POST" in extend_stream_methods
+
+
+def test_get_session_state_includes_turn_history(monkeypatch):
+    """세션 상태 응답에 turn_number와 인사이트 턴 히스토리를 포함한다."""
+    client = _create_client(monkeypatch)
+
+    response = client.get("/api/v1/interview/sessions/session-1/state")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["turn_number"] == 2
+    assert body["insight_turn_history"][0]["turn_number"] == 1
+    assert body["insight_turn_history"][0]["user_message"] == "첫 답변"
+    assert body["insight_turn_history"][0]["insights"][0]["activity_name"] == "해커톤"

--- a/tests/test_features/test_interview/test_graph.py
+++ b/tests/test_features/test_interview/test_graph.py
@@ -1,7 +1,7 @@
 """그래프 구조 테스트"""
 
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from features.interview.agents import InterviewState, build_graph
 from features.interview.agents.state import get_initial_interview_state
@@ -49,15 +49,20 @@ def test_supervisor_routing(initial_state):
 
     result = router.run(initial_state)
     assert result["next_node"] == "question_generator"
+    assert result["turn_number"] == 0
 
 
 def test_interviewer_routing(initial_state):
     """Router가 후속 턴에 retriever로 라우팅하는지 확인"""
     from features.interview.agents.nodes import router
 
-    state = {**initial_state, "messages": [AIMessage(content="이전 질문")]}
+    state = {
+        **initial_state,
+        "messages": [AIMessage(content="이전 질문"), HumanMessage(content="첫 답변")],
+    }
     result = router.run(state)
     assert result["next_node"] == "retriever"
+    assert result["turn_number"] == 1
 
 
 def test_interviewer_routing_with_file_attachment(initial_state):
@@ -66,11 +71,34 @@ def test_interviewer_routing_with_file_attachment(initial_state):
 
     state = {
         **initial_state,
-        "messages": [AIMessage(content="이전 질문")],
+        "messages": [AIMessage(content="이전 질문"), HumanMessage(content="파일 포함 답변")],
         "current_turn_files": ["file-1"],
     }
     result = router.run(state)
     assert result["next_node"] == "file_processor"
+    assert result["turn_number"] == 1
+
+
+def test_router_increments_existing_turn_number(initial_state):
+    """Router는 사용자 메시지 처리 시 기존 turn_number를 증가시킨다."""
+    from features.interview.agents.nodes import router
+
+    state = {
+        **initial_state,
+        "turn_number": 2,
+        "messages": [
+            AIMessage(content="이전 질문"),
+            HumanMessage(content="이전 답변"),
+            AIMessage(content="둘째 질문"),
+            HumanMessage(content="둘째 답변"),
+            AIMessage(content="새 질문"),
+            HumanMessage(content="새 답변"),
+        ],
+    }
+
+    result = router.run(state)
+
+    assert result["turn_number"] == 3
 
 
 @pytest.mark.asyncio
@@ -94,7 +122,8 @@ async def test_graph_with_end_condition(initial_state, monkeypatch):
 
     state = {
         **initial_state,
-        "messages": [AIMessage(content="이전 질문")],
+        "turn_number": 1,
+        "messages": [AIMessage(content="이전 질문"), HumanMessage(content="답변")],
     }  # Router가 analyst로 분기
     graph = build_graph()
     result = await graph.ainvoke(state)

--- a/tests/test_features/test_interview/test_question_generator.py
+++ b/tests/test_features/test_interview/test_question_generator.py
@@ -31,7 +31,7 @@ def first_turn_state():
 def test_first_turn_question_generation(first_turn_state, monkeypatch):
     """
     첫 턴 질문 생성 테스트
-    - 메시지가 비어있을 때 첫 질문을 생성하는지 확인
+    - turn_number가 0일 때 첫 질문을 생성하는지 확인
     - AIMessage가 추가되는지 확인
     - stage_progress의 fixed_q_used가 1로 증가하는지 확인
     - next_node가 'end'인지 확인
@@ -84,6 +84,32 @@ def test_first_turn_uses_fixed_question_content(first_turn_state, monkeypatch):
     assert "AI 에이전트 개발 프로젝트" in question_content
 
 
+def test_turn_number_controls_first_turn_detection(first_turn_state, monkeypatch):
+    """messages 길이가 아니라 turn_number로 첫 턴을 판별한다."""
+    monkeypatch.setattr(
+        question_generator,
+        "get_llm",
+        lambda model=None, temperature=0.7: _mock_llm_raise(),
+    )
+
+    state = {
+        **first_turn_state,
+        "turn_number": 1,
+        "messages": [],
+        "stage_progress": {
+            **first_turn_state["stage_progress"],
+            "fixed_q_used": 1,
+        },
+    }
+
+    result = question_generator.run(state)
+
+    expected_fixed_question = load_stage_config(1).fixed_questions[1]
+
+    assert result["messages"][0].content == expected_fixed_question
+    assert result["stage_progress"]["fixed_q_used"] == 2
+
+
 def test_followup_fixed_question_generation(first_turn_state, monkeypatch):
     """
     후속 고정 질문 생성 테스트
@@ -98,6 +124,7 @@ def test_followup_fixed_question_generation(first_turn_state, monkeypatch):
 
     non_first_turn_state = {
         **first_turn_state,
+        "turn_number": 1,
         "messages": [
             AIMessage(content="첫 질문입니다."),
             HumanMessage(content="사용자 답변입니다."),
@@ -130,6 +157,7 @@ def test_generated_question_fallback_on_llm_error(first_turn_state, monkeypatch)
 
     state = {
         **first_turn_state,
+        "turn_number": 1,
         "messages": [
             AIMessage(content="질문1"),
             HumanMessage(content="답변1"),
@@ -186,6 +214,7 @@ def test_generated_question_ignores_dynamic_followup_switch(first_turn_state, mo
     """enable_dynamic_followup이 false여도 QG는 호출 시 질문을 생성한다."""
     state = {
         **first_turn_state,
+        "turn_number": 1,
         "messages": [
             AIMessage(content="질문1"),
             HumanMessage(content="답변1"),
@@ -226,6 +255,7 @@ def test_fallback_question_when_called_after_exhaustion(first_turn_state):
     """질문 소진 상태로 호출되어도 AIMessage fallback을 반환한다."""
     state = {
         **first_turn_state,
+        "turn_number": 1,
         "messages": [
             AIMessage(content="질문1"),
             HumanMessage(content="답변1"),

--- a/tests/test_features/test_interview/test_retriever.py
+++ b/tests/test_features/test_interview/test_retriever.py
@@ -223,3 +223,51 @@ async def test_run_appends_empty_history_when_store_is_unavailable(monkeypatch):
             "insights": [],
         }
     ]
+
+
+def test_upsert_insight_turn_history_replaces_same_turn_record():
+    """같은 turn_number 기록은 append 대신 교체한다."""
+    history = [
+        {
+            "turn_number": 1,
+            "user_message": "이전 답변",
+            "mentioned_insight_ids": [],
+            "insights": [],
+        },
+        {
+            "turn_number": 2,
+            "user_message": "기존 답변",
+            "mentioned_insight_ids": ["old-id"],
+            "insights": [
+                {
+                    "id": "old-id",
+                    "title": "기존 인사이트",
+                    "activity_name": "활동",
+                    "category": "문제해결",
+                    "content": "기존 내용",
+                    "similarity_score": 0.8,
+                    "source": "search",
+                }
+            ],
+        },
+    ]
+    new_record = {
+        "turn_number": 2,
+        "user_message": "재처리 답변",
+        "mentioned_insight_ids": ["new-id"],
+        "insights": [
+            {
+                "id": "new-id",
+                "title": "새 인사이트",
+                "activity_name": "새 활동",
+                "category": "문제해결",
+                "content": "새 내용",
+                "similarity_score": 0.9,
+                "source": "search",
+            }
+        ],
+    }
+
+    result = retriever._upsert_insight_turn_history(history, new_record)
+
+    assert result == [history[0], new_record]

--- a/tests/test_features/test_interview/test_retriever.py
+++ b/tests/test_features/test_interview/test_retriever.py
@@ -166,9 +166,11 @@ async def test_run_limits_search_results_and_merges_mentions(monkeypatch):
 
     result = await retriever.run(
         {
+            "turn_number": 1,
             "user_id": "user-1",
             "messages": [HumanMessage(content="문제 해결 경험")],
             "mentioned_insight_ids": ["mention-1"],
+            "insight_turn_history": [],
         }
     )
 
@@ -176,6 +178,14 @@ async def test_run_limits_search_results_and_merges_mentions(monkeypatch):
     assert [item["id"] for item in retrieved] == ["search-1", "search-2", "mention-1"]
     assert retrieved[0]["source"] == "search"
     assert retrieved[-1]["source"] == "search"
+    assert result["insight_turn_history"] == [
+        {
+            "turn_number": 1,
+            "user_message": "문제 해결 경험",
+            "mentioned_insight_ids": ["mention-1"],
+            "insights": retrieved,
+        }
+    ]
     assert result["next_node"] == "analyst"
     mock_store.search_similar.assert_awaited_once_with(
         query="문제 해결 경험",
@@ -183,3 +193,33 @@ async def test_run_limits_search_results_and_merges_mentions(monkeypatch):
         top_k=3,
         threshold=0.6,
     )
+
+
+@pytest.mark.asyncio
+async def test_run_appends_empty_history_when_store_is_unavailable(monkeypatch):
+    """스토어가 없어도 현재 턴 복원 이력은 남긴다."""
+    monkeypatch.setattr(
+        retriever,
+        "get_insight_store",
+        lambda: (_ for _ in ()).throw(RuntimeError("store missing")),
+    )
+
+    result = await retriever.run(
+        {
+            "turn_number": 2,
+            "user_id": "user-1",
+            "messages": [HumanMessage(content="추가 설명입니다.")],
+            "mentioned_insight_ids": ["mention-2"],
+            "insight_turn_history": [],
+        }
+    )
+
+    assert result["retrieved_insights"] == []
+    assert result["insight_turn_history"] == [
+        {
+            "turn_number": 2,
+            "user_message": "추가 설명입니다.",
+            "mentioned_insight_ids": ["mention-2"],
+            "insights": [],
+        }
+    ]

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -317,13 +317,24 @@ async def test_get_session_state_returns_none_on_empty_snapshot(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_session_state_returns_values(monkeypatch):
-    """스냅샷 값 반환 테스트"""
+    """스냅샷 값 반환 시 신규 기본 필드를 보강한다."""
     dummy_graph = DummyGraph()
-    expected_state = {"session_id": "session_1", "current_stage": 1}
+    expected_state = {
+        "session_id": "session_1",
+        "current_stage": 1,
+        "messages": [HumanMessage(content="답변")],
+    }
     dummy_graph.state_snapshot = DummyStateSnapshot(values=expected_state)
     service = _build_service(monkeypatch, dummy_graph)
 
-    assert await service.get_session_state("session_1") == expected_state
+    result = await service.get_session_state("session_1")
+
+    assert result is not None
+    assert result["session_id"] == "session_1"
+    assert result["turn_number"] == 1
+    assert result["retrieved_insights"] == []
+    assert result["mentioned_insight_ids"] == []
+    assert result["insight_turn_history"] == []
 
 
 def test_singleton_get_and_reset(monkeypatch):


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #160

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `InterviewState`에 `turn_number`, `InsightTurnRecord`, `insight_turn_history`를 추가하고 초기 상태/구세션 기본값 보정 로직을 정리했습니다.
- `Router`, `QuestionGenerator`에서 `messages` 길이 기반 첫 턴 판별을 제거하고 사용자 메시지 입력 기준으로 턴 증가 규칙을 명시했습니다.
- `Retriever`가 현재 턴 실행용 `retrieved_insights`는 유지하면서 복원용 `insight_turn_history`에 턴별 인사이트 카드를 누적 저장하도록 변경했습니다.
- `GET /interview/sessions/{session_id}/state` 응답에 `turn_number`와 `insight_turn_history`를 포함하도록 스키마/API를 확장했습니다.
- 상태/라우팅/질문 생성기/retriever/service/API 테스트를 추가 및 보강했습니다.

## 📸 스크린샷

- UI 변경이 없어 스크린샷은 없습니다.
- 검증 명령:
  - `uv run pytest tests/test_features/test_interview/test_graph.py tests/test_features/test_interview/test_question_generator.py tests/test_features/test_interview/test_retriever.py tests/test_features/test_interview/test_service.py tests/test_app/test_api/test_v1/test_interview.py`
  - `uv run ruff check features/interview/agents/state.py features/interview/agents/nodes/router.py features/interview/agents/nodes/question_generator.py features/interview/agents/nodes/retriever.py features/interview/service.py app/api/v1/interview.py app/schemas/interview.py tests/test_features/test_interview/test_graph.py tests/test_features/test_interview/test_question_generator.py tests/test_features/test_interview/test_retriever.py tests/test_features/test_interview/test_service.py tests/test_app/test_api/test_v1/test_interview.py`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 기존 체크포인트에 `turn_number`, `insight_turn_history`가 없을 수 있어 서비스 조회 시 기본값 보정 로직을 함께 추가했습니다.

### 개선 제안 및 추가 필요 작업
- 연장 모드 사용자 메시지도 동일한 턴 카운팅 정책을 따르므로, 후속 이슈에서 프론트 세션 복원 UI와의 매핑 검증이 한 번 더 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 세션 상태에 현재 턴 번호(turn_number) 추적 추가
  * 각 턴의 사용자 메시지와 해당 통찰(인사이트) 목록을 기록하는 턴별 통찰 이력(insight_turn_history) 저장 추가
  * 세션 상태 API가 위 정보를 포함한 확장된 상태(payload)를 반환하도록 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->