### PR TITLE
[Feat] PDF 포트폴리오 구조화 기반 스키마 및 callback 레이어 추가

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -19,6 +19,7 @@ from .interview import (
     SessionStateResponse,
     StageProgressSchema,
 )
+from .pdf_extraction import PdfExtractionAcceptedResponse
 from .portfolio import (
     GeneratePortfolioRequest,
     GeneratePortfolioResponse,
@@ -48,4 +49,5 @@ __all__ = [
     "PortfolioResultResponse",
     "PortfolioStatusResponse",
     "UpdateContributionRateRequest",
+    "PdfExtractionAcceptedResponse",
 ]

--- a/app/schemas/pdf_extraction.py
+++ b/app/schemas/pdf_extraction.py
@@ -1,0 +1,11 @@
+"""PDF 포트폴리오 구조화 API 스키마 정의"""
+
+from pydantic import BaseModel, Field
+
+
+class PdfExtractionAcceptedResponse(BaseModel):
+    """PDF 추출 요청 접수 응답"""
+
+    correction_id: str = Field(..., description="첨삭 ID")
+    status: str = Field(..., description="현재 처리 상태")
+    message: str = Field(..., description="처리 시작 안내 메시지")

--- a/common/clients/correction_client.py
+++ b/common/clients/correction_client.py
@@ -1,6 +1,7 @@
 """첨삭 서비스용 메인 서버 API 클라이언트"""
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 from .base_client import BaseClient
@@ -169,7 +170,7 @@ class CorrectionClient(BaseClient):
     async def complete_pdf_extraction(
         self,
         correction_id: int,
-        activities: list[dict[str, Any]],
+        activities: Sequence[Any],
         source_type: str = "EXTERNAL",
     ) -> dict:
         """

--- a/common/clients/correction_client.py
+++ b/common/clients/correction_client.py
@@ -1,12 +1,44 @@
 """첨삭 서비스용 메인 서버 API 클라이언트"""
 
 import logging
+from typing import Any
 
 from .base_client import BaseClient
 
 logger = logging.getLogger(__name__)
 
 _client: "CorrectionClient | None" = None
+
+
+def _as_payload_dict(value: Any) -> dict[str, Any]:
+    """Pydantic 모델 또는 dict를 payload용 dict로 변환"""
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    return value
+
+
+def _build_problem_solving_payload(item: Any) -> dict[str, Any]:
+    """문제 해결 항목을 callback payload 형식으로 변환"""
+    data = _as_payload_dict(item)
+    return {
+        "no": data["no"],
+        "situation": data["situation"],
+        "strategy": data["strategy"],
+        "reason": data["reason"],
+    }
+
+
+def _build_pdf_activity_payload(activity: Any) -> dict[str, Any]:
+    """PDF 활동 스키마를 callback payload 형식으로 변환"""
+    data = _as_payload_dict(activity)
+    problem_solving = data.get("problem_solving", data.get("problemSolving", []))
+    return {
+        "activityName": data.get("activity_name", data.get("activityName")),
+        "detail": data["detail"],
+        "responsibility": data["responsibility"],
+        "problemSolving": [_build_problem_solving_payload(item) for item in problem_solving],
+        "learning": data["learning"],
+    }
 
 
 class CorrectionClient(BaseClient):
@@ -18,6 +50,7 @@ class CorrectionClient(BaseClient):
     """
 
     _PREFIX = "/corrections"
+    _PDF_EXTRACTION_CALLBACK_PREFIX = "/internal/corrections"
 
     async def get_correction(self, correction_id: int) -> dict:
         """
@@ -131,6 +164,41 @@ class CorrectionClient(BaseClient):
         return await self.patch(
             f"{self._PREFIX}/{correction_id}/emphasis-points",
             json={"highlightPoint": emphasis_points},
+        )
+
+    async def complete_pdf_extraction(
+        self,
+        correction_id: int,
+        activities: list[dict[str, Any]],
+        source_type: str = "EXTERNAL",
+    ) -> dict:
+        """
+        PDF 추출 성공 callback 전송
+
+        Args:
+            correction_id: 첨삭 ID
+            activities: PDF에서 추출한 활동 목록
+            source_type: 추출 소스 타입
+        """
+        return await self.post(
+            f"{self._PDF_EXTRACTION_CALLBACK_PREFIX}/{correction_id}/pdf-extraction-result",
+            json={
+                "activities": [_build_pdf_activity_payload(activity) for activity in activities],
+                "sourceType": source_type,
+            },
+        )
+
+    async def fail_pdf_extraction(self, correction_id: int, error_message: str) -> dict:
+        """
+        PDF 추출 실패 callback 전송
+
+        Args:
+            correction_id: 첨삭 ID
+            error_message: 실패 메시지
+        """
+        return await self.post(
+            f"{self._PDF_EXTRACTION_CALLBACK_PREFIX}/{correction_id}/pdf-extraction-result",
+            json={"errorMessage": error_message},
         )
 
     async def delete_correction(self, correction_id: int) -> None:

--- a/features/portfolio/pdf_extraction/__init__.py
+++ b/features/portfolio/pdf_extraction/__init__.py
@@ -1,0 +1,9 @@
+"""PDF 포트폴리오 구조화 스키마 패키지"""
+
+from .schemas import PdfActivity, PdfExtractionResult, PdfProblemSolvingItem
+
+__all__ = [
+    "PdfActivity",
+    "PdfExtractionResult",
+    "PdfProblemSolvingItem",
+]

--- a/features/portfolio/pdf_extraction/schemas.py
+++ b/features/portfolio/pdf_extraction/schemas.py
@@ -25,4 +25,8 @@ class PdfActivity(BaseModel):
 class PdfExtractionResult(BaseModel):
     """LLM Structured Output용 PDF 추출 결과"""
 
-    activities: list[PdfActivity] = Field(..., description="PDF에서 추출한 활동 목록")
+    activities: list[PdfActivity] = Field(
+        ...,
+        min_length=1,
+        description="PDF에서 추출한 활동 목록",
+    )

--- a/features/portfolio/pdf_extraction/schemas.py
+++ b/features/portfolio/pdf_extraction/schemas.py
@@ -1,0 +1,28 @@
+"""PDF 포트폴리오 구조화 도메인 스키마 정의"""
+
+from pydantic import BaseModel, Field
+
+
+class PdfProblemSolvingItem(BaseModel):
+    """문제 해결 항목 스키마"""
+
+    no: int = Field(..., ge=1, description="문제 해결 항목 번호")
+    situation: str = Field(..., description="문제 상황")
+    strategy: str = Field(..., description="대응 전략")
+    reason: str = Field(..., description="전략 선택 이유")
+
+
+class PdfActivity(BaseModel):
+    """PDF에서 추출한 활동 스키마"""
+
+    activity_name: str = Field(..., description="활동명 또는 프로젝트명")
+    detail: str = Field(..., description="활동 상세 설명")
+    responsibility: str = Field(..., description="담당 업무")
+    problem_solving: list[PdfProblemSolvingItem] = Field(..., description="문제 해결 내용 목록")
+    learning: str = Field(..., description="배운 점")
+
+
+class PdfExtractionResult(BaseModel):
+    """LLM Structured Output용 PDF 추출 결과"""
+
+    activities: list[PdfActivity] = Field(..., description="PDF에서 추출한 활동 목록")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "psycopg[binary]>=3.2.10",
     "psycopg-pool>=3.2.6",
     "pydantic-settings>=2.12.0",
+    "python-multipart>=0.0.20",
     "python-dotenv>=1.2.1",
     "pyyaml>=6.0.3",
     "sse-starlette>=2.1.3",

--- a/tests/test_common/test_clients/test_correction_client.py
+++ b/tests/test_common/test_clients/test_correction_client.py
@@ -1,11 +1,20 @@
 """첨삭 클라이언트 callback payload 테스트"""
 
+from collections.abc import Sequence
+from typing import Any, get_type_hints
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from common.clients.correction_client import CorrectionClient
 from features.portfolio.pdf_extraction.schemas import PdfActivity
+
+
+def test_complete_pdf_extraction_type_hint_accepts_model_sequences():
+    """complete_pdf_extraction activities는 모델 리스트도 허용하는 시퀀스 타입 힌트여야 한다."""
+    activities_hint = get_type_hints(CorrectionClient.complete_pdf_extraction)["activities"]
+
+    assert activities_hint == Sequence[Any]
 
 
 @pytest.mark.asyncio

--- a/tests/test_common/test_clients/test_correction_client.py
+++ b/tests/test_common/test_clients/test_correction_client.py
@@ -1,0 +1,137 @@
+"""첨삭 클라이언트 callback payload 테스트"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from common.clients.correction_client import CorrectionClient
+from features.portfolio.pdf_extraction.schemas import PdfActivity
+
+
+@pytest.mark.asyncio
+async def test_complete_pdf_extraction_sends_camelcase_payload():
+    """PDF 추출 성공 callback은 camelCase payload로 전송한다."""
+    client = CorrectionClient(base_url="https://example.com", api_key="test-key")
+
+    try:
+        with patch.object(client, "post", new_callable=AsyncMock, return_value={}) as mock_post:
+            await client.complete_pdf_extraction(
+                correction_id=174,
+                activities=[
+                    PdfActivity.model_validate(
+                        {
+                            "activity_name": "프로젝트명",
+                            "detail": "상세 설명",
+                            "responsibility": "담당 업무",
+                            "problem_solving": [
+                                {
+                                    "no": 1,
+                                    "situation": "문제 상황",
+                                    "strategy": "대응 전략",
+                                    "reason": "선택 이유",
+                                },
+                            ],
+                            "learning": "배운 점",
+                        }
+                    )
+                ],
+            )
+
+            mock_post.assert_awaited_once_with(
+                "/internal/corrections/174/pdf-extraction-result",
+                json={
+                    "activities": [
+                        {
+                            "activityName": "프로젝트명",
+                            "detail": "상세 설명",
+                            "responsibility": "담당 업무",
+                            "problemSolving": [
+                                {
+                                    "no": 1,
+                                    "situation": "문제 상황",
+                                    "strategy": "대응 전략",
+                                    "reason": "선택 이유",
+                                }
+                            ],
+                            "learning": "배운 점",
+                        }
+                    ],
+                    "sourceType": "EXTERNAL",
+                },
+            )
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_complete_pdf_extraction_allows_source_type_override():
+    """source_type 인자를 전달하면 sourceType 값에 반영한다."""
+    client = CorrectionClient(base_url="https://example.com", api_key="test-key")
+
+    try:
+        with patch.object(client, "post", new_callable=AsyncMock, return_value={}) as mock_post:
+            await client.complete_pdf_extraction(
+                correction_id=175,
+                activities=[
+                    {
+                        "activity_name": "다른 프로젝트",
+                        "detail": "상세 설명",
+                        "responsibility": "담당 업무",
+                        "problem_solving": [
+                            {
+                                "no": 1,
+                                "situation": "문제 상황",
+                                "strategy": "대응 전략",
+                                "reason": "선택 이유",
+                            }
+                        ],
+                        "learning": "배운 점",
+                    },
+                ],
+                source_type="INTERNAL",
+            )
+
+            mock_post.assert_awaited_once_with(
+                "/internal/corrections/175/pdf-extraction-result",
+                json={
+                    "activities": [
+                        {
+                            "activityName": "다른 프로젝트",
+                            "detail": "상세 설명",
+                            "responsibility": "담당 업무",
+                            "problemSolving": [
+                                {
+                                    "no": 1,
+                                    "situation": "문제 상황",
+                                    "strategy": "대응 전략",
+                                    "reason": "선택 이유",
+                                }
+                            ],
+                            "learning": "배운 점",
+                        }
+                    ],
+                    "sourceType": "INTERNAL",
+                },
+            )
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_fail_pdf_extraction_sends_error_message_payload():
+    """PDF 추출 실패 callback은 errorMessage payload로 전송한다."""
+    client = CorrectionClient(base_url="https://example.com", api_key="test-key")
+
+    try:
+        with patch.object(client, "post", new_callable=AsyncMock, return_value={}) as mock_post:
+            await client.fail_pdf_extraction(
+                correction_id=174,
+                error_message="PDF 추출 중 오류가 발생했습니다.",
+            )
+
+            mock_post.assert_awaited_once_with(
+                "/internal/corrections/174/pdf-extraction-result",
+                json={"errorMessage": "PDF 추출 중 오류가 발생했습니다."},
+            )
+    finally:
+        await client.close()

--- a/tests/test_features/test_portfolio/test_pdf_extraction_schemas.py
+++ b/tests/test_features/test_portfolio/test_pdf_extraction_schemas.py
@@ -1,0 +1,44 @@
+"""PDF 포트폴리오 구조화 스키마 테스트"""
+
+from app.schemas.pdf_extraction import PdfExtractionAcceptedResponse
+from features.portfolio.pdf_extraction.schemas import PdfExtractionResult
+
+
+def test_pdf_extraction_result_schema():
+    """PDF 추출 결과 스키마 생성 테스트"""
+    result = PdfExtractionResult.model_validate(
+        {
+            "activities": [
+                {
+                    "activity_name": "포트폴리오 개선 프로젝트",
+                    "detail": "PDF 기반 경력기술서 구조화 기능 구현",
+                    "responsibility": "백엔드 설계 및 API 연동",
+                    "problem_solving": [
+                        {
+                            "no": 1,
+                            "situation": "입력 PDF마다 구조가 달랐습니다.",
+                            "strategy": "공통 활동 스키마를 먼저 정의했습니다.",
+                            "reason": "후속 로직에서 동일한 계약을 재사용하기 위해서입니다.",
+                        }
+                    ],
+                    "learning": "추출 결과 계약을 먼저 고정하면 후속 구현이 쉬워집니다.",
+                }
+            ]
+        }
+    )
+
+    assert result.activities[0].activity_name == "포트폴리오 개선 프로젝트"
+    assert result.activities[0].problem_solving[0].no == 1
+
+
+def test_pdf_extraction_accepted_response_schema():
+    """PDF 추출 요청 접수 응답 스키마 생성 테스트"""
+    response = PdfExtractionAcceptedResponse(
+        correction_id="174",
+        status="accepted",
+        message="PDF 추출 작업이 시작되었습니다.",
+    )
+
+    assert response.correction_id == "174"
+    assert response.status == "accepted"
+    assert response.message == "PDF 추출 작업이 시작되었습니다."

--- a/tests/test_features/test_portfolio/test_pdf_extraction_schemas.py
+++ b/tests/test_features/test_portfolio/test_pdf_extraction_schemas.py
@@ -1,5 +1,8 @@
 """PDF 포트폴리오 구조화 스키마 테스트"""
 
+import pytest
+from pydantic import ValidationError
+
 from app.schemas.pdf_extraction import PdfExtractionAcceptedResponse
 from features.portfolio.pdf_extraction.schemas import PdfExtractionResult
 
@@ -29,6 +32,12 @@ def test_pdf_extraction_result_schema():
 
     assert result.activities[0].activity_name == "포트폴리오 개선 프로젝트"
     assert result.activities[0].problem_solving[0].no == 1
+
+
+def test_pdf_extraction_result_rejects_empty_activities():
+    """PDF 추출 성공 결과는 최소 1개의 활동을 포함해야 한다."""
+    with pytest.raises(ValidationError):
+        PdfExtractionResult.model_validate({"activities": []})
 
 
 def test_pdf_extraction_accepted_response_schema():

--- a/uv.lock
+++ b/uv.lock
@@ -360,6 +360,7 @@ dependencies = [
     { name = "psycopg-pool" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sse-starlette" },
     { name = "tavily-python" },
@@ -389,6 +390,7 @@ requires-dist = [
     { name = "psycopg-pool", specifier = ">=3.2.6" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "sse-starlette", specifier = ">=2.1.3" },
     { name = "tavily-python", specifier = ">=0.7.22" },
@@ -1447,6 +1449,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #174

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PDF 포트폴리오 구조화용 도메인 스키마와 API 응답 스키마를 추가했습니다.
- `CorrectionClient`에 PDF 추출 성공/실패 callback 메서드를 추가하고, 메인 백엔드 요청 body를 camelCase로 맞췄습니다.
- `python-multipart` 의존성을 추가하고 관련 스키마 및 callback payload 테스트를 보강했습니다.

## 📸 스크린샷

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/test_common/test_clients/test_correction_client.py tests/test_features/test_portfolio/test_pdf_extraction_schemas.py -v`
- 참고: 전체 `uv run pytest` 실행 시 기존 인터뷰 스트림 테스트 1건이 실패했습니다.

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 전체 테스트 실패 1건은 이번 변경과 무관한 기존 테스트였습니다. 실패 내용은 `create_session_stream`의 초기 상태값 기대치가 `generating`이 아니라 `completed`로 관찰된 건입니다.

## 개선 제안 및 추가 필요 작업

- 후속 이슈에서 PDF 추출 서비스/엔드포인트 구현 시 이번 스키마와 callback 계약을 그대로 재사용하면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * PDF 포트폴리오 구조화 추출 결과 모델 및 수신 응답 스키마 추가
  * PDF 추출 완료·실패 결과를 제출하는 콜백 전송 기능 추가
  * 멀티파트 폼 데이터 처리를 위한 의존성 추가

* **Tests**
  * PDF 추출 콜백 요청/페이로드 검증 테스트 추가
  * PDF 추출 스키마 유효성 검사 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->