### PR TITLE
[Fix] markdown 코드펜스 감싸진 LLM 응답 파싱 지원 (#211)

### DIFF
--- a/features/correction/generator.py
+++ b/features/correction/generator.py
@@ -16,6 +16,10 @@ _FIELD_HEADER_PATTERN = re.compile(
     r"^\[[^\]]+ - (?P<field_name>description|contributions|achievements|insights)\]$"
 )
 _NUMBERED_LINE_PATTERN = re.compile(r"^\d+\.\s+")
+_CODE_FENCE_PATTERN = re.compile(
+    r"^\s*```(?:[a-zA-Z0-9_-]+)?\s*\n(?P<body>.*?)\n?\s*```\s*$",
+    re.DOTALL,
+)
 logger = logging.getLogger(__name__)
 
 
@@ -35,13 +39,11 @@ class CorrectionGenerator:
         self._min_lines_per_field = validation_config.min_lines_per_field
         self._allow_null_comment_for_keep = validation_config.allow_null_comment_for_keep
 
-        llm = get_llm(
+        self._llm = get_llm(
             model=llm_config.model,
             temperature=llm_config.temperature,
             timeout=llm_config.timeout,
         )
-        self._llm = llm
-        self._structured_llm = llm.with_structured_output(SingleCorrectionOutput)
 
     def generate(
         self,
@@ -101,8 +103,10 @@ class CorrectionGenerator:
 
             try:
                 logger.info("LLM 첨삭 생성 시도 %s/%s 시작", attempt, total_attempts)
-                chain = correction_generator_prompt | self._structured_llm
-                output: SingleCorrectionOutput = chain.invoke(prompt_variables)
+                chain = correction_generator_prompt | self._llm
+                raw_response = chain.invoke(prompt_variables)
+                response_text = _coerce_llm_text_response(raw_response)
+                output: SingleCorrectionOutput = _parse_single_correction_output(response_text)
                 logger.info("LLM 첨삭 생성 시도 %s/%s 완료", attempt, total_attempts)
             except Exception as exc:
                 last_error_message = f"LLM 호출/파싱 실패: {exc}"
@@ -239,6 +243,44 @@ class CorrectionGenerator:
                     )
 
         return errors
+
+
+def _strip_json_code_fence(text: str) -> str:
+    """LLM 응답을 감싼 마크다운 코드펜스(```json ... ```)를 제거한다.
+
+    OpenRouter를 통한 일부 모델(예: ``openai/gpt-oss-120b``)이 function/tool calling
+    대신 메시지 본문에 펜스로 감싼 JSON을 반환하는 사례를 흡수하기 위한 정규화 헬퍼다.
+
+    Args:
+        text: LLM이 반환한 원본 텍스트
+
+    Returns:
+        str: 펜스가 제거되고 양끝 공백이 정리된 문자열. 펜스가 없으면 원본을 strip한 값.
+    """
+    stripped = text.strip()
+    match = _CODE_FENCE_PATTERN.match(stripped)
+    if match is not None:
+        return match.group("body").strip()
+    return stripped
+
+
+def _parse_single_correction_output(text: str) -> SingleCorrectionOutput:
+    """LLM 텍스트 응답을 ``SingleCorrectionOutput``으로 파싱한다.
+
+    Args:
+        text: LLM이 반환한 JSON 문자열 (마크다운 코드펜스 포함 가능)
+
+    Returns:
+        SingleCorrectionOutput: 스키마 검증을 통과한 첨삭 결과
+
+    Raises:
+        ValueError: 응답이 비어 있는 경우
+        pydantic.ValidationError: JSON 파싱은 됐지만 스키마 검증에 실패한 경우
+    """
+    cleaned = _strip_json_code_fence(text)
+    if not cleaned:
+        raise ValueError("LLM 응답이 비어 있습니다.")
+    return SingleCorrectionOutput.model_validate_json(cleaned)
 
 
 def _get_field_line_counts(portfolio_data: dict) -> dict[str, int]:

--- a/features/correction/prompts/correction_prompt.py
+++ b/features/correction/prompts/correction_prompt.py
@@ -59,6 +59,10 @@ CORRECTION_SYSTEM_PROMPT = """
 - 출력은 SingleCorrectionOutput 스키마에 정확히 맞춰야 합니다.
 - 각 field 객체는 반드시 1개씩만 반환하세요.
 - type은 reduce, keep, emphasize만 사용하세요.
+- 응답은 추가 설명이나 마크다운 코드펜스(```) 없이, 유효한 JSON object 하나만 반환하세요.
+- 모든 line 객체는 line_number, original_text, type, comment 키를 모두 포함해야 하며, keep 타입은 comment를 null로 설정하세요.
+- JSON 구조 예시:
+  {{"fields": [{{"field_name": "description", "lines": [{{"line_number": 1, "original_text": "...", "type": "keep", "comment": null}}]}}]}}
 """.strip()
 
 CORRECTION_GENERATOR_SYSTEM_TEMPLATE = f"""

--- a/tests/test_features/test_correction/test_generator.py
+++ b/tests/test_features/test_correction/test_generator.py
@@ -1,6 +1,7 @@
 """첨삭 생성기 테스트"""
 
 import pytest
+from pydantic import ValidationError
 
 from features.correction.config.loader import CorrectionConfig, CorrectionValidationConfig
 from features.correction.generator import (
@@ -8,6 +9,8 @@ from features.correction.generator import (
     CorrectionGenerator,
     _coerce_llm_text_response,
     _format_portfolio_corrections_for_summary,
+    _parse_single_correction_output,
+    _strip_json_code_fence,
     get_correction_generator,
     reset_correction_generator,
 )
@@ -40,10 +43,7 @@ class DummyPrompt:
 
 
 class DummyLLM:
-    """structured output 래퍼를 대체하는 LLM 모킹 객체."""
-
-    def with_structured_output(self, _: type[SingleCorrectionOutput]) -> object:
-        return object()
+    """LLM 클라이언트를 대체하는 모킹 객체."""
 
 
 def _output(line_number: int = 1, comment: str | None = "좋습니다.") -> SingleCorrectionOutput:
@@ -99,12 +99,17 @@ def _output(line_number: int = 1, comment: str | None = "좋습니다.") -> Sing
     )
 
 
+def _output_json(line_number: int = 1, comment: str | None = "좋습니다.") -> str:
+    """`_output()`을 JSON 문자열로 직렬화한다."""
+    return _output(line_number=line_number, comment=comment).model_dump_json()
+
+
 def test_generate_retry_with_validation_feedback(monkeypatch: pytest.MonkeyPatch):
     """검증 실패 시 피드백을 포함해 재시도한다."""
     from features.correction import generator
 
-    invalid = _output(line_number=2)
-    valid = _output(line_number=1)
+    invalid = _output_json(line_number=2)
+    valid = _output_json(line_number=1)
 
     chain = DummyChain([invalid, valid])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
@@ -124,16 +129,69 @@ def test_generate_retry_with_validation_feedback(monkeypatch: pytest.MonkeyPatch
         emphasis_points="강조 포인트",
     )
 
-    assert result == valid
+    assert result == _output(line_number=1)
     assert len(chain.calls) == 2
     assert chain.calls[1]["validation_feedback"].startswith("이전 출력 보완 필요:")
+
+
+def test_generate_retries_on_fenced_json_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    """LLM이 ```json``` 코드펜스로 감싼 JSON을 반환해도 파싱 후 진행한다."""
+    from features.correction import generator
+
+    fenced = f"```json\n{_output_json(line_number=1)}\n```"
+    chain = DummyChain([fenced])
+    monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
+    monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
+
+    result = CorrectionGenerator(max_retries=0).generate(
+        company_name="테스트 회사",
+        job_title="백엔드",
+        job_description="채용 공고",
+        company_insight="인사이트",
+        portfolio_data={
+            "description": "- 한 줄",
+            "contributions": "- 한 줄",
+            "achievements": "- 한 줄",
+            "insights": "- 한 줄",
+        },
+        emphasis_points="강조 포인트",
+    )
+
+    assert result == _output(line_number=1)
+
+
+def test_generate_retries_when_response_is_invalid_json(monkeypatch: pytest.MonkeyPatch):
+    """첫 응답이 JSON 파싱 실패하면 피드백을 포함해 재시도한다."""
+    from features.correction import generator
+
+    chain = DummyChain(["```json\n{not valid json\n```", _output_json(line_number=1)])
+    monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
+    monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
+
+    result = CorrectionGenerator(max_retries=2).generate(
+        company_name="테스트 회사",
+        job_title="백엔드",
+        job_description="채용 공고",
+        company_insight="인사이트",
+        portfolio_data={
+            "description": "- 한 줄",
+            "contributions": "- 한 줄",
+            "achievements": "- 한 줄",
+            "insights": "- 한 줄",
+        },
+        emphasis_points="강조 포인트",
+    )
+
+    assert result == _output(line_number=1)
+    assert len(chain.calls) == 2
+    assert chain.calls[1]["validation_feedback"].startswith("LLM 호출/파싱 실패:")
 
 
 def test_generate_returns_last_output_when_retries_exhausted(monkeypatch: pytest.MonkeyPatch):
     """재시도 소진 시 마지막 출력을 반환한다."""
     from features.correction import generator
 
-    invalid_last = _output(line_number=3)
+    invalid_last = _output_json(line_number=3)
     chain = DummyChain([invalid_last, invalid_last, invalid_last])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
     monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
@@ -152,7 +210,7 @@ def test_generate_returns_last_output_when_retries_exhausted(monkeypatch: pytest
         emphasis_points="강조 포인트",
     )
 
-    assert result == invalid_last
+    assert result == _output(line_number=3)
 
 
 def test_generate_raises_error_when_llm_fails_without_output(monkeypatch: pytest.MonkeyPatch):
@@ -470,3 +528,38 @@ def test_correction_generator_singleton(monkeypatch: pytest.MonkeyPatch):
     third = get_correction_generator()
 
     assert third is not first
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"fields": []}', '{"fields": []}'),
+        ('```json\n{"fields": []}\n```', '{"fields": []}'),
+        ('```\n{"fields": []}\n```', '{"fields": []}'),
+        ('  ```json\n  {"fields": []}\n  ```  ', '{"fields": []}'),
+        ('```JSON\n{"fields": []}\n```', '{"fields": []}'),
+    ],
+)
+def test_strip_json_code_fence(raw: str, expected: str):
+    """다양한 형태의 마크다운 코드펜스를 제거한다."""
+    assert _strip_json_code_fence(raw) == expected
+
+
+def test_parse_single_correction_output_accepts_fenced_json():
+    """```json``` 펜스로 감싸진 JSON도 정상 파싱된다."""
+    payload = _output_json(line_number=1)
+    parsed = _parse_single_correction_output(f"```json\n{payload}\n```")
+
+    assert parsed == _output(line_number=1)
+
+
+def test_parse_single_correction_output_raises_on_empty():
+    """공백/펜스만 들어 있으면 ValueError를 발생시킨다."""
+    with pytest.raises(ValueError, match="LLM 응답이 비어 있습니다"):
+        _parse_single_correction_output("```json\n\n```")
+
+
+def test_parse_single_correction_output_raises_on_invalid_json():
+    """깨진 JSON은 ValidationError로 전파된다."""
+    with pytest.raises(ValidationError):
+        _parse_single_correction_output("{not valid json")


### PR DESCRIPTION
`with_structured_output()` 기본 function calling 경로가 `openai/gpt-oss-120b` 같은 OpenRouter 모델에서 동작하지 않아, LLM이 ```json ... ``` 펜스로 감싼 텍스트 응답을 반환하면 JSON 파싱이 첫 글자에서 실패하던 문제를 해결한다.

- 구조화 출력 래퍼 제거하고 raw LLM 호출 + 펜스 strip 후 직접 `SingleCorrectionOutput.model_validate_json`으로 파싱
- 프롬프트의 출력 제약에 "코드펜스 없는 JSON object 단독 출력" 지시와 최소 JSON 구조 예시 추가
- 펜스 strip / JSON 파싱 헬퍼 단위 테스트와 펜스 응답·잘못된 JSON 재시도 시나리오 테스트 추가

## 📌 관련 이슈

- Closes #211 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [✅] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `features/correction/generator.py`
  - `with_structured_output` 래퍼 제거 → raw LLM 호출 + `_strip_json_code_fence` 후 `SingleCorrectionOutput.model_validate_json`으로 직접 파싱
  - 코드펜스 strip / 단일 첨삭 파싱 헬퍼 신설 (`_strip_json_code_fence`, `_parse_single_correction_output`)
- `features/correction/prompts/correction_prompt.py`
  - 출력 제약에 "코드펜스 없는 JSON object 단독 출력" 지시 + 최소 JSON 구조 예시 추가
  - 모든 line이 `comment` 키를 반드시 포함하도록 명시 (keep은 `null`)
- `tests/test_features/test_correction/test_generator.py`
  - DummyChain 응답을 JSON 텍스트로 전환 (실제 LLM 응답 형태와 일치)
  - 펜스 strip / 펜스 응답 파싱 / 잘못된 JSON 재시도 케이스 추가

## 📸 스크린샷

- [x] `uv run pytest tests/test_features/test_correction/` — 109 passed
- [x] `uv run ruff check features/correction/ tests/test_features/test_correction/` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] 로컬 smoke: `app.main` import + `get_health()` + 운영에서 떨어졌던 펜스 JSON round-trip 통과 확인 (lifespan은 Postgres 의존이라 패스)

## ✅ 체크리스트
- [ ] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 코드 스타일 가이드를 준수했습니다
- [ ] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 첨삭 생성 로직을 개선하여 JSON 응답 처리의 견고성 향상
  * 마크다운 코드 펜스로 감싼 JSON 응답도 올바르게 처리 가능

* **Tests**
  * JSON 응답 파싱 및 에러 처리에 대한 테스트 확대
  * 재시도 시나리오 및 엣지 케이스에 대한 검증 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->