### PR TITLE
[Test] 인터뷰 파일 업로드 — 테스트 보강

### DIFF
--- a/tests/test_app/test_api/test_v1/test_interview_file_upload.py
+++ b/tests/test_app/test_api/test_v1/test_interview_file_upload.py
@@ -42,25 +42,34 @@ def _create_client(monkeypatch, service: DummyInterviewService) -> TestClient:
     return TestClient(app)
 
 
+def _patch_streaming_response(monkeypatch):
+    async def _passthrough_events(stream):
+        async for event in stream:
+            yield event["data"]
+
+    monkeypatch.setattr(interview_api, "_interleave_ping_events", _passthrough_events)
+    monkeypatch.setattr(interview_api, "EventSourceResponse", StreamingResponse)
+
+
 def test_chat_stream_accepts_multipart_with_files(monkeypatch, tmp_path):
     """chat_stream 엔드포인트는 multipart 파일 업로드를 서비스에 전달한다."""
     service = DummyInterviewService()
     client = _create_client(monkeypatch, service)
     temp_paths = iter([tmp_path / "interview-upload-1.pdf", tmp_path / "interview-upload-2.jpg"])
     monkeypatch.setattr(interview_api, "_create_temp_upload_file", lambda _suffix: next(temp_paths))
+    _patch_streaming_response(monkeypatch)
 
-    with client.stream(
-        "POST",
+    response = client.post(
         "/api/v1/interview/sessions/session-1/chat/stream",
         data={"message": "안녕하세요"},
         files=[
             ("files", ("portfolio.pdf", b"%PDF-1.4", "application/pdf")),
             ("files", ("image.jpg", b"jpeg-bytes", "image/jpeg")),
         ],
-    ) as response:
-        assert response.status_code == 200
-        body = "".join(response.iter_text())
+    )
 
+    assert response.status_code == 200
+    body = response.text
     assert "message_complete" in body
     assert service.stream_calls[0]["files"] == [
         {
@@ -135,13 +144,7 @@ def test_chat_stream_works_without_files(monkeypatch):
     """chat_stream 엔드포인트는 파일 없이도 정상 동작한다."""
     service = DummyInterviewService()
     client = _create_client(monkeypatch, service)
-
-    async def _passthrough_events(stream):
-        async for event in stream:
-            yield event["data"]
-
-    monkeypatch.setattr(interview_api, "_interleave_ping_events", _passthrough_events)
-    monkeypatch.setattr(interview_api, "EventSourceResponse", StreamingResponse)
+    _patch_streaming_response(monkeypatch)
 
     response = client.post(
         "/api/v1/interview/sessions/session-1/chat/stream",

--- a/tests/test_app/test_api/test_v1/test_interview_file_upload.py
+++ b/tests/test_app/test_api/test_v1/test_interview_file_upload.py
@@ -1,0 +1,155 @@
+"""인터뷰 파일 업로드 API 테스트"""
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
+
+from app.api.v1 import interview as interview_api
+
+
+class DummyInterviewService:
+    def __init__(self):
+        self.stream_calls: list[dict] = []
+
+    async def process_message_stream(
+        self,
+        session_id: str,
+        message: str,
+        files: list[dict] | None = None,
+        mentioned_insight: str | None = None,
+    ):
+        self.stream_calls.append(
+            {
+                "session_id": session_id,
+                "message": message,
+                "files": files,
+                "mentioned_insight": mentioned_insight,
+            }
+        )
+
+        yield {
+            "event": "message_complete",
+            "data": json.dumps({"type": "message_complete", "message": {}}),
+        }
+
+
+def _create_client(monkeypatch, service: DummyInterviewService) -> TestClient:
+    monkeypatch.setattr(interview_api, "get_interview_service", lambda: service)
+    app = FastAPI()
+    app.include_router(interview_api.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def test_chat_stream_accepts_multipart_with_files(monkeypatch, tmp_path):
+    """chat_stream 엔드포인트는 multipart 파일 업로드를 서비스에 전달한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+    temp_paths = iter([tmp_path / "interview-upload-1.pdf", tmp_path / "interview-upload-2.jpg"])
+    monkeypatch.setattr(interview_api, "_create_temp_upload_file", lambda _suffix: next(temp_paths))
+
+    with client.stream(
+        "POST",
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        data={"message": "안녕하세요"},
+        files=[
+            ("files", ("portfolio.pdf", b"%PDF-1.4", "application/pdf")),
+            ("files", ("image.jpg", b"jpeg-bytes", "image/jpeg")),
+        ],
+    ) as response:
+        assert response.status_code == 200
+        body = "".join(response.iter_text())
+
+    assert "message_complete" in body
+    assert service.stream_calls[0]["files"] == [
+        {
+            "filename": "portfolio.pdf",
+            "content_type": "application/pdf",
+            "temp_path": str(tmp_path / "interview-upload-1.pdf"),
+        },
+        {
+            "filename": "image.jpg",
+            "content_type": "image/jpeg",
+            "temp_path": str(tmp_path / "interview-upload-2.jpg"),
+        },
+    ]
+    assert (tmp_path / "interview-upload-1.pdf").exists() is False
+    assert (tmp_path / "interview-upload-2.jpg").exists() is False
+
+
+def test_chat_stream_rejects_more_than_3_files(monkeypatch):
+    """chat_stream 엔드포인트는 4개 이상 파일 업로드를 거부한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        data={"message": "안녕하세요"},
+        files=[
+            ("files", ("one.pdf", b"a", "application/pdf")),
+            ("files", ("two.pdf", b"a", "application/pdf")),
+            ("files", ("three.pdf", b"a", "application/pdf")),
+            ("files", ("four.pdf", b"a", "application/pdf")),
+        ],
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "파일은 한 번에 최대 3개까지 업로드할 수 있습니다."
+    assert service.stream_calls == []
+
+
+def test_chat_stream_rejects_oversized_file(monkeypatch):
+    """chat_stream 엔드포인트는 10MB 초과 파일 업로드를 거부한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        data={"message": "안녕하세요"},
+        files=[("files", ("large.pdf", b"a" * (10 * 1024 * 1024 + 1), "application/pdf"))],
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "large.pdf 크기는 10MB를 초과할 수 없습니다."
+    assert service.stream_calls == []
+
+
+def test_chat_stream_rejects_unsupported_file_type(monkeypatch):
+    """chat_stream 엔드포인트는 지원하지 않는 형식의 파일 업로드를 거부한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        data={"message": "안녕하세요"},
+        files=[("files", ("animated.gif", b"gif-data", "image/gif"))],
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "PDF, PNG, JPG(JPEG) 파일만 업로드할 수 있습니다."
+    assert service.stream_calls == []
+
+
+def test_chat_stream_works_without_files(monkeypatch):
+    """chat_stream 엔드포인트는 파일 없이도 정상 동작한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+
+    async def _passthrough_events(stream):
+        async for event in stream:
+            yield event["data"]
+
+    monkeypatch.setattr(interview_api, "_interleave_ping_events", _passthrough_events)
+    monkeypatch.setattr(interview_api, "EventSourceResponse", StreamingResponse)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        data={"message": "안녕하세요"},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert "message_complete" in body
+    assert service.stream_calls[0]["files"] == []
+    assert service.stream_calls[0]["message"] == "안녕하세요"

--- a/tests/test_features/test_interview/test_file_processor.py
+++ b/tests/test_features/test_interview/test_file_processor.py
@@ -74,6 +74,39 @@ def test_file_processor_run_reads_temp_path_and_clears_current_turn_files(tmp_pa
     )
 
 
+def test_file_processor_run_extracts_image_text(tmp_path, monkeypatch):
+    """이미지 파일은 Vision LLM의 image_url 입력으로 전달한다."""
+    file_path = tmp_path / "architecture.png"
+    file_bytes = b"png-binary-data"
+    file_path.write_bytes(file_bytes)
+    fake_llm = _CaptureVisionLLM("추출된 이미지 텍스트")
+    monkeypatch.setattr(file_processor, "get_file_processor_llm", lambda: fake_llm)
+
+    state = get_initial_interview_state(
+        user_id="test_user",
+        session_id="test_session",
+        experience_name="테스트 경험",
+    )
+    state["current_turn_files"] = [
+        {
+            "filename": "architecture.png",
+            "content_type": "image/png",
+            "temp_path": str(file_path),
+        }
+    ]
+
+    result = file_processor.run(state)
+
+    assert result["file_contexts"] == ["[파일: architecture.png]\n추출된 이미지 텍스트"]
+    assert result["current_turn_files"] == []
+
+    human_content = fake_llm.invocations[0][1].content
+    assert human_content[1]["type"] == "image_url"
+    assert human_content[1]["image_url"]["url"] == (
+        "data:image/png;base64," + base64.b64encode(file_bytes).decode("utf-8")
+    )
+
+
 def test_file_processor_run_continues_when_one_file_fails(tmp_path, monkeypatch):
     """파일 하나가 실패해도 나머지 파일은 계속 처리한다."""
     image_path = tmp_path / "image.png"


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #184

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `tests/test_features/test_interview/test_file_processor.py`에 이미지 파일의 `image_url` Vision 입력 경로를 직접 검증하는 테스트를 추가했습니다.
- `tests/test_app/test_api/test_v1/test_interview_file_upload.py`를 새로 추가해 `/chat/stream` 기준 파일 업로드 검증 시나리오 5개를 분리했습니다.
- 스트리밍 성공 케이스는 `sse-starlette` TestClient 이벤트루프 충돌을 피하도록 테스트 내부에서만 응답 래퍼를 대체해 안정적으로 검증했습니다.

## 📸 스크린샷

- 자동화 검증 결과

```text
uv run ruff check --fix .
uv run ruff format .
uv run pytest
407 passed
```

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 기존 `tests/test_app/test_api/test_v1/test_interview.py`의 업로드 검증 테스트는 유지하고, 이슈 명세에 맞는 업로드 전용 테스트 파일을 추가하는 방식으로 정리했습니다.

## 개선 제안 및 추가 필요 작업

- 향후 `sse-starlette` 테스트 환경 이슈가 반복되면 공용 SSE 테스트 헬퍼를 분리해 중복 monkeypatch를 줄일 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 파일 업로드 엔드포인트 테스트 추가: 여러 파일 지원, 파일 수 및 크기 제한 검증, 지원하지 않는 파일 형식 처리
  * 이미지 텍스트 추출 기능 테스트 추가: 이미지 파일 처리 및 데이터 변환 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->