### PR TITLE
[Feat] 인터뷰 세션 status 기반 재진입 상태 복원 지원

### DIFF
--- a/app/api/v1/interview.py
+++ b/app/api/v1/interview.py
@@ -22,6 +22,7 @@ from app.schemas.interview import (
     InsightTurnRecordSchema,
     MessageSchema,
     SessionStateResponse,
+    SessionStatusResponse,
     StageProgressSchema,
 )
 from common.sse import SSEErrorCode, SSEEventType
@@ -316,6 +317,29 @@ async def extend_session_stream(session_id: str):
 
 
 @router.get(
+    "/sessions/{session_id}/status",
+    response_model=SessionStatusResponse,
+    status_code=status.HTTP_200_OK,
+    summary="세션 경량 상태 조회",
+    description="현재 세션의 경량 상태를 조회합니다.",
+    responses={404: {"model": ErrorResponse, "description": "세션을 찾을 수 없음"}},
+)
+async def get_session_status(session_id: str) -> SessionStatusResponse:
+    """세션의 경량 상태를 조회한다."""
+
+    service = get_interview_service()
+    session_status = await service.get_session_status(session_id)
+
+    if session_status is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"세션을 찾을 수 없습니다: {session_id}",
+        )
+
+    return SessionStatusResponse(**session_status)
+
+
+@router.get(
     "/sessions/{session_id}/state",
     response_model=SessionStateResponse,
     status_code=status.HTTP_200_OK,
@@ -362,6 +386,7 @@ async def get_session_state(session_id: str) -> SessionStateResponse:
         session_id=state["session_id"],
         user_id=state["user_id"],
         experience_name=state["experience_name"],
+        status=state["status"],
         turn_number=state["turn_number"],
         current_stage=state["current_stage"],
         stage_progress=StageProgressSchema(**state["stage_progress"]),

--- a/app/schemas/interview.py
+++ b/app/schemas/interview.py
@@ -1,6 +1,7 @@
 """인터뷰 API 스키마 정의"""
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -125,6 +126,10 @@ class SessionStateResponse(BaseModel):
     session_id: str = Field(..., description="세션 ID")
     user_id: str = Field(..., description="사용자 ID")
     experience_name: str = Field(..., description="경험/프로젝트 이름")
+    status: Literal["generating", "completed", "failed"] = Field(
+        ...,
+        description="세션 생성 상태",
+    )
     turn_number: int = Field(..., ge=0, description="현재 사용자 턴 번호")
     current_stage: int = Field(..., ge=1, le=4, description="현재 단계")
     stage_progress: StageProgressSchema = Field(..., description="단계 진행 상황")
@@ -140,6 +145,18 @@ class SessionStateResponse(BaseModel):
         description="과거 사용자 턴별 인사이트 복원 이력",
     )
     messages: list[MessageSchema] = Field(..., description="전체 대화 기록")
+
+
+class SessionStatusResponse(BaseModel):
+    """세션 경량 상태 조회 응답"""
+
+    session_id: str = Field(..., description="세션 ID")
+    status: Literal["generating", "completed", "failed"] = Field(
+        ...,
+        description="세션 생성 상태",
+    )
+    current_stage: int = Field(..., ge=1, le=4, description="현재 단계")
+    all_complete: bool = Field(..., description="모든 단계 완료 여부")
 
 
 # ===== 에러 응답 =====
@@ -189,6 +206,10 @@ class SSEMessagePayload(BaseModel):
     """최종 완료 메시지 내용"""
 
     ai_response: str | None = Field(None, description="전체 AI 응답 (없으면 null)")
+    status: Literal["generating", "completed", "failed"] = Field(
+        ...,
+        description="세션 생성 상태",
+    )
     current_stage: int = Field(..., ge=1, le=4, description="현재 단계")
     stage_progress: StageProgressSchema = Field(..., description="단계 진행 상황")
     overall_completion: float = Field(..., ge=0.0, le=100.0, description="전체 완료율 (%)")

--- a/features/interview/agents/state.py
+++ b/features/interview/agents/state.py
@@ -61,6 +61,9 @@ class CollectedField(TypedDict):
 
 
 # 메인 State 정의
+InterviewSessionStatus = Literal["generating", "completed", "failed"]
+
+
 class InterviewState(TypedDict):
     """
     인터뷰 에이전트의 공유 상태
@@ -72,6 +75,7 @@ class InterviewState(TypedDict):
     user_id: str  # 사용자 고유 ID
     session_id: str  # 세션 고유 ID
     experience_name: str  # 사용자가 정리하려는 경험/프로젝트명 (세션 생성 시 입력)
+    status: InterviewSessionStatus  # 세션 생성 상태
     turn_number: int  # 현재 사용자 턴 번호 (세션 생성 직후 0, 사용자 메시지 처리 시 1부터 증가)
 
     # ===== 대화 기록 (LangGraph 메시지 리듀서 사용) =====
@@ -184,6 +188,7 @@ def get_initial_interview_state(
         "user_id": user_id,
         "session_id": session_id,
         "experience_name": experience_name,
+        "status": "completed",
         "turn_number": 0,
         # 대화 기록
         "messages": [],
@@ -238,6 +243,7 @@ def ensure_interview_state_defaults(state: InterviewState | dict) -> InterviewSt
 
     return {
         **state,
+        "status": state.get("status", "completed"),
         "turn_number": state.get("turn_number", get_turn_number_from_messages(messages)),
         "mentioned_insight": state.get("mentioned_insight"),
         "retrieved_insights": list(state.get("retrieved_insights") or []),

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -162,7 +162,9 @@ class InterviewService:
             session_id=session_id,
             experience_name=experience_name,
         )
-        initial_state["status"] = "generating"
+        # "generating" 상태를 체크포인터에 즉시 저장 (process_message_stream, extend_session_stream과 일관성)
+        # 세션 최초 생성이므로 fallback_state로 초기 상태 전달 → 체크포인터에 세션이 없으면 전체 초기 상태를 포함해 저장
+        await self._set_session_status(session_id, "generating", fallback_state=initial_state)
         config = self._get_thread_config(session_id)
         accumulated_text = ""
 

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 
 from langchain_core.messages import AIMessage, HumanMessage
 
@@ -16,6 +17,7 @@ from common.sse import (
 )
 from features.interview.agents.graph import build_graph
 from features.interview.agents.state import (
+    InterviewSessionStatus,
     InterviewState,
     ensure_interview_state_defaults,
     get_initial_interview_state,
@@ -65,6 +67,27 @@ class InterviewService:
             "extension_turns_used": state.get("extension_turns_used"),
             "extension_turns_max": state.get("extension_turns_max"),
         }
+
+    @staticmethod
+    def _get_thread_config(session_id: str) -> dict[str, dict[str, str]]:
+        """세션별 LangGraph thread config를 반환"""
+        return {"configurable": {"thread_id": session_id}}
+
+    async def _set_session_status(
+        self,
+        session_id: str,
+        status: InterviewSessionStatus,
+        fallback_state: dict | None = None,
+    ) -> None:
+        """세션 상태(status)를 저장한다."""
+        state_update: dict = {"status": status}
+
+        if fallback_state is not None:
+            current_state = await self.get_session_state(session_id)
+            if current_state is None:
+                state_update = {**fallback_state, "status": status}
+
+        await self._graph.aupdate_state(self._get_thread_config(session_id), state_update)
 
     async def create_session(
         self,
@@ -139,7 +162,8 @@ class InterviewService:
             session_id=session_id,
             experience_name=experience_name,
         )
-        config = {"configurable": {"thread_id": session_id}}
+        initial_state["status"] = "generating"
+        config = self._get_thread_config(session_id)
         accumulated_text = ""
 
         # 2. 스트리밍 진행
@@ -178,6 +202,12 @@ class InterviewService:
             # 4. 스트리밍 완료 후 최종 상태에서 첫 질문 추출
             final_state = await self.get_session_state(session_id)
             if final_state:
+                await self._set_session_status(
+                    session_id,
+                    "completed",
+                    fallback_state=initial_state,
+                )
+                final_state = {**final_state, "status": "completed"}
                 first_question = accumulated_text
                 messages = final_state.get("messages", [])
                 if not first_question and messages:
@@ -191,6 +221,7 @@ class InterviewService:
                             "message": {
                                 "session_id": session_id,
                                 "first_question": first_question,
+                                "status": final_state["status"],
                                 "current_stage": final_state["current_stage"],
                                 "stage_progress": final_state["stage_progress"],
                                 **self._build_extension_meta(final_state),
@@ -200,6 +231,12 @@ class InterviewService:
                     ),
                 }
             else:
+                with suppress(Exception):
+                    await self._set_session_status(
+                        session_id,
+                        "failed",
+                        fallback_state=initial_state,
+                    )
                 logger.error(f"세션 상태를 찾을 수 없습니다: {session_id}")
                 yield {
                     "event": SSEEventType.ERROR,
@@ -216,6 +253,12 @@ class InterviewService:
                 }
 
         except Exception as e:
+            with suppress(Exception):
+                await self._set_session_status(
+                    session_id,
+                    "failed",
+                    fallback_state=initial_state,
+                )
             logger.exception(f"SSE 스트리밍 중 예외 발생: {e}")
             yield {
                 "event": SSEEventType.ERROR,
@@ -331,10 +374,11 @@ class InterviewService:
             "extension_turns_max": global_config.extension_turns_per_session,
             "mentioned_insight": None,
         }
-        config = {"configurable": {"thread_id": session_id}}
+        config = self._get_thread_config(session_id)
         accumulated_text = ""
 
         try:
+            await self._set_session_status(session_id, "generating")
             async for event in self._graph.astream_events(input_state, config=config, version="v2"):
                 event_type = event.get("event")
                 metadata = event.get("metadata", {})
@@ -365,6 +409,8 @@ class InterviewService:
 
             final_state = await self.get_session_state(session_id)
             if final_state:
+                await self._set_session_status(session_id, "completed")
+                final_state = {**final_state, "status": "completed"}
                 ai_response = accumulated_text or self._get_latest_ai_response(
                     final_state.get("messages", [])
                 )
@@ -376,6 +422,7 @@ class InterviewService:
                             "type": SSEEventType.MESSAGE_COMPLETE,
                             "message": {
                                 "ai_response": ai_response,
+                                "status": final_state["status"],
                                 "current_stage": final_state["current_stage"],
                                 "stage_progress": final_state["stage_progress"],
                                 "overall_completion": final_state["overall_completion_percentage"],
@@ -387,6 +434,8 @@ class InterviewService:
                     ),
                 }
             else:
+                with suppress(Exception):
+                    await self._set_session_status(session_id, "failed")
                 logger.error(f"세션 상태를 찾을 수 없습니다: {session_id}")
                 yield {
                     "event": SSEEventType.ERROR,
@@ -403,6 +452,8 @@ class InterviewService:
                 }
 
         except Exception as e:
+            with suppress(Exception):
+                await self._set_session_status(session_id, "failed")
             logger.exception(f"SSE 스트리밍 중 예외 발생: {e}")
             yield {
                 "event": SSEEventType.ERROR,
@@ -461,7 +512,7 @@ class InterviewService:
         # 그래프 비동기 실행 (Checkpointer가 이전 상태 자동 로드)
         result = await self._graph.ainvoke(
             input_state,
-            config={"configurable": {"thread_id": session_id}},
+            config=self._get_thread_config(session_id),
         )
 
         ai_response = None
@@ -488,14 +539,25 @@ class InterviewService:
             InterviewState | None: 세션 상태 (없으면 None)
         """
 
-        state_snapshot = await self._graph.aget_state(
-            config={"configurable": {"thread_id": session_id}}
-        )
+        state_snapshot = await self._graph.aget_state(config=self._get_thread_config(session_id))
 
         if state_snapshot is None or not state_snapshot.values:
             return None
 
         return ensure_interview_state_defaults(state_snapshot.values)
+
+    async def get_session_status(self, session_id: str) -> dict | None:
+        """현재 세션의 경량 status 정보를 조회한다."""
+        state = await self.get_session_state(session_id)
+        if state is None:
+            return None
+
+        return {
+            "session_id": state["session_id"],
+            "status": state["status"],
+            "current_stage": state["current_stage"],
+            "all_complete": state["all_stages_complete"],
+        }
 
     @staticmethod
     def _build_retriever_result_payload(output: dict | None) -> dict:
@@ -572,11 +634,12 @@ class InterviewService:
             "mentioned_insight": mentioned_insight,
         }
 
-        config = {"configurable": {"thread_id": session_id}}
+        config = self._get_thread_config(session_id)
         accumulated_text = ""
 
         # 3. LangGraph astream_events로 스트리밍
         try:
+            await self._set_session_status(session_id, "generating")
             async for event in self._graph.astream_events(input_state, config=config, version="v2"):
                 event_type = event.get("event")
                 metadata = event.get("metadata", {})
@@ -630,6 +693,8 @@ class InterviewService:
             # 4. 스트리밍 완료 후 최종 상태 조회 -> message_complete 전송
             final_state = await self.get_session_state(session_id)
             if final_state:
+                await self._set_session_status(session_id, "completed")
+                final_state = {**final_state, "status": "completed"}
                 ai_response: str | None = None
                 if not final_state["all_stages_complete"]:
                     ai_response = accumulated_text or self._get_latest_ai_response(
@@ -643,6 +708,7 @@ class InterviewService:
                             "type": SSEEventType.MESSAGE_COMPLETE,
                             "message": {
                                 "ai_response": ai_response,
+                                "status": final_state["status"],
                                 "current_stage": final_state["current_stage"],
                                 "stage_progress": final_state["stage_progress"],
                                 "overall_completion": final_state["overall_completion_percentage"],
@@ -654,6 +720,8 @@ class InterviewService:
                     ),
                 }
             else:
+                with suppress(Exception):
+                    await self._set_session_status(session_id, "failed")
                 logger.error(f"세션 상태를 찾을 수 없습니다: {session_id}")
                 yield {
                     "event": SSEEventType.ERROR,
@@ -670,6 +738,8 @@ class InterviewService:
                 }
 
         except Exception as e:
+            with suppress(Exception):
+                await self._set_session_status(session_id, "failed")
             logger.exception(f"SSE 스트리밍 중 예외 발생: {e}")
             yield {
                 "event": SSEEventType.ERROR,

--- a/tests/test_app/test_api/test_v1/test_interview.py
+++ b/tests/test_app/test_api/test_v1/test_interview.py
@@ -7,6 +7,9 @@ from app.api.v1 import interview as interview_api
 
 
 class DummyInterviewService:
+    def __init__(self, missing_session_ids: set[str] | None = None):
+        self.missing_session_ids = missing_session_ids or set()
+
     async def create_session_stream(self, user_id: str, session_id: str, experience_name: str):
         assert user_id
         assert session_id
@@ -14,10 +17,14 @@ class DummyInterviewService:
         yield {"event": "message_complete", "data": "{}"}
 
     async def get_session_state(self, session_id: str):
+        if session_id in self.missing_session_ids:
+            return None
+
         return {
             "session_id": session_id,
             "user_id": "user-1",
             "experience_name": "프로젝트",
+            "status": "completed",
             "turn_number": 2,
             "current_stage": 1,
             "stage_progress": {
@@ -55,9 +62,22 @@ class DummyInterviewService:
             "retrieved_insights": [],
         }
 
+    async def get_session_status(self, session_id: str):
+        if session_id in self.missing_session_ids:
+            return None
 
-def _create_client(monkeypatch) -> TestClient:
-    monkeypatch.setattr(interview_api, "get_interview_service", lambda: DummyInterviewService())
+        return {
+            "session_id": session_id,
+            "status": "completed",
+            "current_stage": 1,
+            "all_complete": False,
+        }
+
+
+def _create_client(monkeypatch, service: DummyInterviewService | None = None) -> TestClient:
+    monkeypatch.setattr(
+        interview_api, "get_interview_service", lambda: service or DummyInterviewService()
+    )
     monkeypatch.setattr(interview_api, "uuid4", lambda: "test-session-id")
     app = FastAPI()
     app.include_router(interview_api.router, prefix="/api/v1")
@@ -102,7 +122,34 @@ def test_get_session_state_includes_turn_history(monkeypatch):
 
     assert response.status_code == 200
     body = response.json()
+    assert body["status"] == "completed"
     assert body["turn_number"] == 2
     assert body["insight_turn_history"][0]["turn_number"] == 1
     assert body["insight_turn_history"][0]["user_message"] == "첫 답변"
     assert body["insight_turn_history"][0]["insights"][0]["activity_name"] == "해커톤"
+
+
+def test_get_session_status_returns_compact_payload(monkeypatch):
+    """세션 경량 상태 조회 응답에 status 핵심 필드를 포함한다."""
+    client = _create_client(monkeypatch)
+
+    response = client.get("/api/v1/interview/sessions/session-1/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "session_id": "session-1",
+        "status": "completed",
+        "current_stage": 1,
+        "all_complete": False,
+    }
+
+
+def test_get_session_status_returns_404_when_missing(monkeypatch):
+    """존재하지 않는 세션의 경량 상태 조회는 404를 반환한다."""
+    client = _create_client(monkeypatch, DummyInterviewService({"missing-session"}))
+
+    response = client.get("/api/v1/interview/sessions/missing-session/status")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "세션을 찾을 수 없습니다: missing-session"

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -40,6 +40,7 @@ class DummyGraph:
         self.invoke_result = None
         self.state_snapshot = None
         self.last_get_state_config = None
+        self.update_state_calls = []
 
     async def ainvoke(self, state, config=None):
         self.invocations.append({"state": state, "config": config})
@@ -48,6 +49,13 @@ class DummyGraph:
     async def aget_state(self, config=None):
         self.last_get_state_config = config
         return self.state_snapshot
+
+    async def aupdate_state(self, config, state):
+        self.update_state_calls.append({"config": config, "state": state})
+        if self.state_snapshot is None:
+            self.state_snapshot = DummyStateSnapshot(values=dict(state))
+        else:
+            self.state_snapshot.values = {**self.state_snapshot.values, **state}
 
 
 def _build_service(monkeypatch, dummy_graph):
@@ -99,6 +107,7 @@ async def test_create_session_returns_expected_payload(monkeypatch):
     assert invocation["state"]["user_id"] == "user_1"
     assert invocation["state"]["session_id"] == "session_1"
     assert invocation["state"]["experience_name"] == "프로젝트 A"
+    assert invocation["state"]["status"] == "completed"
 
 
 @pytest.mark.asyncio
@@ -332,9 +341,33 @@ async def test_get_session_state_returns_values(monkeypatch):
     assert result is not None
     assert result["session_id"] == "session_1"
     assert result["turn_number"] == 1
+    assert result["status"] == "completed"
     assert result["retrieved_insights"] == []
     assert result["mentioned_insight"] is None
     assert result["insight_turn_history"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_session_status_returns_compact_payload(monkeypatch):
+    """세션 경량 상태 조회 시 status와 핵심 필드만 반환한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "current_stage": 2,
+            "all_stages_complete": False,
+        }
+    )
+    service = _build_service(monkeypatch, dummy_graph)
+
+    result = await service.get_session_status("session_1")
+
+    assert result == {
+        "session_id": "session_1",
+        "status": "completed",
+        "current_stage": 2,
+        "all_complete": False,
+    }
 
 
 def test_singleton_get_and_reset(monkeypatch):

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -29,18 +29,29 @@ class DummyGraph:
 
     def __init__(self):
         self.stream_events = []
+        self.stream_error = None
         self.state_snapshot = None
         self.astream_calls = []
         self.aget_state_calls = []
+        self.update_state_calls = []
 
     async def astream_events(self, state, config=None, version=None):
         self.astream_calls.append({"state": state, "config": config, "version": version})
+        if self.stream_error is not None:
+            raise self.stream_error
         for event in self.stream_events:
             yield event
 
     async def aget_state(self, config=None):
         self.aget_state_calls.append(config)
         return self.state_snapshot
+
+    async def aupdate_state(self, config, state):
+        self.update_state_calls.append({"config": config, "state": state})
+        if self.state_snapshot is None:
+            self.state_snapshot = DummyStateSnapshot(values=dict(state))
+        else:
+            self.state_snapshot.values = {**self.state_snapshot.values, **state}
 
 
 @pytest.mark.anyio
@@ -92,8 +103,11 @@ async def test_create_session_stream_yields_delta_and_complete(monkeypatch):
     complete_payload = json.loads(events[1]["data"])
     assert complete_payload["message"]["session_id"] == "session-1"
     assert complete_payload["message"]["first_question"] == "첫 질문"
+    assert complete_payload["message"]["status"] == "completed"
     assert complete_payload["message"]["current_stage"] == 1
     assert complete_payload["message"]["is_extended_mode"] is False
+    assert dummy_graph.astream_calls[0]["state"]["status"] == "generating"
+    assert dummy_graph.update_state_calls[-1]["state"]["status"] == "completed"
 
 
 def test_create_session_stream_route_exists():
@@ -197,6 +211,13 @@ async def test_process_message_stream_emits_retriever_events(monkeypatch):
     assert retriever_payload["insights"][1]["source"] == "mention"
 
     assert events[2]["event"] == SSEEventType.CONTENT_BLOCK_DELTA
+    complete_event = next(
+        event for event in events if event["event"] == SSEEventType.MESSAGE_COMPLETE
+    )
+    complete_payload = json.loads(complete_event["data"])
+    assert complete_payload["message"]["status"] == "completed"
+    assert dummy_graph.update_state_calls[0]["state"]["status"] == "generating"
+    assert dummy_graph.update_state_calls[-1]["state"]["status"] == "completed"
 
 
 @pytest.mark.anyio
@@ -280,6 +301,7 @@ async def test_process_message_stream_returns_none_when_all_complete(monkeypatch
     )
     complete_payload = json.loads(complete_event["data"])
     assert complete_payload["message"]["ai_response"] is None
+    assert complete_payload["message"]["status"] == "completed"
     assert complete_payload["message"]["is_extended_mode"] is False
 
 
@@ -357,6 +379,50 @@ async def test_extend_session_stream_yields_delta_and_complete(monkeypatch):
     )
     complete_payload = json.loads(complete_event["data"])
     assert complete_payload["message"]["ai_response"] == "연장 질문"
+    assert complete_payload["message"]["status"] == "completed"
     assert complete_payload["message"]["is_extended_mode"] is True
-    assert complete_payload["message"]["extension_turns_used"] == 1
-    assert complete_payload["message"]["extension_turns_max"] == 3
+    assert dummy_graph.update_state_calls[0]["state"]["status"] == "generating"
+    assert dummy_graph.update_state_calls[-1]["state"]["status"] == "completed"
+
+
+@pytest.mark.anyio
+async def test_process_message_stream_sets_failed_status_on_exception(monkeypatch):
+    """스트리밍 예외 발생 시 세션 status를 failed로 기록한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session-1",
+            "current_stage": 1,
+            "stage_progress": {
+                "fixed_q_used": 0,
+                "fixed_q_total": 1,
+                "generated_q_used": 0,
+                "generated_q_max": 0,
+                "force_all_generated_q": False,
+                "is_complete": False,
+            },
+            "overall_completion_percentage": 25.0,
+            "all_stages_complete": False,
+        }
+    )
+    dummy_graph.stream_error = RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "features.interview.service.build_graph", lambda checkpointer=None: dummy_graph
+    )
+    monkeypatch.setattr("features.interview.service.get_checkpointer", lambda: object())
+    service = InterviewService()
+
+    events = [
+        event
+        async for event in service.process_message_stream(
+            session_id="session-1",
+            message="사용자 답변",
+        )
+    ]
+
+    assert events[0]["event"] == SSEEventType.ERROR
+    error_payload = json.loads(events[0]["data"])
+    assert error_payload["error"]["code"] == "llm_error"
+    assert dummy_graph.update_state_calls[0]["state"]["status"] == "generating"
+    assert dummy_graph.update_state_calls[-1]["state"]["status"] == "failed"


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #170

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 인터뷰 세션 state에 `status`(`generating | completed | failed`)를 추가하고, 초기 state 및 구버전 세션 기본값을 `completed`로 보강했습니다.
- `create_session_stream()`, `process_message_stream()`, `extend_session_stream()`에서만 `generating -> completed | failed` 상태 전이를 기록하도록 공통 helper를 추가했습니다.
- `GET /interview/sessions/{session_id}/state` 응답에 `status`를 포함하고, 경량 polling 용도인 `GET /interview/sessions/{session_id}/status` API를 새로 추가했습니다.
- SSE `message_complete` payload에도 `status`를 포함해 최종 상태 응답의 일관성을 맞췄습니다.
- 서비스/SSE/API 테스트를 보강해 기본값 보강, 상태 전이, `/state`, `/status` 응답을 검증했습니다.

## 📸 스크린샷

- 텍스트 기반 백엔드 작업이라 별도 UI 스크린샷은 없습니다.
- 검증 명령:
  - `uv run pytest tests/test_features/test_interview/test_service.py tests/test_features/test_interview/test_service_session_stream.py tests/test_app/test_api/test_v1/test_interview.py`
  - `uv run ruff check features/interview/agents/state.py features/interview/service.py app/schemas/interview.py app/api/v1/interview.py tests/test_features/test_interview/test_service.py tests/test_features/test_interview/test_service_session_stream.py tests/test_app/test_api/test_v1/test_interview.py`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 이번 스코프는 SSE 이어받기 자체가 아니라, 세션 `status` 조회를 통한 생성 중/완료 상태 복원 지원에 집중했습니다.
- non-streaming 경로(`create_session`, `process_message`, `extend_session`)는 이슈 범위에 맞춰 상태 전이 대상에서 제외했습니다.

## 개선 제안 및 추가 필요 작업

- 추후 프론트 연동 시 `/state` 1회 조회 후 `status == generating`일 때만 `/status` polling 하는 흐름을 E2E 수준에서 한 번 더 검증하면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 세션 상태를 조회하는 신규 API 엔드포인트가 추가되었습니다.
  * 세션 응답에 실시간 상태(status)가 포함되도록 확장되었습니다.
  * 세션 생성/처리 흐름에서 상태("generating","completed","failed") 추적이 전반에 걸쳐 강화되었습니다.

* **테스트**
  * 상태 추적과 에러 시 상태 전환을 검증하는 테스트가 추가/확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->