### PR TITLE
[Hotfix] dev → main (chat/stream 422 대응)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ opencode.json
 *.sqlite-wal
 
 docs/
+.omx/

--- a/app/api/v1/interview.py
+++ b/app/api/v1/interview.py
@@ -77,6 +77,24 @@ def _cleanup_temp_files(files: list[FilePayload] | None) -> None:
                 logger.warning("임시 업로드 파일 정리에 실패했습니다: %s", temp_path, exc_info=True)
 
 
+def _normalize_chat_message(message: str | None) -> str:
+    """채팅 입력 메시지를 file-only 호환 형태로 정규화한다."""
+    if message is None:
+        return ""
+    return message if message.strip() else ""
+
+
+def _validate_chat_input_presence(message: str | None, files: list[FilePayload] | None) -> str:
+    """메시지 또는 파일 중 하나는 반드시 존재하도록 검증한다."""
+    normalized_message = _normalize_chat_message(message)
+    if not normalized_message and not files:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="메시지 또는 파일 중 하나는 반드시 전송해야 합니다.",
+        )
+    return normalized_message
+
+
 async def _read_and_validate_files(files: list[UploadFile] | None) -> list[FilePayload]:
     """multipart 업로드 파일을 읽고 인터뷰 파일 참조 payload로 변환한다."""
     upload_files = list(files or [])
@@ -327,7 +345,7 @@ async def create_session_stream(request: CreateSessionRequest):
 )
 async def chat(
     session_id: str,
-    message: str = Form(..., min_length=1),
+    message: str | None = Form(None),
     mentioned_insight: str | None = Form(None),
     files: list[UploadFile] | None = File(None),
 ) -> ChatResponse:
@@ -339,11 +357,12 @@ async def chat(
     """
     service = get_interview_service()
     validated_files = await _read_and_validate_files(files)
+    normalized_message = _validate_chat_input_presence(message, validated_files)
 
     try:
         result = await service.process_message(
             session_id=session_id,
-            message=message,
+            message=normalized_message,
             files=validated_files,
             mentioned_insight=mentioned_insight,
         )
@@ -540,7 +559,7 @@ async def get_session_state(session_id: str) -> SessionStateResponse:
 )
 async def chat_stream(
     session_id: str,
-    message: str = Form(..., min_length=1),
+    message: str | None = Form(None),
     mentioned_insight: str | None = Form(None),
     files: list[UploadFile] | None = File(None),
 ):
@@ -556,12 +575,13 @@ async def chat_stream(
 
     service = get_interview_service()
     validated_files = await _read_and_validate_files(files)
+    normalized_message = _validate_chat_input_presence(message, validated_files)
 
     async def event_generator():
         """SSE 이벤트를 생성하는 비동기 제너레이터"""
         stream = service.process_message_stream(
             session_id=session_id,
-            message=message,
+            message=normalized_message,
             files=validated_files,
             mentioned_insight=mentioned_insight,
         )

--- a/features/interview/agents/nodes/retriever.py
+++ b/features/interview/agents/nodes/retriever.py
@@ -107,10 +107,12 @@ def _get_latest_user_message(state: InterviewState) -> str | None:
         if getattr(message, "type", None) == "human":
             content = getattr(message, "content", None)
             if isinstance(content, str):
-                return content
+                normalized = content.strip()
+                return normalized or None
             if content is None:
                 return None
-            return str(content)
+            normalized = str(content).strip()
+            return normalized or None
     return None
 
 
@@ -138,6 +140,19 @@ def _upsert_insight_turn_history(
     turn_number = new_record["turn_number"]
     filtered_history = [record for record in history if record["turn_number"] != turn_number]
     return [*filtered_history, new_record]
+
+
+def _should_record_insight_turn(
+    user_message: str | None,
+    mentioned_insight: str | None,
+) -> bool:
+    """현재 턴의 인사이트 복원 이력을 남길지 판단한다."""
+    return user_message is not None or bool(mentioned_insight)
+
+
+def _history_user_message(user_message: str | None) -> str:
+    """복원 이력에 저장할 user_message 값을 반환한다."""
+    return "" if user_message is None else user_message
 
 
 def _filter_search_results(
@@ -171,19 +186,25 @@ async def run(state: InterviewState) -> InterviewState:
 
     normalized_state = ensure_interview_state_defaults(state)
     user_message = _get_latest_user_message(normalized_state)
+    mentioned_insight = normalized_state.get("mentioned_insight")
+    should_record_turn = _should_record_insight_turn(user_message, mentioned_insight)
 
     try:
         store = get_insight_store()
     except RuntimeError:
         logger.warning("InsightStore가 초기화되지 않음. 인사이트 검색을 건너뜁니다.")
-        if user_message is None:
+        if not should_record_turn:
             return {
                 **normalized_state,
                 "retrieved_insights": [],
                 "next_node": "analyst",
             }
 
-        insight_turn_record = _build_insight_turn_record(normalized_state, [], user_message)
+        insight_turn_record = _build_insight_turn_record(
+            normalized_state,
+            [],
+            _history_user_message(user_message),
+        )
 
         return {
             **normalized_state,
@@ -199,46 +220,40 @@ async def run(state: InterviewState) -> InterviewState:
     similar_insights: list[InsightLog] = []
     if user_message is None:
         logger.warning("메시지가 비어있어 인사이트 검색을 건너뜁니다.")
-        return {
-            **normalized_state,
-            "retrieved_insights": [],
-            "next_node": "analyst",
-        }
-
-    try:
-        top_k = max(0, min(_DEFAULT_TOP_K, 3))
-        similar_insights = await store.search_similar(
-            query=user_message,
-            user_id=normalized_state["user_id"],
-            top_k=top_k,
-            threshold=_DEFAULT_THRESHOLD,
-        )
-        similar_insights = _filter_search_results(
-            [_with_source(insight, "search") for insight in similar_insights],
-            threshold=_DEFAULT_THRESHOLD,
-            top_k=top_k,
-        )
-        logger.info(
-            "🔎 유사 인사이트 %d건 검색됨 (user_id=%s, top_k=%d, threshold=%.2f)",
-            len(similar_insights),
-            normalized_state["user_id"],
-            top_k,
-            _DEFAULT_THRESHOLD,
-        )
-        # 각 인사이트의 유사도 수치 로그
-        for insight in similar_insights:
-            logger.info(
-                "  📌 score=%.4f | id=%s | title='%s'",
-                insight.get("similarity_score", 0.0),
-                insight["id"],
-                insight["title"][:40],
+    else:
+        try:
+            top_k = max(0, min(_DEFAULT_TOP_K, 3))
+            similar_insights = await store.search_similar(
+                query=user_message,
+                user_id=normalized_state["user_id"],
+                top_k=top_k,
+                threshold=_DEFAULT_THRESHOLD,
             )
-    except Exception:
-        logger.exception("인사이트 유사도 검색 중 오류 발생")
+            similar_insights = _filter_search_results(
+                [_with_source(insight, "search") for insight in similar_insights],
+                threshold=_DEFAULT_THRESHOLD,
+                top_k=top_k,
+            )
+            logger.info(
+                "🔎 유사 인사이트 %d건 검색됨 (user_id=%s, top_k=%d, threshold=%.2f)",
+                len(similar_insights),
+                normalized_state["user_id"],
+                top_k,
+                _DEFAULT_THRESHOLD,
+            )
+            # 각 인사이트의 유사도 수치 로그
+            for insight in similar_insights:
+                logger.info(
+                    "  📌 score=%.4f | id=%s | title='%s'",
+                    insight.get("similarity_score", 0.0),
+                    insight["id"],
+                    insight["title"][:40],
+                )
+        except Exception:
+            logger.exception("인사이트 유사도 검색 중 오류 발생")
 
     # 2. @ 멘션 인사이트 강제 포함
     mentioned_insights: list[InsightLog] = []
-    mentioned_insight = normalized_state.get("mentioned_insight")
 
     if mentioned_insight:
         try:
@@ -253,13 +268,25 @@ async def run(state: InterviewState) -> InterviewState:
 
     # 3. 병합 및 중복 제거 (해당 턴의 인사이트만 / 누적하지 않음)
     all_insights = _merge_and_deduplicate(similar_insights, mentioned_insights)
-    insight_turn_record = _build_insight_turn_record(normalized_state, all_insights, user_message)
 
     logger.info(
         "✅ 인사이트 병합 완료: 유사=%d, 멘션=%d → 최종=%d",
         len(similar_insights),
         len(mentioned_insights),
         len(all_insights),
+    )
+
+    if not should_record_turn:
+        return {
+            **normalized_state,
+            "retrieved_insights": all_insights,
+            "next_node": "analyst",
+        }
+
+    insight_turn_record = _build_insight_turn_record(
+        normalized_state,
+        all_insights,
+        _history_user_message(user_message),
     )
 
     # 검색 후 Analyst 노드로 전환

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -32,6 +32,13 @@ logger = logging.getLogger(__name__)
 _service: "InterviewService | None" = None
 
 
+def _normalize_user_message(message: str | None) -> str:
+    """file-only 요청을 위해 사용자 메시지를 안전하게 정규화한다."""
+    if message is None:
+        return ""
+    return message if message.strip() else ""
+
+
 class InterviewService:
     """
     인터뷰 세션 관리 및 그래프 실행 오케스트레이터
@@ -524,7 +531,7 @@ class InterviewService:
     async def process_message(
         self,
         session_id: str,
-        message: str,
+        message: str | None,
         files: list[FilePayload] | None = None,
         mentioned_insight: str | None = None,
     ) -> dict:
@@ -533,7 +540,7 @@ class InterviewService:
 
         Args:
             session_id: 세션 ID
-            message: 사용자 메시지
+            message: 사용자 메시지 (file-only 요청이면 None 가능)
             files: 현재 턴에서 업로드된 파일 payload 목록 (선택)
             mentioned_insight: @ 멘션으로 참조한 인사이트 로그 ID (선택)
 
@@ -554,9 +561,11 @@ class InterviewService:
         if current_state is None:
             raise ValueError(f"세션을 찾을 수 없습니다: {session_id}")
 
+        normalized_message = _normalize_user_message(message)
+
         # 입력 상태 구성
         input_state: dict = {
-            "messages": [HumanMessage(content=message)],
+            "messages": [HumanMessage(content=normalized_message)],
             "current_turn_files": files or [],
             "file_contexts": [],
             "mentioned_insight": mentioned_insight,
@@ -640,7 +649,7 @@ class InterviewService:
     async def process_message_stream(
         self,
         session_id: str,
-        message: str,
+        message: str | None,
         files: list[FilePayload] | None = None,
         mentioned_insight: str | None = None,
     ) -> AsyncGenerator[dict, None]:
@@ -652,7 +661,7 @@ class InterviewService:
 
         Args:
             session_id: 세션 ID
-            message: 사용자 메시지
+            message: 사용자 메시지 (file-only 요청이면 None 가능)
             files: 현재 턴에서 업로드된 파일 payload 목록 (선택)
             mentioned_insight: @ 멘션으로 참조한 인사이트 로그 ID (선택)
 
@@ -680,9 +689,11 @@ class InterviewService:
             }
             return
 
+        normalized_message = _normalize_user_message(message)
+
         # 2. 입력 상태 구성
         input_state: dict = {
-            "messages": [HumanMessage(content=message)],
+            "messages": [HumanMessage(content=normalized_message)],
             "current_turn_files": files or [],
             "file_contexts": [],
             "mentioned_insight": mentioned_insight,

--- a/tests/test_app/test_api/test_v1/test_interview.py
+++ b/tests/test_app/test_api/test_v1/test_interview.py
@@ -303,6 +303,67 @@ def test_chat_accepts_multipart_form_and_passes_file_payloads(monkeypatch, tmp_p
     assert "file_turn_history" not in response.json()
 
 
+def test_chat_accepts_file_only_multipart_form(monkeypatch, tmp_path):
+    """chat 엔드포인트는 message 없이 파일만 있어도 허용한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+    temp_file_path = tmp_path / "interview-upload-1.pdf"
+    monkeypatch.setattr(interview_api, "_create_temp_upload_file", lambda _suffix: temp_file_path)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat",
+        files=[("files", ("portfolio.pdf", b"%PDF-1.4", "application/pdf"))],
+    )
+
+    assert response.status_code == 200
+    assert service.process_calls[0]["message"] == ""
+    assert service.process_calls[0]["files"] == [
+        {
+            "filename": "portfolio.pdf",
+            "content_type": "application/pdf",
+            "temp_path": str(temp_file_path),
+            "file_size": len(b"%PDF-1.4"),
+        }
+    ]
+    assert temp_file_path.exists() is False
+
+
+def test_chat_rejects_request_without_message_and_files(monkeypatch):
+    """chat 엔드포인트는 message와 files가 모두 없으면 400을 반환한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+
+    response = client.post("/api/v1/interview/sessions/session-1/chat", data={})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "메시지 또는 파일 중 하나는 반드시 전송해야 합니다."
+    assert service.process_calls == []
+
+
+def test_normalize_chat_message_returns_blank_for_missing_or_whitespace():
+    """채팅 입력 정규화 helper는 file-only 판정용 blank를 반환한다."""
+    assert interview_api._normalize_chat_message(None) == ""
+    assert interview_api._normalize_chat_message("") == ""
+    assert interview_api._normalize_chat_message("   ") == ""
+    assert interview_api._normalize_chat_message(" 안녕하세요 ") == " 안녕하세요 "
+
+
+def test_validate_chat_input_presence_accepts_message_or_files():
+    """채팅 입력 검증 helper는 message 또는 files 중 하나가 있으면 통과한다."""
+    assert interview_api._validate_chat_input_presence("안녕하세요", []) == "안녕하세요"
+    assert interview_api._validate_chat_input_presence(None, [{"filename": "portfolio.pdf"}]) == ""
+    assert interview_api._validate_chat_input_presence("   ", [{"filename": "portfolio.pdf"}]) == ""
+
+
+def test_validate_chat_input_presence_rejects_blank_without_files():
+    """채팅 입력 검증 helper는 blank message와 빈 파일 조합을 거부한다."""
+    with pytest.raises(HTTPException) as exc_info:
+        interview_api._validate_chat_input_presence("   ", [])
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "메시지 또는 파일 중 하나는 반드시 전송해야 합니다."
+
+
 def test_chat_cleans_up_temp_files_when_service_raises(monkeypatch, tmp_path):
     """서비스 오류가 나도 임시 업로드 파일은 정리한다."""
     client = _create_client(monkeypatch, DummyInterviewService({"missing-session"}))

--- a/tests/test_app/test_api/test_v1/test_interview_file_upload.py
+++ b/tests/test_app/test_api/test_v1/test_interview_file_upload.py
@@ -89,6 +89,63 @@ def test_chat_stream_accepts_multipart_with_files(monkeypatch, tmp_path):
     assert (tmp_path / "interview-upload-2.jpg").exists() is False
 
 
+def test_chat_stream_accepts_file_only_multipart(monkeypatch, tmp_path):
+    """chat_stream 엔드포인트는 message 없이 파일만 있어도 허용한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+    temp_file_path = tmp_path / "interview-upload-1.pdf"
+    monkeypatch.setattr(interview_api, "_create_temp_upload_file", lambda _suffix: temp_file_path)
+    _patch_streaming_response(monkeypatch)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        files=[("files", ("portfolio.pdf", b"%PDF-1.4", "application/pdf"))],
+    )
+
+    assert response.status_code == 200
+    assert service.stream_calls[0]["message"] == ""
+    assert service.stream_calls[0]["files"] == [
+        {
+            "filename": "portfolio.pdf",
+            "content_type": "application/pdf",
+            "temp_path": str(temp_file_path),
+            "file_size": len(b"%PDF-1.4"),
+        }
+    ]
+    assert temp_file_path.exists() is False
+
+
+def test_chat_stream_rejects_request_without_message_and_files(monkeypatch):
+    """chat_stream 엔드포인트는 message와 files가 모두 없으면 거부한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+
+    response = client.post("/api/v1/interview/sessions/session-1/chat/stream", data={})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "메시지 또는 파일 중 하나는 반드시 전송해야 합니다."
+    assert service.stream_calls == []
+
+
+def test_chat_stream_allows_blank_message_when_files_exist(monkeypatch, tmp_path):
+    """chat_stream 엔드포인트는 공백-only message와 파일 조합을 file-only로 처리한다."""
+    service = DummyInterviewService()
+    client = _create_client(monkeypatch, service)
+    temp_file_path = tmp_path / "interview-upload-1.pdf"
+    monkeypatch.setattr(interview_api, "_create_temp_upload_file", lambda _suffix: temp_file_path)
+    _patch_streaming_response(monkeypatch)
+
+    response = client.post(
+        "/api/v1/interview/sessions/session-1/chat/stream",
+        data={"message": "   "},
+        files=[("files", ("portfolio.pdf", b"%PDF-1.4", "application/pdf"))],
+    )
+
+    assert response.status_code == 200
+    assert service.stream_calls[0]["message"] == ""
+    assert temp_file_path.exists() is False
+
+
 def test_chat_stream_rejects_more_than_3_files(monkeypatch):
     """chat_stream 엔드포인트는 4개 이상 파일 업로드를 거부한다."""
     service = DummyInterviewService()

--- a/tests/test_features/test_interview/test_retriever.py
+++ b/tests/test_features/test_interview/test_retriever.py
@@ -225,6 +225,132 @@ async def test_run_appends_empty_history_when_store_is_unavailable(monkeypatch):
     ]
 
 
+@pytest.mark.asyncio
+async def test_run_skips_similarity_search_for_blank_message(monkeypatch):
+    """blank 최신 사용자 메시지에 mention이 없으면 유사도 검색과 히스토리 append를 생략한다."""
+    mock_store = AsyncMock()
+    monkeypatch.setattr(retriever, "get_insight_store", lambda: mock_store)
+
+    result = await retriever.run(
+        {
+            "turn_number": 3,
+            "user_id": "user-1",
+            "messages": [HumanMessage(content="   ")],
+            "mentioned_insight": None,
+            "insight_turn_history": [],
+        }
+    )
+
+    assert result["retrieved_insights"] == []
+    assert result["insight_turn_history"] == []
+    assert result["next_node"] == "analyst"
+    mock_store.search_similar.assert_not_awaited()
+    mock_store.get_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_fetches_mentioned_insight_for_blank_message(monkeypatch):
+    """blank 메시지여도 mentioned_insight가 있으면 explicit mention fetch를 수행한다."""
+    mock_store = AsyncMock()
+    mock_store.get_by_id.return_value = {
+        "id": "mention-3",
+        "title": "멘션 인사이트",
+        "activity_name": "활동3",
+        "category": "문제해결",
+        "content": "멘션 내용",
+        "similarity_score": None,
+    }
+    monkeypatch.setattr(retriever, "get_insight_store", lambda: mock_store)
+
+    result = await retriever.run(
+        {
+            "turn_number": 4,
+            "user_id": "user-1",
+            "messages": [HumanMessage(content="   ")],
+            "mentioned_insight": "mention-3",
+            "insight_turn_history": [],
+        }
+    )
+
+    assert result["retrieved_insights"] == [
+        {
+            "id": "mention-3",
+            "title": "멘션 인사이트",
+            "activity_name": "활동3",
+            "category": "문제해결",
+            "content": "멘션 내용",
+            "similarity_score": None,
+            "source": "mention",
+        }
+    ]
+    assert result["insight_turn_history"] == [
+        {
+            "turn_number": 4,
+            "user_message": "",
+            "mentioned_insight": "mention-3",
+            "insights": result["retrieved_insights"],
+        }
+    ]
+    assert result["next_node"] == "analyst"
+    mock_store.search_similar.assert_not_awaited()
+    mock_store.get_by_id.assert_awaited_once_with("mention-3")
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_append_history_for_blank_message_when_store_missing(monkeypatch):
+    """스토어가 없어도 blank 메시지 턴은 bogus insight history를 남기지 않는다."""
+    monkeypatch.setattr(
+        retriever,
+        "get_insight_store",
+        lambda: (_ for _ in ()).throw(RuntimeError("store missing")),
+    )
+
+    result = await retriever.run(
+        {
+            "turn_number": 4,
+            "user_id": "user-1",
+            "messages": [HumanMessage(content="")],
+            "mentioned_insight": None,
+            "insight_turn_history": [],
+        }
+    )
+
+    assert result["retrieved_insights"] == []
+    assert result["insight_turn_history"] == []
+    assert result["next_node"] == "analyst"
+
+
+@pytest.mark.asyncio
+async def test_run_appends_empty_history_for_blank_message_with_mention_when_store_missing(monkeypatch):
+    """스토어가 없어도 blank+mention 턴은 빈 user_message로 복원 이력을 남긴다."""
+    monkeypatch.setattr(
+        retriever,
+        "get_insight_store",
+        lambda: (_ for _ in ()).throw(RuntimeError("store missing")),
+    )
+
+    result = await retriever.run(
+        {
+            "turn_number": 5,
+            "user_id": "user-1",
+            "messages": [HumanMessage(content="")],
+            "mentioned_insight": "mention-5",
+            "insight_turn_history": [],
+        }
+    )
+
+    assert result["retrieved_insights"] == []
+    assert result["insight_turn_history"] == [
+        {
+            "turn_number": 5,
+            "user_message": "",
+            "mentioned_insight": "mention-5",
+            "insights": [],
+        }
+    ]
+    assert result["next_node"] == "analyst"
+
+
 def test_upsert_insight_turn_history_replaces_same_turn_record():
     """같은 turn_number 기록은 append 대신 교체한다."""
     history = [

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -271,6 +271,46 @@ async def test_process_message_with_files(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_process_message_accepts_file_only_request(monkeypatch):
+    """file-only 요청이면 빈 HumanMessage를 주입해 기존 graph 흐름을 유지한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(values={"session_id": "session_1"})
+    dummy_graph.invoke_result = {
+        "messages": [AIMessage(content="응답")],
+        "current_stage": 2,
+        "stage_progress": {"fixed_q_used": 2},
+        "overall_completion_percentage": 40.0,
+        "all_stages_complete": False,
+    }
+
+    service = _build_service(monkeypatch, dummy_graph)
+
+    await service.process_message(
+        session_id="session_1",
+        message=None,
+        files=[
+            {
+                "filename": "portfolio.pdf",
+                "content_type": "application/pdf",
+                "temp_path": "/tmp/portfolio.pdf",
+            }
+        ],
+    )
+
+    invocation = dummy_graph.invocations[0]
+    assert isinstance(invocation["state"]["messages"][0], HumanMessage)
+    assert invocation["state"]["messages"][0].content == ""
+    assert invocation["state"]["current_turn_files"] == [
+        {
+            "filename": "portfolio.pdf",
+            "content_type": "application/pdf",
+            "temp_path": "/tmp/portfolio.pdf",
+        }
+    ]
+    assert invocation["state"]["file_contexts"] == []
+
+
+@pytest.mark.asyncio
 async def test_process_message_returns_none_when_all_complete(monkeypatch):
     """모든 단계 완료 상태면 ai_response를 None으로 반환한다."""
     dummy_graph = DummyGraph()

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -264,6 +264,61 @@ async def test_process_message_stream_resets_current_turn_files_when_no_files(mo
 
 
 @pytest.mark.anyio
+async def test_process_message_stream_accepts_file_only_request(monkeypatch):
+    """스트리밍 경로도 file-only 요청이면 빈 HumanMessage를 주입한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "messages": [AIMessage(content="최종 응답")],
+            "current_stage": 1,
+            "stage_progress": {
+                "fixed_q_used": 0,
+                "fixed_q_total": 1,
+                "generated_q_used": 0,
+                "generated_q_max": 0,
+                "force_all_generated_q": False,
+                "is_complete": False,
+            },
+            "overall_completion_percentage": 25.0,
+            "all_stages_complete": False,
+        }
+    )
+    dummy_graph.stream_events = []
+
+    monkeypatch.setattr(
+        "features.interview.service.build_graph", lambda checkpointer=None: dummy_graph
+    )
+    monkeypatch.setattr("features.interview.service.get_checkpointer", lambda: object())
+    service = InterviewService()
+
+    _ = [
+        event
+        async for event in service.process_message_stream(
+            session_id="session-1",
+            message=None,
+            files=[
+                {
+                    "filename": "portfolio.pdf",
+                    "content_type": "application/pdf",
+                    "temp_path": "/tmp/portfolio.pdf",
+                }
+            ],
+        )
+    ]
+
+    invocation = dummy_graph.astream_calls[0]["state"]
+    assert invocation["messages"] == [HumanMessage(content="")]
+    assert invocation["current_turn_files"] == [
+        {
+            "filename": "portfolio.pdf",
+            "content_type": "application/pdf",
+            "temp_path": "/tmp/portfolio.pdf",
+        }
+    ]
+    assert invocation["file_contexts"] == []
+
+
+@pytest.mark.anyio
 async def test_process_message_stream_returns_none_when_all_complete(monkeypatch):
     """모든 단계 완료 상태면 message_complete의 ai_response는 null이다."""
     dummy_graph = DummyGraph()


### PR DESCRIPTION
## 🎯 배포 버전
v0.3.1-hotfix 배포

## 🚨 배포 목적
prod 인터뷰 스트리밍(`/chat/stream`)에서 발생한 422 이슈 대응을 위해
dev의 file-only 입력 허용 변경(PR #196)을 main에 반영합니다.

## 📦 포함 범위
- 포함 커밋: `c29f947` (PR #196)
- 주요 변경:
  - `chat` / `chat_stream`의 `message`를 optional로 변경
  - `message or files` 유효성 검증 추가(둘 다 없으면 400)
  - file-only 요청 시 서비스 내부에서 `""`로 정규화하여 기존 LangGraph 턴 흐름 유지
  - no-text 턴에서 `mentioned_insight` explicit fetch 동작 보완
  - 관련 회귀 테스트 추가

## 🔁 롤백 계획
문제 발생 시 `c29f947` revert로 즉시 롤백 가능합니다.