### PR TITLE
[Feat] PDF 구조화/첨삭 후처리 정규화

### DIFF
--- a/features/correction/service.py
+++ b/features/correction/service.py
@@ -369,6 +369,19 @@ class CorrectionService:
     }
 
     @staticmethod
+    def _normalize_comment_for_server(line_type: str, comment: str | None) -> str | None:
+        """메인 서버 전송용 코멘트 포맷을 최소 정규화한다."""
+        marker = "수정 예시:"
+        if line_type != "emphasize" or not comment or marker not in comment:
+            return comment
+
+        marker_index = comment.find(marker)
+        if marker_index <= 0 or comment[marker_index - 1] == "\n":
+            return comment
+
+        return f"{comment[:marker_index]}\n{comment[marker_index:]}"
+
+    @staticmethod
     def _convert_result_for_server(result: CorrectionOutput) -> list[dict]:
         """CorrectionOutput을 메인 서버 result 배열 포맷으로 변환"""
         if hasattr(result, "model_dump"):
@@ -388,7 +401,9 @@ class CorrectionService:
                             "lineNumber": line["line_number"],
                             "originalText": line["original_text"],
                             "type": line["type"],
-                            "comment": line["comment"],
+                            "comment": CorrectionService._normalize_comment_for_server(
+                                line["type"], line["comment"]
+                            ),
                         }
                         for line in field.get("lines", [])
                     ]

--- a/features/correction/service.py
+++ b/features/correction/service.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import re
 import time
 
 from fastapi import BackgroundTasks
@@ -376,7 +377,7 @@ class CorrectionService:
             return comment
 
         marker_index = comment.find(marker)
-        if marker_index <= 0 or comment[marker_index - 1] == "\n":
+        if marker_index <= 0 or re.search(r"\n[ \t]*$", comment[:marker_index]):
             return comment
 
         return f"{comment[:marker_index]}\n{comment[marker_index:]}"

--- a/features/portfolio/pdf_extraction/service.py
+++ b/features/portfolio/pdf_extraction/service.py
@@ -94,7 +94,15 @@ class PdfExtractionService:
             logger.exception("PDF 추출 완료 콜백 전송 실패 (correction_id: %s)", correction_id)
 
     @staticmethod
-    def _validate_result(result: PdfExtractionResult) -> list[PdfActivity]:
+    def _normalize_structured_text(value: str) -> str:
+        """구조화 문자열의 선행 '- ' bullet만 제거한다."""
+        stripped = value.lstrip()
+        if stripped.startswith("- "):
+            return stripped[2:]
+        return value
+
+    @classmethod
+    def _validate_result(cls, result: PdfExtractionResult) -> list[PdfActivity]:
         """추출 결과를 후처리하고 메인 서버 콜백 형식으로 정리한다."""
         activities = list(result.activities[:5])
         if not activities:
@@ -110,14 +118,30 @@ class PdfExtractionService:
 
             seen_names.add(dedupe_key)
             problem_solving = [
-                item.model_copy(update={"no": index})
+                item.model_copy(
+                    update={
+                        "no": index,
+                        "situation": cls._normalize_structured_text(item.situation),
+                        "strategy": cls._normalize_structured_text(item.strategy),
+                        "reason": cls._normalize_structured_text(item.reason),
+                    }
+                )
                 for index, item in enumerate(activity.problem_solving, start=1)
             ]
             normalized_activities.append(
                 activity.model_copy(
                     update={
                         "activity_name": dedupe_key,
+                        "detail": [
+                            cls._normalize_structured_text(item) for item in activity.detail
+                        ],
+                        "responsibility": [
+                            cls._normalize_structured_text(item) for item in activity.responsibility
+                        ],
                         "problem_solving": problem_solving,
+                        "learning": [
+                            cls._normalize_structured_text(item) for item in activity.learning
+                        ],
                     }
                 )
             )

--- a/tests/test_features/test_correction/test_service.py
+++ b/tests/test_features/test_correction/test_service.py
@@ -23,7 +23,20 @@ def _install_dummy_langchain_openai():
     sys.modules.setdefault("langchain_openai", dummy_module)
 
 
+def _install_dummy_tavily():
+    """테스트용 tavily 더미 모듈 설치"""
+    dummy_module = types.ModuleType("tavily")
+
+    class DummyAsyncTavilyClient:  # pragma: no cover - 간단 더미
+        def __init__(self, *args, **kwargs):
+            pass
+
+    dummy_module.AsyncTavilyClient = DummyAsyncTavilyClient
+    sys.modules.setdefault("tavily", dummy_module)
+
+
 _install_dummy_langchain_openai()
+_install_dummy_tavily()
 
 correction_service_module = importlib.import_module("features.correction.service")
 RAGRunResult = importlib.import_module("features.correction.rag.pipeline").RAGRunResult
@@ -1001,6 +1014,86 @@ def test_convert_result_for_server_converts_multi_portfolio_format():
             },
         },
     ]
+
+
+def _make_conversion_result_with_comments(
+    *,
+    emphasize_comment: str,
+    reduce_comment: str = "줄이세요.",
+    keep_comment: str | None = None,
+) -> CorrectionOutput:
+    """서버 변환 테스트용 댓글 값을 가진 CorrectionOutput 생성."""
+    single_output = _make_single_output().model_dump()
+    single_output["fields"][0]["lines"][0]["comment"] = keep_comment
+    single_output["fields"][1]["lines"][0]["comment"] = emphasize_comment
+    single_output["fields"][2]["lines"][0]["comment"] = reduce_comment
+
+    return CorrectionOutput(
+        portfolio_corrections=[
+            PortfolioCorrectionResult(
+                portfolio_id=11,
+                fields=SingleCorrectionOutput.model_validate(single_output).fields,
+            )
+        ],
+        overall_summary="총평",
+    )
+
+
+def test_convert_result_for_server_breaks_emphasize_comment_before_example():
+    """emphasize 코멘트의 inline 수정 예시는 서버 변환 시 줄바꿈으로 정규화한다."""
+    result = _make_conversion_result_with_comments(
+        emphasize_comment="강조하세요. 수정 예시: 이렇게 작성하세요.",
+    )
+
+    converted = CorrectionService._convert_result_for_server(result)
+
+    assert converted[0]["responsibilities"]["lines"][0]["comment"] == (
+        "강조하세요. \n수정 예시: 이렇게 작성하세요."
+    )
+
+
+def test_convert_result_for_server_leaves_reduce_and_keep_comments_unchanged():
+    """reduce/keep 코멘트는 수정 예시 문구가 있어도 그대로 유지한다."""
+    result = _make_conversion_result_with_comments(
+        emphasize_comment="강조하세요.",
+        reduce_comment="줄이세요. 수정 예시: 더 짧게 작성하세요.",
+        keep_comment="유지하세요. 수정 예시: 현재 표현을 유지하세요.",
+    )
+
+    converted = CorrectionService._convert_result_for_server(result)
+
+    assert converted[0]["problemSolving"]["lines"][0]["comment"] == (
+        "줄이세요. 수정 예시: 더 짧게 작성하세요."
+    )
+    assert converted[0]["description"]["lines"][0]["comment"] == (
+        "유지하세요. 수정 예시: 현재 표현을 유지하세요."
+    )
+
+
+def test_convert_result_for_server_keeps_already_formatted_emphasize_comment():
+    """이미 줄바꿈된 emphasize 수정 예시는 그대로 유지한다."""
+    result = _make_conversion_result_with_comments(
+        emphasize_comment="강조하세요.\n수정 예시: 이렇게 작성하세요.",
+    )
+
+    converted = CorrectionService._convert_result_for_server(result)
+
+    assert converted[0]["responsibilities"]["lines"][0]["comment"] == (
+        "강조하세요.\n수정 예시: 이렇게 작성하세요."
+    )
+
+
+def test_convert_result_for_server_preserves_spacing_before_inserted_newline():
+    """inline 수정 예시 앞 공백은 유지하고 줄바꿈만 추가한다."""
+    result = _make_conversion_result_with_comments(
+        emphasize_comment="강조하세요.  수정 예시: 이렇게 작성하세요.",
+    )
+
+    converted = CorrectionService._convert_result_for_server(result)
+
+    assert converted[0]["responsibilities"]["lines"][0]["comment"] == (
+        "강조하세요.  \n수정 예시: 이렇게 작성하세요."
+    )
 
 
 # ------------------------------------------------------------------

--- a/tests/test_features/test_correction/test_service.py
+++ b/tests/test_features/test_correction/test_service.py
@@ -1096,6 +1096,19 @@ def test_convert_result_for_server_preserves_spacing_before_inserted_newline():
     )
 
 
+def test_convert_result_for_server_keeps_indented_already_formatted_example():
+    """개행 뒤 공백이 있는 수정 예시는 이미 포맷된 것으로 유지한다."""
+    result = _make_conversion_result_with_comments(
+        emphasize_comment="강조하세요.\n 수정 예시: 이렇게 작성하세요.",
+    )
+
+    converted = CorrectionService._convert_result_for_server(result)
+
+    assert converted[0]["responsibilities"]["lines"][0]["comment"] == (
+        "강조하세요.\n 수정 예시: 이렇게 작성하세요."
+    )
+
+
 # ------------------------------------------------------------------
 # retry
 # ------------------------------------------------------------------

--- a/tests/test_features/test_portfolio/test_pdf_extraction_service.py
+++ b/tests/test_features/test_portfolio/test_pdf_extraction_service.py
@@ -1,15 +1,33 @@
 """PDF 추출 서비스 테스트"""
 
+import sys
+import types
+
 import pytest
 
-from features.portfolio.pdf_extraction import __all__ as pdf_extraction_exports
-from features.portfolio.pdf_extraction import service as pdf_extraction_service_module
-from features.portfolio.pdf_extraction.schemas import (
+
+def _install_dummy_langchain_openai() -> None:
+    """패키지 import 체인 테스트용 langchain_openai 더미 모듈 설치"""
+    dummy_module = types.ModuleType("langchain_openai")
+
+    class DummyChatOpenAI:  # pragma: no cover - 간단 더미
+        def __init__(self, *args, **kwargs):
+            pass
+
+    dummy_module.ChatOpenAI = DummyChatOpenAI
+    sys.modules.setdefault("langchain_openai", dummy_module)
+
+
+_install_dummy_langchain_openai()
+
+from features.portfolio.pdf_extraction import __all__ as pdf_extraction_exports  # noqa: E402
+from features.portfolio.pdf_extraction import service as pdf_extraction_service_module  # noqa: E402
+from features.portfolio.pdf_extraction.schemas import (  # noqa: E402
     PdfActivity,
     PdfExtractionResult,
     PdfProblemSolvingItem,
 )
-from features.portfolio.pdf_extraction.service import (
+from features.portfolio.pdf_extraction.service import (  # noqa: E402
     PdfExtractionService,
     get_pdf_extraction_service,
     init_pdf_extraction_service,
@@ -290,6 +308,47 @@ def test_validate_result_skips_blank_activity_names_and_trims_values():
     activities = service._validate_result(result)
 
     assert [activity.activity_name for activity in activities] == ["Project A"]
+
+
+def test_validate_result_removes_only_leading_dash_bullets_from_structured_fields():
+    """구조화 필드에서는 선행 '- '만 제거하고 다른 마커는 유지한다."""
+    service = PdfExtractionService(
+        correction_client=DummyCorrectionClient(),
+        generator=DummyGenerator(),
+    )
+    result = PdfExtractionResult(
+        activities=[
+            PdfActivity(
+                activity_name=" Project A ",
+                detail=["- 상세", "1. 유지", "• 유지"],
+                responsibility=["  - 담당 업무", "• 그대로 유지"],
+                problem_solving=[
+                    PdfProblemSolvingItem(
+                        no=9,
+                        situation="- 문제 상황",
+                        strategy="  - 대응 전략",
+                        reason="- 선택 이유",
+                    )
+                ],
+                learning=["- 배운 점", "1. 유지"],
+            )
+        ]
+    )
+
+    activities = service._validate_result(result)
+
+    assert [activity.activity_name for activity in activities] == ["Project A"]
+    assert activities[0].detail == ["상세", "1. 유지", "• 유지"]
+    assert activities[0].responsibility == ["담당 업무", "• 그대로 유지"]
+    assert activities[0].learning == ["배운 점", "1. 유지"]
+    assert activities[0].problem_solving == [
+        PdfProblemSolvingItem(
+            no=1,
+            situation="문제 상황",
+            strategy="대응 전략",
+            reason="선택 이유",
+        )
+    ]
 
 
 def test_validate_file_allows_pdf_extension_for_wrong_mime_type():


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #191

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PDF 구조화 후처리에서 `detail`, `responsibility`, `learning`, `problem_solving` 문자열의 선행 `- `만 제거하도록 정규화했습니다.
- 첨삭 결과 서버 변환 시 `emphasize` 코멘트의 `수정 예시:` 앞에만 줄바꿈을 삽입하도록 정규화했습니다.
- 두 정규화 동작에 대한 회귀 테스트를 추가하고, PDF 서비스 테스트가 import 체인 의존성 없이 실행되도록 더미 모듈 스텁을 보강했습니다.

## 📸 스크린샷

- 테스트 결과는 아래 검증 명령으로 확인했습니다.

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 검증 명령
  - `uv run ruff check features/portfolio/pdf_extraction/service.py features/correction/service.py tests/test_features/test_portfolio/test_pdf_extraction_service.py tests/test_features/test_correction/test_service.py`
  - `uv run pytest tests/test_features/test_portfolio/test_pdf_extraction_service.py tests/test_features/test_correction/test_service.py -q`
- PDF 정규화는 선행 `- `만 제거하며 `1.`/`•` 같은 다른 마커는 유지합니다.
- `수정 예시:` 줄바꿈은 `emphasize` 코멘트에만 적용되고, 이미 줄바꿈된 경우는 그대로 둡니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 교정 기능에서 강조 코멘트의 서버 전송 형식이 특정 문구에 대해 일관되게 정리되도록 개선되었습니다.
  * PDF 추출 기능에서 구조화된 텍스트의 선행 "- " 글머리표만 제거하도록 정규화 처리가 추가되어 불필요한 표기만 정리됩니다.

* **테스트**
  * 교정 및 PDF 추출 서비스 관련 단위 테스트가 추가·확대되어 위 동작들이 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->