### PR TITLE
[Feat] 경험정리 정규 플로우 고정 질문 우선 진행

### DIFF
--- a/features/interview/agents/nodes/analyst.py
+++ b/features/interview/agents/nodes/analyst.py
@@ -27,7 +27,6 @@ from .utils import (
     _format_file_contexts,
     _format_retrieved_insights,
     _get_conversation_context,
-    _get_incomplete_fields,
 )
 
 logger = logging.getLogger(__name__)
@@ -307,29 +306,7 @@ def _is_stage_complete(
 ) -> bool:
     """현재 단계 완료 여부 판단"""
     progress = state["stage_progress"]
-
-    fixed_q_exhausted = progress["fixed_q_used"] >= progress["fixed_q_total"]
-    generated_q_exhausted = progress["generated_q_used"] >= progress["generated_q_max"]
-
-    # 조건 1: 고정/생성 질문 모두 소진
-    if fixed_q_exhausted and generated_q_exhausted:
-        return True
-
-    # 조건 2: 고정 질문 소진 + 동적 질문 비활성화
-    if fixed_q_exhausted and not enable_dynamic_followup:
-        return True
-
-    # 조건 3: 고정 질문 소진 + 미수집 필드 없음 + 생성 질문 강제 소진 아님
-    if fixed_q_exhausted and not stage_config.force_all_generated_questions:
-        incomplete_fields = _get_incomplete_fields(
-            state=state,
-            stage_config=stage_config,
-            collected_data=collected_data,
-        )
-        if not incomplete_fields:
-            return True
-
-    return False
+    return progress["fixed_q_used"] >= progress["fixed_q_total"]
 
 
 def _format_required_fields(required_fields: dict[str, dict[str, str]]) -> str:

--- a/features/interview/agents/nodes/question_generator.py
+++ b/features/interview/agents/nodes/question_generator.py
@@ -264,7 +264,6 @@ def run(state: InterviewState) -> InterviewState:
     플로우:
     - 첫 턴: 첫 고정 질문 생성
     - 고정 질문 단계: 순차적으로 고정 질문 생성
-    - 생성 질문 단계: 미수집 필드 기반 동적 질문 생성
     - 질문 소진: 안전한 fallback 질문 생성
     """
 
@@ -305,14 +304,6 @@ def run(state: InterviewState) -> InterviewState:
         updated_progress = {
             **progress,
             "fixed_q_used": progress["fixed_q_used"] + 1,
-        }
-
-    elif progress["generated_q_used"] < progress["generated_q_max"]:
-        # ===== 생성 질문 생성 =====
-        question, llm_error = _generate_dynamic_question(normalized_state, stage_config)
-        updated_progress = {
-            **progress,
-            "generated_q_used": progress["generated_q_used"] + 1,
         }
 
     else:

--- a/features/interview/config/loader.py
+++ b/features/interview/config/loader.py
@@ -18,6 +18,14 @@ class StageConfig(BaseModel):
     max_generated_questions: int
     force_all_generated_questions: bool
 
+    @field_validator("max_generated_questions")
+    @classmethod
+    def validate_max_generated_questions(cls, value: int) -> int:
+        """단계별 생성 질문 수는 0 이상이어야 한다."""
+        if value < 0:
+            raise ValueError("max_generated_questions는 0 이상이어야 합니다.")
+        return value
+
 
 class GlobalConfig(BaseModel):
     """전역 설정 스키마"""

--- a/features/interview/config/stages.yaml
+++ b/features/interview/config/stages.yaml
@@ -19,7 +19,7 @@ stages:
                 description: "전체 참여 인원 수와 본인의 포지션"
             target_audience:
                 description: "결과물 또는 활동의 예상 사용자, 수혜자 또는 구체적인 페르소나"
-        max_generated_questions: 2
+        max_generated_questions: 0
         force_all_generated_questions: false
 
     2:
@@ -31,8 +31,8 @@ stages:
         required_fields:
             work_categories:
                 description: "2개 이상의 업무 카테고리 (리스트)"
-        max_generated_questions: 3
-        force_all_generated_questions: true
+        max_generated_questions: 0
+        force_all_generated_questions: false
 
     3:
         name: "문제 해결과 논리"
@@ -44,8 +44,8 @@ stages:
         required_fields:
             problem_episodes:
                 description: "2개 이상의 에피소드 (리스트)"
-        max_generated_questions: 3
-        force_all_generated_questions: true
+        max_generated_questions: 0
+        force_all_generated_questions: false
 
     4:
         name: "성과 및 회고"
@@ -67,7 +67,7 @@ stages:
                 description: "대상, 관계 또는 해당 업무나 산업에 대해 새롭게 얻은 관점"
             future_plans:
                 description: "아쉬웠던 점을 보완하기 위한 구체적인 개선 방향 또는 학습 계획"
-        max_generated_questions: 2
+        max_generated_questions: 0
         force_all_generated_questions: false
 
 # 전역 설정 (임시)

--- a/tests/test_features/test_interview/test_analyst.py
+++ b/tests/test_features/test_interview/test_analyst.py
@@ -105,8 +105,8 @@ def test_format_retrieved_insights_includes_activity_source_and_similarity():
     assert "유사도: 없음" in formatted
 
 
-def test_run_moves_to_next_stage_when_questions_exhausted(monkeypatch):
-    """고정/생성 질문이 모두 소진되면 다음 단계로 전환한다."""
+def test_run_moves_to_next_stage_when_fixed_questions_exhausted(monkeypatch):
+    """고정 질문이 소진되면 생성 질문 상태와 무관하게 다음 단계로 전환한다."""
     response = AnalystResponse(
         fields=[
             AnalystFieldResult(
@@ -126,7 +126,9 @@ def test_run_moves_to_next_stage_when_questions_exhausted(monkeypatch):
         experience_name="테스트 경험",
     )
     state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
-    state["stage_progress"]["generated_q_used"] = state["stage_progress"]["generated_q_max"]
+    state["stage_progress"]["generated_q_used"] = 0
+    state["stage_progress"]["generated_q_max"] = 99
+    state["stage_progress"]["force_all_generated_q"] = True
 
     result = analyst.run(state)
     stage_2_config = load_stage_config(2)
@@ -144,8 +146,8 @@ def test_run_moves_to_next_stage_when_questions_exhausted(monkeypatch):
     assert result["stage_progress"]["is_complete"] is False
 
 
-def test_run_moves_to_next_stage_when_dynamic_followup_disabled(monkeypatch):
-    """고정 질문 소진 후 동적 질문이 비활성화면 단계를 완료 처리한다."""
+def test_run_moves_to_next_stage_when_dynamic_followup_enabled(monkeypatch):
+    """동적 질문 설정이 켜져 있어도 고정 질문이 소진되면 단계를 완료 처리한다."""
     response = AnalystResponse(fields=[])
     monkeypatch.setattr(
         analyst, "get_analyst_llm", lambda temperature=0.3: _mock_analyst_llm(response)
@@ -153,7 +155,7 @@ def test_run_moves_to_next_stage_when_dynamic_followup_disabled(monkeypatch):
     monkeypatch.setattr(
         analyst,
         "get_global_config",
-        lambda: _DummyGlobalConfig(enable_dynamic_followup=False),
+        lambda: _DummyGlobalConfig(enable_dynamic_followup=True),
     )
 
     state = get_initial_interview_state(
@@ -163,6 +165,7 @@ def test_run_moves_to_next_stage_when_dynamic_followup_disabled(monkeypatch):
     )
     state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
     state["stage_progress"]["generated_q_used"] = 0
+    state["stage_progress"]["generated_q_max"] = 99
 
     result = analyst.run(state)
 
@@ -170,8 +173,10 @@ def test_run_moves_to_next_stage_when_dynamic_followup_disabled(monkeypatch):
     assert result["next_node"] == "question_generator"
 
 
-def test_run_moves_to_next_stage_when_required_fields_complete(monkeypatch):
-    """고정 질문 소진 후 모든 필드가 충분하면 단계를 완료 처리한다."""
+def test_run_keeps_stage_when_fixed_questions_remain_even_if_required_fields_complete(
+    monkeypatch,
+):
+    """필수 필드가 충분해도 고정 질문이 남아 있으면 단계를 완료하지 않는다."""
     response = AnalystResponse(fields=[])
     monkeypatch.setattr(
         analyst, "get_analyst_llm", lambda temperature=0.3: _mock_analyst_llm(response)
@@ -183,9 +188,8 @@ def test_run_moves_to_next_stage_when_required_fields_complete(monkeypatch):
         experience_name="테스트 경험",
     )
     stage_1_config = load_stage_config(1)
-    state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
-    state["stage_progress"]["generated_q_used"] = 0
-    state["stage_progress"]["force_all_generated_q"] = False
+    state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"] - 1
+    state["stage_progress"]["generated_q_used"] = state["stage_progress"]["generated_q_max"]
     state["collected_data"]["stage_1"] = {
         field_name: {
             "field_name": field_name,
@@ -198,8 +202,9 @@ def test_run_moves_to_next_stage_when_required_fields_complete(monkeypatch):
 
     result = analyst.run(state)
 
-    assert result["current_stage"] == 2
+    assert result["current_stage"] == 1
     assert result["next_node"] == "question_generator"
+    assert result["stage_progress"]["is_complete"] is False
 
 
 def test_run_marks_all_complete_at_stage_4(monkeypatch):
@@ -233,7 +238,9 @@ def test_run_marks_all_complete_at_stage_4(monkeypatch):
     state["stage_progress"]["generated_q_max"] = stage_4_config.max_generated_questions
     state["stage_progress"]["force_all_generated_q"] = stage_4_config.force_all_generated_questions
     state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
-    state["stage_progress"]["generated_q_used"] = state["stage_progress"]["generated_q_max"]
+    state["stage_progress"]["generated_q_used"] = 0
+    state["stage_progress"]["generated_q_max"] = 99
+    state["stage_progress"]["force_all_generated_q"] = True
 
     result = analyst.run(state)
 

--- a/tests/test_features/test_interview/test_analyst.py
+++ b/tests/test_features/test_interview/test_analyst.py
@@ -235,8 +235,6 @@ def test_run_marks_all_complete_at_stage_4(monkeypatch):
     state["current_stage"] = 4
     stage_4_config = load_stage_config(4)
     state["stage_progress"]["fixed_q_total"] = len(stage_4_config.fixed_questions)
-    state["stage_progress"]["generated_q_max"] = stage_4_config.max_generated_questions
-    state["stage_progress"]["force_all_generated_q"] = stage_4_config.force_all_generated_questions
     state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
     state["stage_progress"]["generated_q_used"] = 0
     state["stage_progress"]["generated_q_max"] = 99

--- a/tests/test_features/test_interview/test_config.py
+++ b/tests/test_features/test_interview/test_config.py
@@ -35,7 +35,6 @@ def test_load_stage_config_stage_1():
     assert "problem_definition" in config.required_fields
     assert "project_duration" in config.required_fields
     assert config.max_generated_questions == 0
-    assert config.force_all_generated_questions is False
 
 
 def test_load_all_stages():
@@ -90,7 +89,6 @@ def test_regular_flow_disables_generated_questions(stage):
     config = load_stage_config(stage)
 
     assert config.max_generated_questions == 0
-    assert config.force_all_generated_questions is False
 
 
 def test_get_global_config():

--- a/tests/test_features/test_interview/test_config.py
+++ b/tests/test_features/test_interview/test_config.py
@@ -34,7 +34,7 @@ def test_load_stage_config_stage_1():
     assert "project_background" in config.required_fields
     assert "problem_definition" in config.required_fields
     assert "project_duration" in config.required_fields
-    assert config.max_generated_questions == 2
+    assert config.max_generated_questions == 0
     assert config.force_all_generated_questions is False
 
 
@@ -71,8 +71,26 @@ def test_all_stages_have_required_fields(stage):
     assert config.description
     assert len(config.fixed_questions) >= 1
     assert len(config.required_fields) >= 1
-    assert config.max_generated_questions >= 1
+    assert config.max_generated_questions >= 0
     assert isinstance(config.force_all_generated_questions, bool)
+
+
+def test_regular_flow_fixed_question_counts():
+    """정규 플로우는 단계별 고정 질문 3, 2, 3, 3개로 구성된다."""
+    stages = get_all_stages()
+    expected_counts = {1: 3, 2: 2, 3: 3, 4: 3}
+
+    assert {stage: len(config.fixed_questions) for stage, config in stages.items()} == expected_counts
+    assert sum(len(config.fixed_questions) for config in stages.values()) == 11
+
+
+@pytest.mark.parametrize("stage", [1, 2, 3, 4])
+def test_regular_flow_disables_generated_questions(stage):
+    """정규 단계에서는 생성 질문을 사용하지 않는다."""
+    config = load_stage_config(stage)
+
+    assert config.max_generated_questions == 0
+    assert config.force_all_generated_questions is False
 
 
 def test_get_global_config():
@@ -94,6 +112,21 @@ def test_invalid_yaml_type_raises_korean_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(loader.yaml, "safe_load", lambda _: [])
 
     with pytest.raises(ValueError, match="인터뷰 설정 파일 형식이 올바르지 않습니다"):
+        loader._load_stages_yaml()
+
+    loader._load_stages_yaml.cache_clear()
+
+
+def test_negative_max_generated_questions_raises_error(monkeypatch: pytest.MonkeyPatch):
+    """단계별 생성 질문 수는 0 이상이어야 한다."""
+    from features.interview.config import loader
+
+    loader._load_stages_yaml.cache_clear()
+    data = copy.deepcopy(_load_raw_stages_yaml())
+    data["stages"][1]["max_generated_questions"] = -1
+    monkeypatch.setattr(loader.yaml, "safe_load", lambda _: data)
+
+    with pytest.raises(ValueError, match="max_generated_questions는 0 이상이어야 합니다"):
         loader._load_stages_yaml()
 
     loader._load_stages_yaml.cache_clear()

--- a/tests/test_features/test_interview/test_question_generator.py
+++ b/tests/test_features/test_interview/test_question_generator.py
@@ -200,54 +200,16 @@ def test_followup_fixed_question_includes_retrieved_insights_prompt_variable(
     assert captured["file_contexts"] == "[파일: report.pdf]\n프로젝트 요구사항 요약"
 
 
-def test_generated_question_fallback_on_llm_error(first_turn_state, monkeypatch):
-    """
-    생성 질문 LLM 실패 시 fallback 질문 생성 테스트
-    - 미수집 필드의 설명을 기반으로 질문이 생성되는지 확인
-    """
-    monkeypatch.setattr(
-        question_generator,
-        "get_llm",
-        lambda model=None, temperature=0.7: _mock_llm_raise(),
-    )
-
-    state = {
-        **first_turn_state,
-        "turn_number": 1,
-        "messages": [
-            AIMessage(content="질문1"),
-            HumanMessage(content="답변1"),
-        ],
-        "stage_progress": {
-            **first_turn_state["stage_progress"],
-            "fixed_q_used": first_turn_state["stage_progress"]["fixed_q_total"],
-            "generated_q_used": 0,
-        },
-    }
-
-    result = question_generator.run(state)
-
-    assert result["stage_progress"]["generated_q_used"] == 1
-    assert "이 활동을 시작하게 된 이유" in result["messages"][0].content
-
-
-def test_generated_question_includes_retrieved_insights_prompt_variable(
+def test_regular_mode_skips_dynamic_question_after_fixed_exhaustion(
     first_turn_state,
     monkeypatch,
 ):
-    """생성 질문 프롬프트에 retrieved_insights를 전달한다."""
-    captured: dict[str, object] = {}
+    """정규 모드는 legacy generated 설정이 남아 있어도 생성 질문을 만들지 않는다."""
 
-    def _capture_invoke(chain, prompt_variables, max_retries_per_question):
-        captured.update(prompt_variables)
-        return "추가 질문"
+    def _raise_if_called(*args, **kwargs):
+        raise AssertionError("정규 모드에서 생성 질문이 호출되면 안 됩니다.")
 
-    monkeypatch.setattr(question_generator, "_invoke_with_retry", _capture_invoke)
-    monkeypatch.setattr(
-        question_generator,
-        "get_llm",
-        lambda model=None, temperature=0.7: _mock_llm_return("사용되지 않는 질문"),
-    )
+    monkeypatch.setattr(question_generator, "_generate_dynamic_question", _raise_if_called)
 
     state = {
         **first_turn_state,
@@ -256,36 +218,19 @@ def test_generated_question_includes_retrieved_insights_prompt_variable(
             AIMessage(content="질문1"),
             HumanMessage(content="답변1"),
         ],
-        "file_contexts": ["[파일: architecture.png]\n시스템 구성도가 포함된 이미지"],
-        "retrieved_insights": [
-            {
-                "id": "insight-1",
-                "title": "멘션 인사이트",
-                "activity_name": "프로젝트 B",
-                "category": "기타",
-                "content": "사용자가 직접 언급한 참고 내용",
-                "similarity_score": None,
-                "source": "mention",
-            }
-        ],
         "stage_progress": {
             **first_turn_state["stage_progress"],
             "fixed_q_used": first_turn_state["stage_progress"]["fixed_q_total"],
             "generated_q_used": 0,
+            "generated_q_max": 3,
         },
     }
 
     result = question_generator.run(state)
 
-    assert result["messages"][0].content == "추가 질문"
-    assert captured["retrieved_insights"] == (
-        "- [기타] 멘션 인사이트\n"
-        "  - 활동명: 프로젝트 B\n"
-        "  - 출처: mention\n"
-        "  - 유사도: 없음\n"
-        "  - 내용: 사용자가 직접 언급한 참고 내용"
-    )
-    assert captured["file_contexts"] == "[파일: architecture.png]\n시스템 구성도가 포함된 이미지"
+    assert result["messages"][0].content == "혹시 더 추가하고 싶은 내용이 있으신가요?"
+    assert result["stage_progress"]["generated_q_used"] == 0
+    assert result["stage_progress"]["generated_q_max"] == 3
 
 
 def test_first_turn_uses_retry_limit_from_global_config(first_turn_state, monkeypatch):
@@ -323,8 +268,8 @@ def test_first_turn_uses_retry_limit_from_global_config(first_turn_state, monkey
     assert result["messages"][0].content == "재시도 성공 질문"
 
 
-def test_generated_question_ignores_dynamic_followup_switch(first_turn_state, monkeypatch):
-    """enable_dynamic_followup이 false여도 QG는 호출 시 질문을 생성한다."""
+def test_fallback_question_when_called_after_fixed_exhaustion(first_turn_state):
+    """고정 질문 소진 상태로 호출되어도 AIMessage fallback을 반환한다."""
     state = {
         **first_turn_state,
         "turn_number": 1,
@@ -336,47 +281,7 @@ def test_generated_question_ignores_dynamic_followup_switch(first_turn_state, mo
             **first_turn_state["stage_progress"],
             "fixed_q_used": first_turn_state["stage_progress"]["fixed_q_total"],
             "generated_q_used": 0,
-        },
-    }
-    monkeypatch.setattr(
-        question_generator,
-        "get_global_config",
-        lambda: type(
-            "Config",
-            (),
-            {
-                "max_retries_per_question": 1,
-                "enable_dynamic_followup": False,
-                "context_window_size": 5,
-            },
-        )(),
-    )
-    monkeypatch.setattr(
-        question_generator,
-        "get_llm",
-        lambda model=None, temperature=0.7: _mock_llm_return("추가 질문입니다."),
-    )
-
-    result = question_generator.run(state)
-
-    assert result["next_node"] == "end"
-    assert isinstance(result["messages"][0], AIMessage)
-    assert result["messages"][0].content == "추가 질문입니다."
-
-
-def test_fallback_question_when_called_after_exhaustion(first_turn_state):
-    """질문 소진 상태로 호출되어도 AIMessage fallback을 반환한다."""
-    state = {
-        **first_turn_state,
-        "turn_number": 1,
-        "messages": [
-            AIMessage(content="질문1"),
-            HumanMessage(content="답변1"),
-        ],
-        "stage_progress": {
-            **first_turn_state["stage_progress"],
-            "fixed_q_used": first_turn_state["stage_progress"]["fixed_q_total"],
-            "generated_q_used": first_turn_state["stage_progress"]["generated_q_max"],
+            "generated_q_max": 3,
         },
     }
 
@@ -385,6 +290,7 @@ def test_fallback_question_when_called_after_exhaustion(first_turn_state):
     assert result["next_node"] == "end"
     assert isinstance(result["messages"][0], AIMessage)
     assert result["messages"][0].content == "혹시 더 추가하고 싶은 내용이 있으신가요?"
+    assert result["stage_progress"]["generated_q_used"] == 0
 
 
 def test_extended_mode_generates_question_and_increments_turn(first_turn_state, monkeypatch):


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #200

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 경험정리 정규 단계의 `max_generated_questions`를 모두 0으로 변경해 단계 중간 생성 질문이 끼어들지 않도록 수정
- stage 2/3의 `force_all_generated_questions`를 false로 변경해 정규 플로우가 고정 질문 수 기준으로만 진행되도록 정리
- Analyst의 정규 단계 완료 조건을 `fixed_q_used >= fixed_q_total` 기준으로 단순화
- QuestionGenerator 정규 모드에서 고정 질문 소진 후 동적 생성 질문 분기를 타지 않도록 변경
- `max_generated_questions`가 0 이상인지 검증하고, legacy generated 상태가 남아 있어도 정규 플로우에 영향을 주지 않도록 테스트 보강

## 📸 스크린샷

- 백엔드 변경이라 UI 스크린샷은 없습니다. 대신 최신 검증 결과를 첨부합니다.

```text
uv run pytest tests/test_features/test_interview/test_config.py tests/test_features/test_interview/test_question_generator.py tests/test_features/test_interview/test_analyst.py
48 passed in 5.92s

uv run pytest tests/test_features/test_interview/test_graph.py tests/test_features/test_interview/test_graph_analyst_routing.py tests/test_features/test_interview/test_service.py tests/test_features/test_interview/test_service_session_stream.py tests/test_app/test_api/test_v1/test_interview.py
63 passed in 5.29s

git diff --check: passed
```

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 이번 PR은 #200 범위만 다룹니다.
- 추가 대화의 우선순위 target, 18개 질문 제한, 종료 의도 판단은 후속 이슈에서 처리합니다.
- API 응답 스키마와 extension 경로는 변경하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 단계 완료 판정 로직 단순화로 안정성 향상
  * 설정값 검증 추가로 음수 설정 방지

* **Changes**
  * 동적 생성 질문 흐름 비활성화 및 고정 질문 소진 기준으로 단계 전환
  * 각 스테이지의 생성 질문 상한을 0으로 조정

* **Tests**
  * 단계 완료·전환, 설정 검증 및 질문 생성 흐름 관련 테스트 추가 및 수정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->