### PR TITLE
[Feat] 인터뷰 파일 업로드 — 턴별 파일 메타데이터 히스토리 추가

### DIFF
--- a/app/api/v1/interview.py
+++ b/app/api/v1/interview.py
@@ -20,6 +20,8 @@ from app.schemas.interview import (
     CreateSessionResponse,
     ErrorResponse,
     ExtendSessionResponse,
+    FileMetadataSchema,
+    FileTurnRecordSchema,
     InsightLogSchema,
     InsightTurnRecordSchema,
     MessageSchema,
@@ -126,6 +128,7 @@ async def _read_and_validate_files(files: list[UploadFile] | None) -> list[FileP
                     "filename": file.filename or "",
                     "content_type": normalized_content_type,
                     "temp_path": str(temp_path),
+                    "file_size": bytes_written,
                 }
             )
 
@@ -509,6 +512,13 @@ async def get_session_state(session_id: str) -> SessionStateResponse:
                 insights=[InsightLogSchema(**insight) for insight in record["insights"]],
             )
             for record in state["insight_turn_history"]
+        ],
+        file_turn_history=[
+            FileTurnRecordSchema(
+                turn_number=record["turn_number"],
+                files=[FileMetadataSchema(**file_meta) for file_meta in record["files"]],
+            )
+            for record in state["file_turn_history"]
         ],
         messages=messages,
     )

--- a/app/schemas/interview.py
+++ b/app/schemas/interview.py
@@ -64,6 +64,24 @@ class InsightTurnRecordSchema(BaseModel):
     )
 
 
+class FileMetadataSchema(BaseModel):
+    """파일 메타데이터 스키마"""
+
+    filename: str = Field(..., description="원본 파일명")
+    content_type: str = Field(..., description="MIME 타입")
+    file_size: int = Field(..., ge=0, description="파일 크기(바이트)")
+
+
+class FileTurnRecordSchema(BaseModel):
+    """턴별 파일 메타데이터 복원 기록 스키마"""
+
+    turn_number: int = Field(..., ge=1, description="사용자 턴 번호")
+    files: list[FileMetadataSchema] = Field(
+        default_factory=list,
+        description="해당 턴 첨부 파일 목록",
+    )
+
+
 # ===== 세션 생성 =====
 class CreateSessionRequest(BaseModel):
     """세션 생성 요청"""
@@ -134,6 +152,10 @@ class SessionStateResponse(BaseModel):
     insight_turn_history: list[InsightTurnRecordSchema] = Field(
         default_factory=list,
         description="과거 사용자 턴별 인사이트 복원 이력",
+    )
+    file_turn_history: list[FileTurnRecordSchema] = Field(
+        default_factory=list,
+        description="과거 사용자 턴별 파일 메타데이터 복원 이력",
     )
     messages: list[MessageSchema] = Field(..., description="전체 대화 기록")
 

--- a/features/interview/agents/nodes/router.py
+++ b/features/interview/agents/nodes/router.py
@@ -1,6 +1,42 @@
 """Router 노드 - 입력 라우팅 및 초기 상태 감지"""
 
-from ..state import InterviewState, ensure_interview_state_defaults, get_turn_number_from_messages
+from ..state import (
+    FilePayload,
+    FileTurnRecord,
+    InterviewState,
+    ensure_interview_state_defaults,
+    get_turn_number_from_messages,
+)
+
+
+def _build_file_turn_record(
+    turn_number: int,
+    current_turn_files: list[FilePayload],
+) -> FileTurnRecord:
+    """현재 턴 파일 payload를 복원용 파일 턴 레코드로 변환한다."""
+
+    return {
+        "turn_number": turn_number,
+        "files": [
+            {
+                "filename": file_payload["filename"],
+                "content_type": file_payload["content_type"],
+                "file_size": file_payload.get("file_size", 0),
+            }
+            for file_payload in current_turn_files
+        ],
+    }
+
+
+def _upsert_file_turn_history(
+    history: list[FileTurnRecord],
+    new_record: FileTurnRecord,
+) -> list[FileTurnRecord]:
+    """같은 turn_number 기록을 교체하면서 파일 히스토리를 갱신한다."""
+
+    turn_number = new_record["turn_number"]
+    filtered_history = [record for record in history if record["turn_number"] != turn_number]
+    return [*filtered_history, new_record]
 
 
 def run(state: InterviewState) -> InterviewState:
@@ -15,6 +51,7 @@ def run(state: InterviewState) -> InterviewState:
     has_new_user_message = current_turn_number > normalized_state["turn_number"]
     is_session_bootstrap = normalized_state["turn_number"] == 0 and current_turn_number == 0
     turn_number = normalized_state["turn_number"]
+    file_turn_history = normalized_state["file_turn_history"]
 
     if (
         is_session_bootstrap
@@ -29,6 +66,11 @@ def run(state: InterviewState) -> InterviewState:
 
         current_turn_files = normalized_state.get("current_turn_files") or []
         has_file_attachment = len(current_turn_files) > 0
+        if has_new_user_message and has_file_attachment:
+            file_turn_history = _upsert_file_turn_history(
+                file_turn_history,
+                _build_file_turn_record(turn_number, current_turn_files),
+            )
 
         if has_file_attachment:
             next_node = "file_processor"
@@ -38,5 +80,6 @@ def run(state: InterviewState) -> InterviewState:
     return {
         **normalized_state,
         "turn_number": turn_number,
+        "file_turn_history": file_turn_history,
         "next_node": next_node,
     }

--- a/features/interview/agents/state.py
+++ b/features/interview/agents/state.py
@@ -28,12 +28,28 @@ class InsightTurnRecord(TypedDict):
     insights: list[InsightLog]
 
 
+class FileMetadata(TypedDict):
+    """턴 히스토리 복원을 위한 파일 메타데이터"""
+
+    filename: str
+    content_type: str
+    file_size: int
+
+
+class FileTurnRecord(TypedDict):
+    """사용자 턴별 파일 메타데이터 복원 기록"""
+
+    turn_number: int
+    files: list[FileMetadata]
+
+
 class FilePayload(TypedDict):
     """현재 턴 업로드 파일의 임시 저장 참조"""
 
     filename: str
     content_type: str
     temp_path: str
+    file_size: int
 
 
 class StageProgress(TypedDict):
@@ -117,6 +133,10 @@ class InterviewState(TypedDict):
     insight_turn_history: list[InsightTurnRecord]
     # 사용자 턴별 인사이트 카드 복원 이력
     # retrieved_insights와 별개로 과거 턴 전체를 누적 저장
+
+    file_turn_history: list[FileTurnRecord]
+    # 사용자 턴별 파일 메타데이터 복원 이력
+    # current_turn_files와 별개로 과거 턴 전체를 누적 저장
 
     # ===== 파일 업로드 =====
     current_turn_files: list[FilePayload]
@@ -205,6 +225,7 @@ def get_initial_interview_state(
         "mentioned_insight": None,
         "retrieved_insights": [],
         "insight_turn_history": [],
+        "file_turn_history": [],
         # 파일 업로드
         "current_turn_files": [],
         "file_contexts": [],
@@ -241,6 +262,7 @@ def ensure_interview_state_defaults(state: InterviewState | dict) -> InterviewSt
         "mentioned_insight": state.get("mentioned_insight"),
         "retrieved_insights": list(state.get("retrieved_insights") or []),
         "insight_turn_history": list(state.get("insight_turn_history") or []),
+        "file_turn_history": list(state.get("file_turn_history") or []),
         "current_turn_files": list(state.get("current_turn_files") or []),
         "file_contexts": list(state.get("file_contexts") or []),
     }

--- a/tests/test_app/test_api/test_v1/test_interview.py
+++ b/tests/test_app/test_api/test_v1/test_interview.py
@@ -123,6 +123,18 @@ class DummyInterviewService:
                     ],
                 }
             ],
+            "file_turn_history": [
+                {
+                    "turn_number": 1,
+                    "files": [
+                        {
+                            "filename": "portfolio.pdf",
+                            "content_type": "application/pdf",
+                            "file_size": 524288,
+                        }
+                    ],
+                }
+            ],
             "messages": [],
             "mentioned_insight": None,
             "retrieved_insights": [],
@@ -213,6 +225,18 @@ def test_get_session_state_includes_turn_history(monkeypatch):
     assert body["insight_turn_history"][0]["turn_number"] == 1
     assert body["insight_turn_history"][0]["user_message"] == "첫 답변"
     assert body["insight_turn_history"][0]["insights"][0]["activity_name"] == "해커톤"
+    assert body["file_turn_history"] == [
+        {
+            "turn_number": 1,
+            "files": [
+                {
+                    "filename": "portfolio.pdf",
+                    "content_type": "application/pdf",
+                    "file_size": 524288,
+                }
+            ],
+        }
+    ]
 
 
 def test_get_session_status_returns_compact_payload(monkeypatch):
@@ -265,15 +289,18 @@ def test_chat_accepts_multipart_form_and_passes_file_payloads(monkeypatch, tmp_p
             "filename": "portfolio.pdf",
             "content_type": "application/pdf",
             "temp_path": str(tmp_path / "interview-upload-1.pdf"),
+            "file_size": len(b"%PDF-1.4"),
         },
         {
             "filename": "image.jpg",
             "content_type": "image/jpeg",
             "temp_path": str(tmp_path / "interview-upload-2.jpg"),
+            "file_size": len(b"jpeg-bytes"),
         },
     ]
     assert (tmp_path / "interview-upload-1.pdf").exists() is False
     assert (tmp_path / "interview-upload-2.jpg").exists() is False
+    assert "file_turn_history" not in response.json()
 
 
 def test_chat_cleans_up_temp_files_when_service_raises(monkeypatch, tmp_path):
@@ -327,6 +354,7 @@ async def test_chat_stream_cleans_up_temp_files_after_response(monkeypatch, tmp_
             "filename": "portfolio.pdf",
             "content_type": "application/pdf",
             "temp_path": str(temp_file_path),
+            "file_size": len(b"%PDF-1.4"),
         }
     ]
     assert temp_file_path.exists() is False
@@ -354,6 +382,7 @@ async def test_read_and_validate_files_stores_temp_file_and_closes_upload(tmp_pa
             "filename": "portfolio.pdf",
             "content_type": "application/pdf",
             "temp_path": str(temp_file_path),
+            "file_size": len(b"%PDF-1.4"),
         }
     ]
     assert upload.read_sizes == [1024 * 1024, 1024 * 1024, 1024 * 1024]

--- a/tests/test_app/test_api/test_v1/test_interview_file_upload.py
+++ b/tests/test_app/test_api/test_v1/test_interview_file_upload.py
@@ -76,11 +76,13 @@ def test_chat_stream_accepts_multipart_with_files(monkeypatch, tmp_path):
             "filename": "portfolio.pdf",
             "content_type": "application/pdf",
             "temp_path": str(tmp_path / "interview-upload-1.pdf"),
+            "file_size": len(b"%PDF-1.4"),
         },
         {
             "filename": "image.jpg",
             "content_type": "image/jpeg",
             "temp_path": str(tmp_path / "interview-upload-2.jpg"),
+            "file_size": len(b"jpeg-bytes"),
         },
     ]
     assert (tmp_path / "interview-upload-1.pdf").exists() is False

--- a/tests/test_features/test_interview/test_graph.py
+++ b/tests/test_features/test_interview/test_graph.py
@@ -4,7 +4,10 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
 from features.interview.agents import InterviewState, build_graph
-from features.interview.agents.state import get_initial_interview_state
+from features.interview.agents.state import (
+    ensure_interview_state_defaults,
+    get_initial_interview_state,
+)
 
 
 @pytest.fixture
@@ -21,6 +24,30 @@ def test_build_graph():
     """그래프가 정상적으로 빌드되는지 확인"""
     graph = build_graph()
     assert graph is not None
+
+
+def test_initial_state_starts_with_empty_file_turn_history():
+    """초기 state는 빈 파일 턴 히스토리로 시작한다."""
+    state = get_initial_interview_state(
+        user_id="test_user",
+        session_id="test_session",
+        experience_name="테스트 경험",
+    )
+
+    assert state["file_turn_history"] == []
+
+
+def test_ensure_interview_state_defaults_adds_file_turn_history():
+    """구세션 state에도 file_turn_history 기본값을 보강한다."""
+    normalized = ensure_interview_state_defaults(
+        {
+            "messages": [],
+            "current_turn_files": [],
+            "file_contexts": [],
+        }
+    )
+
+    assert normalized["file_turn_history"] == []
 
 
 def test_graph_execution_mock(initial_state, monkeypatch):
@@ -83,6 +110,157 @@ def test_interviewer_routing_with_file_attachment(initial_state):
     result = router.run(state)
     assert result["next_node"] == "file_processor"
     assert result["turn_number"] == 1
+
+
+def test_router_records_file_turn_history_for_new_user_turn(initial_state):
+    """새 사용자 턴의 첨부 파일 메타데이터를 file_turn_history에 기록한다."""
+    from features.interview.agents.nodes import router
+
+    state = {
+        **initial_state,
+        "messages": [AIMessage(content="이전 질문"), HumanMessage(content="파일 포함 답변")],
+        "current_turn_files": [
+            {
+                "filename": "portfolio.pdf",
+                "content_type": "application/pdf",
+                "temp_path": "/tmp/portfolio.pdf",
+                "file_size": 123,
+            }
+        ],
+    }
+
+    result = router.run(state)
+
+    assert result["turn_number"] == 1
+    assert result["file_turn_history"] == [
+        {
+            "turn_number": 1,
+            "files": [
+                {
+                    "filename": "portfolio.pdf",
+                    "content_type": "application/pdf",
+                    "file_size": 123,
+                }
+            ],
+        }
+    ]
+
+
+def test_router_does_not_record_file_history_without_new_user_turn(initial_state):
+    """새 사용자 메시지가 없으면 파일 히스토리를 기록하지 않는다."""
+    from features.interview.agents.nodes import router
+
+    state = {
+        **initial_state,
+        "turn_number": 1,
+        "file_turn_history": [],
+        "messages": [AIMessage(content="이전 질문"), HumanMessage(content="이전 답변")],
+        "current_turn_files": [
+            {
+                "filename": "legacy.pdf",
+                "content_type": "application/pdf",
+                "temp_path": "/tmp/legacy.pdf",
+            }
+        ],
+    }
+
+    result = router.run(state)
+
+    assert result["file_turn_history"] == []
+
+
+def test_router_does_not_record_file_history_during_bootstrap(initial_state):
+    """bootstrap 실행에서는 파일 히스토리를 기록하지 않는다."""
+    from features.interview.agents.nodes import router
+
+    result = router.run(
+        {
+            **initial_state,
+            "current_turn_files": [
+                {
+                    "filename": "bootstrap.pdf",
+                    "content_type": "application/pdf",
+                    "temp_path": "/tmp/bootstrap.pdf",
+                    "file_size": 12,
+                }
+            ],
+        }
+    )
+
+    assert result["turn_number"] == 0
+    assert result["file_turn_history"] == []
+
+
+def test_router_uses_zero_for_legacy_file_payload_without_file_size(initial_state):
+    """레거시 payload에 file_size가 없으면 0으로 보정한다."""
+    from features.interview.agents.nodes import router
+
+    state = {
+        **initial_state,
+        "messages": [AIMessage(content="이전 질문"), HumanMessage(content="레거시 파일 답변")],
+        "current_turn_files": [
+            {
+                "filename": "legacy.pdf",
+                "content_type": "application/pdf",
+                "temp_path": "/tmp/legacy.pdf",
+            }
+        ],
+    }
+
+    result = router.run(state)
+
+    assert result["file_turn_history"] == [
+        {
+            "turn_number": 1,
+            "files": [
+                {
+                    "filename": "legacy.pdf",
+                    "content_type": "application/pdf",
+                    "file_size": 0,
+                }
+            ],
+        }
+    ]
+
+
+def test_upsert_file_turn_history_replaces_same_turn_record():
+    """같은 turn_number 기록은 append 대신 교체한다."""
+    from features.interview.agents.nodes import router
+
+    history = [
+        {
+            "turn_number": 1,
+            "files": [
+                {
+                    "filename": "old.pdf",
+                    "content_type": "application/pdf",
+                    "file_size": 10,
+                }
+            ],
+        },
+        {
+            "turn_number": 2,
+            "files": [
+                {
+                    "filename": "old2.pdf",
+                    "content_type": "application/pdf",
+                    "file_size": 20,
+                }
+            ],
+        },
+    ]
+    new_record = {
+        "turn_number": 2,
+        "files": [
+            {
+                "filename": "new.pdf",
+                "content_type": "application/pdf",
+                "file_size": 30,
+            }
+        ],
+    }
+
+    assert router._upsert_file_turn_history(history, new_record) == [history[0], new_record]
 
 
 def test_router_increments_existing_turn_number(initial_state):

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -216,6 +216,7 @@ async def test_process_message_stream_emits_retriever_events(monkeypatch):
     )
     complete_payload = json.loads(complete_event["data"])
     assert complete_payload["message"]["status"] == "completed"
+    assert "file_turn_history" not in complete_payload["message"]
     assert dummy_graph.update_state_calls[0]["state"]["status"] == "generating"
     assert dummy_graph.update_state_calls[-1]["state"]["status"] == "completed"
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #188

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `features/interview/agents/state.py`에 `FileMetadata`, `FileTurnRecord`, `file_turn_history`를 추가하고, 초기 state 및 기본값 보강 로직에 반영했습니다.
- `app/api/v1/interview.py`에서 업로드 파일 payload에 `file_size`를 포함하도록 변경하고, `features/interview/agents/nodes/router.py`에서 새 사용자 턴의 첨부 파일 메타데이터를 `file_turn_history`로 upsert하도록 구현했습니다.
- `app/schemas/interview.py` 및 세션 상태 조회 응답 매핑을 확장해 `SessionStateResponse`에만 `file_turn_history`를 노출하고, 일반 chat 응답/SSE 완료 이벤트에는 노출되지 않도록 유지했습니다.
- 레거시 `current_turn_files` payload에 `file_size`가 없을 때 `0`으로 보정하는 호환 로직과 관련 회귀 테스트를 추가했습니다.

## 📸 스크린샷

- 자동화 검증 결과

```text
uv run ruff check .
All checks passed!

uv run ruff format --check .
135 files already formatted

uv run pytest
414 passed
```

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- base branch는 저장소 기본 브랜치인 `dev`로 설정했습니다.
- 이번 PR 범위는 상태 복원용 히스토리 저장/조회까지이며, 실시간 응답(`ChatResponse`, SSE 완료 이벤트) 확장은 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인터뷰 세션에서 각 턴별 파일 업로드 이력을 추적하고 유지합니다.
  * 업로드된 각 파일의 메타데이터(파일명, 파일 타입, 파일 크기)를 기록합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->