### PR TITLE
[Feat] 기업 분석 정보 글자 수 제한 2000자 상향 및 제한값 정리

### DIFF
--- a/app/api/v1/correction.py
+++ b/app/api/v1/correction.py
@@ -179,7 +179,6 @@ async def get_company_insight(correction_id: str) -> CompanyInsightResponse:
     status_code=status.HTTP_200_OK,
     summary="기업 분석 수정",
     responses={
-        422: {"model": ErrorResponse, "description": "요청 본문 검증 실패"},
         404: {"model": ErrorResponse, "description": "첨삭이 없는 경우"},
         409: {"model": ErrorResponse, "description": "상태 전이 규칙 위반"},
         500: {"model": ErrorResponse, "description": "내부 서버 에러"},

--- a/app/api/v1/correction.py
+++ b/app/api/v1/correction.py
@@ -179,7 +179,7 @@ async def get_company_insight(correction_id: str) -> CompanyInsightResponse:
     status_code=status.HTTP_200_OK,
     summary="기업 분석 수정",
     responses={
-        400: {"model": ErrorResponse, "description": "요청 데이터 수동 검증 실패"},
+        422: {"model": ErrorResponse, "description": "요청 본문 검증 실패"},
         404: {"model": ErrorResponse, "description": "첨삭이 없는 경우"},
         409: {"model": ErrorResponse, "description": "상태 전이 규칙 위반"},
         500: {"model": ErrorResponse, "description": "내부 서버 에러"},

--- a/features/correction/config/correction.yaml
+++ b/features/correction/config/correction.yaml
@@ -16,6 +16,6 @@ validation:
 rag:
     keyword_count: 6
     max_results_per_keyword: 5
-    company_insight_max_length: 1500
+    company_insight_max_length: 2000
     call_max_retries: 3
     length_retry_max_retries: 2

--- a/features/correction/config/loader.py
+++ b/features/correction/config/loader.py
@@ -28,7 +28,7 @@ class CorrectionRAGConfig(BaseModel):
 
     keyword_count: int = Field(default=6, ge=1)
     max_results_per_keyword: int = Field(default=5, ge=1, le=20)
-    company_insight_max_length: int = Field(default=1500, ge=1)
+    company_insight_max_length: int = Field(default=2000, ge=1)
     call_max_retries: int = Field(default=3, ge=1)
     length_retry_max_retries: int = Field(default=2, ge=0)
 

--- a/features/correction/rag/pipeline.py
+++ b/features/correction/rag/pipeline.py
@@ -19,7 +19,6 @@ from common.utils import (
 )
 from features.correction.config import get_correction_rag_config
 
-_DEFAULT_COMPANY_INSIGHT_MAX_LENGTH = 1500
 _DEFAULT_CALL_MAX_RETRIES = 3
 _DEFAULT_LENGTH_RETRY_MAX_RETRIES = 2
 
@@ -64,11 +63,7 @@ class RAGPipeline:
 
         self._keyword_count = rag_config.keyword_count
         self._max_results_per_keyword = rag_config.max_results_per_keyword
-        self._company_insight_max_length = getattr(
-            rag_config,
-            "company_insight_max_length",
-            _DEFAULT_COMPANY_INSIGHT_MAX_LENGTH,
-        )
+        self._company_insight_max_length = rag_config.company_insight_max_length
         self._call_max_retries = getattr(rag_config, "call_max_retries", _DEFAULT_CALL_MAX_RETRIES)
         self._length_retry_max_retries = getattr(
             rag_config,
@@ -407,7 +402,7 @@ class RAGPipeline:
         )
 
     def _truncate_company_insight(self, text: str) -> str:
-        """기업 인사이트 길이를 1500자로 제한"""
+        """기업 인사이트 길이를 설정된 최대 글자 수로 제한"""
         return truncate_to_char_limit(text, self._company_insight_max_length)
 
 

--- a/tests/test_app/test_api/test_v1/test_correction.py
+++ b/tests/test_app/test_api/test_v1/test_correction.py
@@ -451,8 +451,8 @@ def test_update_company_insight_rejects_payload_over_2000_chars(monkeypatch):
     assert cc.updated_company_insight is None
 
 
-def test_update_company_insight_openapi_documents_422_response(monkeypatch):
-    """기업 분석 수정 API는 요청 검증 실패 422 응답을 문서화한다."""
+def test_update_company_insight_openapi_documents_default_422_validation_schema(monkeypatch):
+    """기업 분석 수정 API는 기본 422 검증 오류 스키마를 문서화한다."""
     cc = DummyCorrectionClient(correction={"id": 123, "status": "COMPANY_INSIGHT"})
     client = _create_client(monkeypatch, cc)
 
@@ -462,7 +462,10 @@ def test_update_company_insight_openapi_documents_422_response(monkeypatch):
     responses = response.json()["paths"]["/api/v1/corrections/{correction_id}/company-insight"][
         "patch"
     ]["responses"]
-    assert responses["422"]["description"] == "요청 본문 검증 실패"
+    assert responses["422"]["description"] == "Validation Error"
+    assert responses["422"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/HTTPValidationError"
+    }
     assert "400" not in responses
 
 

--- a/tests/test_app/test_api/test_v1/test_correction.py
+++ b/tests/test_app/test_api/test_v1/test_correction.py
@@ -437,8 +437,22 @@ def test_update_company_insight_returns_200(monkeypatch):
     assert cc.updated_company_insight == (123, "수정 내용")
 
 
-def test_update_company_insight_openapi_documents_400_response(monkeypatch):
-    """기업 분석 수정 API는 수동 검증 400 응답을 문서화한다."""
+def test_update_company_insight_rejects_payload_over_2000_chars(monkeypatch):
+    """기업 분석 수정은 2000자를 초과한 payload를 422로 거부한다."""
+    cc = DummyCorrectionClient(correction={"id": 123, "status": "COMPANY_INSIGHT"})
+    client = _create_client(monkeypatch, cc)
+
+    response = client.patch(
+        f"/api/v1/corrections/{CORRECTION_ID}/company-insight",
+        json={"company_insight": "가" * 2001},
+    )
+
+    assert response.status_code == 422
+    assert cc.updated_company_insight is None
+
+
+def test_update_company_insight_openapi_documents_422_response(monkeypatch):
+    """기업 분석 수정 API는 요청 검증 실패 422 응답을 문서화한다."""
     cc = DummyCorrectionClient(correction={"id": 123, "status": "COMPANY_INSIGHT"})
     client = _create_client(monkeypatch, cc)
 
@@ -448,7 +462,8 @@ def test_update_company_insight_openapi_documents_400_response(monkeypatch):
     responses = response.json()["paths"]["/api/v1/corrections/{correction_id}/company-insight"][
         "patch"
     ]["responses"]
-    assert responses["400"]["description"] == "요청 데이터 수동 검증 실패"
+    assert responses["422"]["description"] == "요청 본문 검증 실패"
+    assert "400" not in responses
 
 
 @pytest.mark.asyncio

--- a/tests/test_features/test_correction/test_rag_pipeline.py
+++ b/tests/test_features/test_correction/test_rag_pipeline.py
@@ -319,7 +319,11 @@ async def test_run_applies_rag_config_values(monkeypatch, mock_tavily_client):
     monkeypatch.setattr(
         pipeline,
         "get_correction_rag_config",
-        lambda: SimpleNamespace(keyword_count=2, max_results_per_keyword=3),
+        lambda: SimpleNamespace(
+            keyword_count=2,
+            max_results_per_keyword=3,
+            company_insight_max_length=2000,
+        ),
     )
     monkeypatch.setattr(pipeline, "get_llm", lambda: dummy_llm)
 
@@ -363,7 +367,7 @@ def test_generate_insight_raises_on_llm_invoke_failure(monkeypatch):
 
 
 def test_generate_insight_prompt_contains_length_limit(monkeypatch):
-    """인사이트 생성 프롬프트에 1500자 제한이 포함된다."""
+    """인사이트 생성 프롬프트에 2000자 제한이 포함된다."""
     from features.correction.rag import pipeline
 
     dummy_llm = _DummyLLM(["기업 인사이트"])
@@ -377,7 +381,7 @@ def test_generate_insight_prompt_contains_length_limit(monkeypatch):
         job_title="백엔드",
     )
 
-    assert "1500자 이내" in dummy_llm.prompts[0]
+    assert "2000자 이내" in dummy_llm.prompts[0]
 
 
 def test_generate_insight_prompt_contains_required_report_sections(monkeypatch):
@@ -440,7 +444,7 @@ def test_generate_insight_retries_with_length_feedback(monkeypatch):
     """길이 초과 시 구조 유지 피드백을 포함해 재작성한다."""
     from features.correction.rag import pipeline
 
-    dummy_llm = _DummyLLM(["가" * 1600, "기업 인사이트"])
+    dummy_llm = _DummyLLM(["가" * 2100, "기업 인사이트"])
     monkeypatch.setattr(pipeline, "get_llm", lambda: dummy_llm)
     rag_pipeline = RAGPipeline()
 
@@ -502,22 +506,11 @@ def test_generate_insight_prompt_uses_dynamic_recent_years(monkeypatch):
     assert f"동향({recent_years} 최신 정보 우선)" in prompt
 
 
-def test_generate_insight_truncates_result_to_1500_chars(monkeypatch):
-    """인사이트 결과는 1500자를 초과하지 않도록 제한한다."""
+def test_generate_insight_truncates_result_to_2000_chars(monkeypatch):
+    """인사이트 결과는 2000자를 초과하지 않도록 제한한다."""
     from features.correction.rag import pipeline
 
-    monkeypatch.setattr(
-        pipeline,
-        "get_correction_rag_config",
-        lambda: SimpleNamespace(
-            keyword_count=6,
-            max_results_per_keyword=5,
-            company_insight_max_length=1500,
-            call_max_retries=1,
-            length_retry_max_retries=0,
-        ),
-    )
-    dummy_llm = _DummyLLM(["가" * 1600])
+    dummy_llm = _DummyLLM(["가" * 2100, "가" * 2100, "가" * 2100])
     monkeypatch.setattr(pipeline, "get_llm", lambda: dummy_llm)
     rag_pipeline = RAGPipeline()
 
@@ -528,4 +521,4 @@ def test_generate_insight_truncates_result_to_1500_chars(monkeypatch):
         job_title="백엔드",
     )
 
-    assert len(insight) == 1500
+    assert len(insight) == 2000

--- a/tests/test_features/test_correction/test_schemas.py
+++ b/tests/test_features/test_correction/test_schemas.py
@@ -5,6 +5,7 @@ import pytest
 from app.schemas.correction import (
     CorrectionResultResponse,
     CreateCorrectionRequest,
+    UpdateCompanyInsightRequest,
     UpdateEmphasisPointsRequest,
 )
 from features.correction.schemas import (
@@ -152,6 +153,19 @@ def test_update_emphasis_points_request_schema():
     request = UpdateEmphasisPointsRequest(emphasis_points="핵심 역량과 성과 지표를 강조")
 
     assert request.emphasis_points == "핵심 역량과 성과 지표를 강조"
+
+
+def test_update_company_insight_request_accepts_exactly_2000_chars():
+    """UpdateCompanyInsightRequest는 2000자까지 허용한다."""
+    request = UpdateCompanyInsightRequest(company_insight="가" * 2000)
+
+    assert len(request.company_insight) == 2000
+
+
+def test_update_company_insight_request_rejects_more_than_2000_chars():
+    """UpdateCompanyInsightRequest는 2001자를 거부한다."""
+    with pytest.raises(ValueError):
+        UpdateCompanyInsightRequest(company_insight="가" * 2001)
 
 
 def test_single_correction_line_comment_allows_null_for_keep():


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #190

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 기업 분석 정보(`company_insight`) 글자 수 제한과 설정 기본값을 1500자에서 2000자로 상향했습니다.
- RAG 파이프라인이 별도 1500 fallback 없이 설정 로더의 `company_insight_max_length`만 참조하도록 정리했습니다.
- `PATCH /corrections/{id}/company-insight`의 422 검증 동작을 유지하면서, OpenAPI는 FastAPI 기본 `HTTPValidationError` 스키마를 문서화하도록 정리했습니다.
- 2001자 초과 요청 거부와 기본 422 문서 스키마를 검증하는 API 테스트를 추가했습니다.

## 📸 스크린샷

- N/A (백엔드 설정/검증 로직 변경)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 작업 브랜치 `feat/190-change-limit-method`가 `dev` 기준 이전 커밋을 포함하고 있어, PR은 `origin/dev` 기준으로 현재 변경 커밋만 정리한 `feat/190-change-limit-method-clean` 브랜치에서 생성했습니다.
- 검증 명령:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest tests/test_features/test_correction/test_schemas.py tests/test_features/test_correction/test_rag_pipeline.py tests/test_app/test_api/test_v1/test_correction.py -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 회사 정보 입력 시 허용되는 최대 글자 수를 1500자에서 2000자로 증가했습니다.

* **버그 수정**
  * API 검증 오류 응답 처리를 개선하여 명확한 오류 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->