### PR TITLE
[Feat] OOXML 슬라이드 편집 엔진 구현 [1.03]

### DIFF
--- a/features/visualization/pptx/__init__.py
+++ b/features/visualization/pptx/__init__.py
@@ -1,0 +1,5 @@
+"""PPTX OOXML 편집 유틸리티."""
+
+from features.visualization.pptx.slide_editor import SlideEditor
+
+__all__ = ["SlideEditor"]

--- a/features/visualization/pptx/slide_editor.py
+++ b/features/visualization/pptx/slide_editor.py
@@ -1,0 +1,672 @@
+"""DrawingML 규칙을 준수하는 슬라이드 XML 편집기."""
+
+from pathlib import Path
+from typing import Any
+from xml.dom import Node
+from xml.dom.minidom import Document, Element
+
+from defusedxml.minidom import parse
+
+
+class SlideEditor:
+    """
+    디자이너 서식을 보존하면서 텍스트와 차트 데이터만 교체하는 편집기.
+
+    식별자는 PowerPoint 가 자동 부여한 `cNvPr/@id` 만 사용한다.
+    """
+
+    PML_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+    DRAWINGML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+    CHART_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+    REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+    _TITLE_PLACEHOLDER_TYPES = {"title", "ctrTitle", "subTitle"}
+
+    def extract_slots(self, slide_xml_path: str) -> list[dict[str, Any]]:
+        """
+        슬라이드 XML 에서 텍스트 도형과 차트 Slot 디스크립터를 추출한다.
+
+        Returns:
+            shape_id, 좌표/크기(EMU), 현재 텍스트, 폰트 크기, kind 를 담은 dict 목록
+        """
+        doc = parse(slide_xml_path)
+        sp_tree = self._first_descendant(doc, self.PML_NS, "spTree")
+        if sp_tree is None:
+            return []
+
+        slots: list[dict[str, Any]] = []
+        for sp_element in self._descendants(sp_tree, self.PML_NS, "sp"):
+            slot = self._describe_shape(sp_element)
+            if slot is not None:
+                slots.append(slot)
+
+        for graphic_frame in self._descendants(sp_tree, self.PML_NS, "graphicFrame"):
+            slot = self._describe_graphic_frame(graphic_frame, slide_xml_path)
+            if slot is not None:
+                slots.append(slot)
+
+        return slots
+
+    def apply_fills(self, slide_xml_path: str, fills: dict[str, dict[str, Any]]) -> None:
+        """
+        평평한 shape_id -> fill 맵을 슬라이드 XML 에 적용한다.
+
+        `text` 와 `remove` 는 슬라이드 XML 을 수정하고, `chart` 는 rels 로 연결된
+        chartN.xml 의 네이티브 캐시를 수정한다.
+        """
+        doc = parse(slide_xml_path)
+        sp_tree = self._first_descendant(doc, self.PML_NS, "spTree")
+        if sp_tree is None:
+            return
+
+        for sp_element in list(self._descendants(sp_tree, self.PML_NS, "sp")):
+            shape_id = self._get_shape_id(sp_element)
+            if shape_id is None or shape_id not in fills:
+                continue
+
+            fill = fills[shape_id]
+            action = fill.get("action", "text")
+            if action == "remove":
+                sp_element.parentNode.removeChild(sp_element)
+            elif action == "text":
+                self._replace_text(sp_element, fill)
+
+        for graphic_frame in list(self._descendants(sp_tree, self.PML_NS, "graphicFrame")):
+            shape_id = self._get_shape_id(graphic_frame)
+            if shape_id is None or shape_id not in fills:
+                continue
+
+            fill = fills[shape_id]
+            action = fill.get("action")
+            if action == "remove":
+                graphic_frame.parentNode.removeChild(graphic_frame)
+            elif action == "chart":
+                self._replace_chart_cache(slide_xml_path, graphic_frame, fill)
+
+        self._write_document(Path(slide_xml_path), doc)
+
+    def _get_shape_id(self, element: Element) -> str | None:
+        """cNvPr/@id 값을 추출한다."""
+        cnv_pr = self._get_cnv_pr(element)
+        if cnv_pr is None:
+            return None
+        shape_id = cnv_pr.getAttribute("id")
+        return shape_id or None
+
+    def _describe_shape(self, sp_element: Element) -> dict[str, Any] | None:
+        """텍스트 또는 이미지 도형 Slot 디스크립터를 만든다."""
+        shape_id = self._get_shape_id(sp_element)
+        if shape_id is None:
+            return None
+
+        cnv_pr = self._get_cnv_pr(sp_element)
+        tx_body = self._first_descendant(sp_element, self.PML_NS, "txBody")
+        kind = "image" if self._has_image_fill(sp_element) else "text"
+
+        return {
+            "shape_id": shape_id,
+            "shape_name": cnv_pr.getAttribute("name") if cnv_pr is not None else "",
+            **self._coordinates(sp_element),
+            "current_text": self._text_body_content(tx_body) if tx_body is not None else "",
+            "is_title_placeholder": self._is_title_placeholder(sp_element),
+            "font_size_pt": self._first_font_size_pt(tx_body) if tx_body is not None else None,
+            "kind": kind,
+        }
+
+    def _describe_graphic_frame(
+        self,
+        graphic_frame: Element,
+        slide_xml_path: str,
+    ) -> dict[str, Any] | None:
+        """차트 graphicFrame Slot 디스크립터를 만든다."""
+        shape_id = self._get_shape_id(graphic_frame)
+        if shape_id is None:
+            return None
+
+        chart = self._first_descendant(graphic_frame, self.CHART_NS, "chart")
+        if chart is None:
+            return None
+
+        chart_path = self._chart_path_for_graphic_frame(slide_xml_path, graphic_frame)
+        chart_summary = self._chart_summary(chart_path) if chart_path is not None else {}
+        cnv_pr = self._get_cnv_pr(graphic_frame)
+
+        return {
+            "shape_id": shape_id,
+            "shape_name": cnv_pr.getAttribute("name") if cnv_pr is not None else "",
+            **self._coordinates(graphic_frame),
+            "current_text": chart_summary.get("title", ""),
+            "is_title_placeholder": False,
+            "font_size_pt": None,
+            "kind": "chart",
+            "chart_rel_id": self._chart_rel_id(chart),
+            "chart_type": chart_summary.get("chart_type"),
+            "categories": chart_summary.get("categories", []),
+            "series": chart_summary.get("series", []),
+        }
+
+    def _replace_text(self, sp_element: Element, fill: dict[str, Any]) -> None:
+        """도형 내부 텍스트를 교체하되 첫 pPr/rPr 서식을 보존한다."""
+        doc = sp_element.ownerDocument
+        tx_body = self._first_descendant(sp_element, self.PML_NS, "txBody")
+        if tx_body is None:
+            tx_body = self._create_text_body(doc)
+            sp_element.appendChild(tx_body)
+
+        base_p_pr = self._extract_paragraph_props(tx_body)
+        base_r_pr = self._extract_run_props(tx_body, doc)
+
+        if fill.get("font_size_override") is not None:
+            size_val = str(int(round(float(fill["font_size_override"]) * 100)))
+            base_r_pr.setAttribute("sz", size_val)
+
+        if fill.get("is_title"):
+            base_r_pr.setAttribute("b", "1")
+
+        for paragraph in list(self._children(tx_body, self.DRAWINGML_NS, "p")):
+            tx_body.removeChild(paragraph)
+
+        text = str(fill.get("text", ""))
+        for line in text.split("\n"):
+            new_p = doc.createElementNS(self.DRAWINGML_NS, "a:p")
+            if base_p_pr is not None:
+                new_p.appendChild(base_p_pr.cloneNode(deep=True))
+
+            new_r = doc.createElementNS(self.DRAWINGML_NS, "a:r")
+            new_r.appendChild(base_r_pr.cloneNode(deep=True))
+
+            new_t = doc.createElementNS(self.DRAWINGML_NS, "a:t")
+            new_t.setAttribute("xml:space", "preserve")
+            new_t.appendChild(doc.createTextNode(line))
+
+            new_r.appendChild(new_t)
+            new_p.appendChild(new_r)
+            tx_body.appendChild(new_p)
+
+    def _replace_chart_cache(
+        self,
+        slide_xml_path: str,
+        graphic_frame: Element,
+        fill: dict[str, Any],
+    ) -> None:
+        """chartN.xml 의 strCache/numCache/ptCount/c:f 를 일관되게 갱신한다."""
+        chart_path = self._chart_path_for_graphic_frame(slide_xml_path, graphic_frame)
+        if chart_path is None:
+            raise ValueError("차트 관계 정보를 찾을 수 없습니다.")
+
+        data = fill.get("data") or {}
+        series_data = data.get("series") or []
+        if not series_data:
+            raise ValueError("차트 fill 에는 data.series 가 필요합니다.")
+
+        first_values = series_data[0].get("values") or []
+        categories = [str(value) for value in data.get("categories") or []]
+        if not categories:
+            categories = [str(index + 1) for index in range(len(first_values))]
+
+        for series in series_data:
+            values = series.get("values") or []
+            if len(values) != len(categories):
+                raise ValueError("차트 categories 와 values 길이가 일치해야 합니다.")
+
+        chart_doc = parse(str(chart_path))
+        chart_element = self._first_chart_type_element(chart_doc)
+        if chart_element is None:
+            raise ValueError("지원되는 차트 타입을 찾을 수 없습니다.")
+
+        existing_series = self._children(chart_element, self.CHART_NS, "ser")
+        if not existing_series:
+            raise ValueError("차트에 복제할 series 템플릿이 없습니다.")
+
+        template_series = existing_series[0].cloneNode(deep=True)
+        self._resize_series(chart_element, existing_series, template_series, len(series_data))
+
+        sheet_name = self._first_formula_sheet(chart_doc) or "Sheet1"
+        category_formula = self._range_formula(sheet_name, "A", 2, len(categories) + 1)
+
+        for index, series in enumerate(self._children(chart_element, self.CHART_NS, "ser")):
+            values = series_data[index].get("values") or []
+            value_column = self._excel_column(index + 2)
+            self._replace_series_cache(
+                series,
+                index=index,
+                name=str(series_data[index].get("name", f"Series {index + 1}")),
+                categories=categories,
+                values=values,
+                category_formula=category_formula,
+                name_formula=self._cell_formula(sheet_name, value_column, 1),
+                value_formula=self._range_formula(sheet_name, value_column, 2, len(values) + 1),
+            )
+
+        self._write_document(chart_path, chart_doc)
+
+    def _resize_series(
+        self,
+        chart_element: Element,
+        existing_series: list[Element],
+        template_series: Node,
+        target_count: int,
+    ) -> None:
+        """차트 타입은 유지하면서 c:ser 개수만 데이터에 맞춘다."""
+        while len(existing_series) > target_count:
+            series = existing_series.pop()
+            chart_element.removeChild(series)
+
+        while len(existing_series) < target_count:
+            new_series = template_series.cloneNode(deep=True)
+            last_series = existing_series[-1]
+            if last_series.nextSibling is not None:
+                chart_element.insertBefore(new_series, last_series.nextSibling)
+            else:
+                chart_element.appendChild(new_series)
+            existing_series.append(new_series)
+
+    def _replace_series_cache(
+        self,
+        series: Element,
+        *,
+        index: int,
+        name: str,
+        categories: list[str],
+        values: list[Any],
+        category_formula: str,
+        name_formula: str,
+        value_formula: str,
+    ) -> None:
+        self._set_val_attribute(self._first_child(series, self.CHART_NS, "idx"), index)
+        self._set_val_attribute(self._first_child(series, self.CHART_NS, "order"), index)
+
+        tx_ref = self._ensure_ref(series, "tx", "strRef")
+        self._set_formula(tx_ref, name_formula)
+        self._replace_cache_points(self._ensure_cache(tx_ref, "strCache"), [name])
+
+        cat_ref = self._ensure_ref(series, "cat", "strRef")
+        self._set_formula(cat_ref, category_formula)
+        self._replace_cache_points(self._ensure_cache(cat_ref, "strCache"), categories)
+
+        val_ref = self._ensure_ref(series, "val", "numRef")
+        self._set_formula(val_ref, value_formula)
+        self._replace_cache_points(self._ensure_cache(val_ref, "numCache"), values)
+
+    def _get_cnv_pr(self, element: Element) -> Element | None:
+        for tag_name in ("nvSpPr", "nvGraphicFramePr", "nvPicPr"):
+            nv_props = self._first_descendant(element, self.PML_NS, tag_name)
+            if nv_props is None:
+                continue
+
+            cnv_pr = self._first_descendant(nv_props, self.PML_NS, "cNvPr")
+            if cnv_pr is None:
+                cnv_pr = self._first_descendant(nv_props, self.DRAWINGML_NS, "cNvPr")
+            return cnv_pr
+
+        return None
+
+    def _coordinates(self, element: Element) -> dict[str, int | None]:
+        xfrm = self._first_descendant(element, self.PML_NS, "xfrm")
+        if xfrm is None:
+            xfrm = self._first_descendant(element, self.DRAWINGML_NS, "xfrm")
+
+        off = self._first_descendant(xfrm, self.DRAWINGML_NS, "off") if xfrm else None
+        ext = self._first_descendant(xfrm, self.DRAWINGML_NS, "ext") if xfrm else None
+
+        return {
+            "x_emu": self._int_attr(off, "x"),
+            "y_emu": self._int_attr(off, "y"),
+            "w_emu": self._int_attr(ext, "cx"),
+            "h_emu": self._int_attr(ext, "cy"),
+        }
+
+    def _is_title_placeholder(self, sp_element: Element) -> bool:
+        ph = self._first_descendant(sp_element, self.PML_NS, "ph")
+        return ph is not None and ph.getAttribute("type") in self._TITLE_PLACEHOLDER_TYPES
+
+    def _has_image_fill(self, sp_element: Element) -> bool:
+        return (
+            self._first_descendant(sp_element, self.PML_NS, "blipFill") is not None
+            or self._first_descendant(sp_element, self.DRAWINGML_NS, "blip") is not None
+        )
+
+    def _text_body_content(self, tx_body: Element) -> str:
+        lines = []
+        for paragraph in self._children(tx_body, self.DRAWINGML_NS, "p"):
+            parts = [
+                self._node_text(text_node)
+                for text_node in self._descendants(paragraph, self.DRAWINGML_NS, "t")
+            ]
+            lines.append("".join(parts))
+        return "\n".join(lines)
+
+    def _first_font_size_pt(self, tx_body: Element) -> float | None:
+        for tag_name in ("rPr", "defRPr", "endParaRPr"):
+            for run_props in self._descendants(tx_body, self.DRAWINGML_NS, tag_name):
+                size = run_props.getAttribute("sz")
+                if not size:
+                    continue
+                try:
+                    return int(size) / 100
+                except ValueError:
+                    return None
+        return None
+
+    def _extract_paragraph_props(self, tx_body: Element) -> Element | None:
+        paragraph_props = self._first_descendant(tx_body, self.DRAWINGML_NS, "pPr")
+        return paragraph_props.cloneNode(deep=True) if paragraph_props is not None else None
+
+    def _extract_run_props(self, tx_body: Element, doc: Document) -> Element:
+        run_props = self._first_descendant(tx_body, self.DRAWINGML_NS, "rPr")
+        if run_props is not None:
+            return run_props.cloneNode(deep=True)
+        return doc.createElementNS(self.DRAWINGML_NS, "a:rPr")
+
+    def _create_text_body(self, doc: Document) -> Element:
+        tx_body = doc.createElementNS(self.PML_NS, "p:txBody")
+        tx_body.appendChild(doc.createElementNS(self.DRAWINGML_NS, "a:bodyPr"))
+        tx_body.appendChild(doc.createElementNS(self.DRAWINGML_NS, "a:lstStyle"))
+        return tx_body
+
+    def _chart_path_for_graphic_frame(
+        self,
+        slide_xml_path: str,
+        graphic_frame: Element,
+    ) -> Path | None:
+        chart = self._first_descendant(graphic_frame, self.CHART_NS, "chart")
+        if chart is None:
+            return None
+
+        rel_id = self._chart_rel_id(chart)
+        if rel_id is None:
+            return None
+
+        target = self._relationship_target(Path(slide_xml_path), rel_id)
+        if target is None:
+            return None
+
+        return self._resolve_part_path(Path(slide_xml_path), target)
+
+    def _chart_rel_id(self, chart: Element) -> str | None:
+        rel_id = chart.getAttributeNS(self.REL_NS, "id") or chart.getAttribute("r:id")
+        return rel_id or None
+
+    def _relationship_target(self, slide_xml_path: Path, rel_id: str) -> str | None:
+        rels_path = slide_xml_path.parent / "_rels" / f"{slide_xml_path.name}.rels"
+        if not rels_path.exists():
+            return None
+
+        rels_doc = parse(str(rels_path))
+        relationships = self._descendants(rels_doc, self.PKG_REL_NS, "Relationship")
+        if not relationships:
+            relationships = list(rels_doc.getElementsByTagName("Relationship"))
+
+        for relationship in relationships:
+            if relationship.getAttribute("Id") == rel_id:
+                return relationship.getAttribute("Target") or None
+
+        return None
+
+    def _resolve_part_path(self, source_xml_path: Path, target: str) -> Path:
+        normalized_target = target.replace("\\", "/")
+        if not normalized_target.startswith("/"):
+            return (source_xml_path.parent / normalized_target).resolve()
+
+        package_target = normalized_target.lstrip("/")
+        for parent in (source_xml_path.parent, *source_xml_path.parents):
+            candidate = parent / package_target
+            if candidate.exists():
+                return candidate.resolve()
+
+        return (source_xml_path.parent / package_target).resolve()
+
+    def _chart_summary(self, chart_path: Path) -> dict[str, Any]:
+        chart_doc = parse(str(chart_path))
+        chart_element = self._first_chart_type_element(chart_doc)
+        if chart_element is None:
+            return {}
+
+        return {
+            "title": self._chart_title(chart_doc),
+            "chart_type": self._chart_type(chart_element),
+            "categories": self._chart_categories(chart_element),
+            "series": self._chart_series(chart_element),
+        }
+
+    def _first_chart_type_element(self, chart_doc: Document) -> Element | None:
+        plot_area = self._first_descendant(chart_doc, self.CHART_NS, "plotArea")
+        if plot_area is None:
+            return None
+
+        for child in self._element_children(plot_area):
+            if child.namespaceURI == self.CHART_NS and child.localName.endswith("Chart"):
+                return child
+
+        return None
+
+    def _chart_type(self, chart_element: Element) -> str:
+        local_name = chart_element.localName or ""
+        return local_name.removesuffix("Chart")
+
+    def _chart_title(self, chart_doc: Document) -> str:
+        title = self._first_descendant(chart_doc, self.CHART_NS, "title")
+        if title is None:
+            return ""
+        return "".join(
+            self._node_text(text_node)
+            for text_node in self._descendants(title, self.DRAWINGML_NS, "t")
+        )
+
+    def _chart_categories(self, chart_element: Element) -> list[str]:
+        first_series = self._first_child(chart_element, self.CHART_NS, "ser")
+        if first_series is None:
+            return []
+        cat = self._first_child(first_series, self.CHART_NS, "cat")
+        if cat is None:
+            return []
+        return self._cached_values(cat, "strCache")
+
+    def _chart_series(self, chart_element: Element) -> list[dict[str, Any]]:
+        series_list = []
+        for series in self._children(chart_element, self.CHART_NS, "ser"):
+            tx = self._first_child(series, self.CHART_NS, "tx")
+            val = self._first_child(series, self.CHART_NS, "val")
+            series_list.append(
+                {
+                    "name": self._series_name(tx),
+                    "values": [
+                        self._parse_number(value) for value in self._cached_values(val, "numCache")
+                    ]
+                    if val is not None
+                    else [],
+                }
+            )
+        return series_list
+
+    def _series_name(self, tx: Element | None) -> str:
+        if tx is None:
+            return ""
+
+        cached_names = self._cached_values(tx, "strCache")
+        if cached_names:
+            return cached_names[0]
+
+        value = self._first_child(tx, self.CHART_NS, "v")
+        return self._node_text(value) if value is not None else ""
+
+    def _cached_values(self, parent: Element | None, cache_tag: str) -> list[str]:
+        if parent is None:
+            return []
+
+        cache = self._first_descendant(parent, self.CHART_NS, cache_tag)
+        if cache is None:
+            return []
+
+        values = []
+        for point in self._children(cache, self.CHART_NS, "pt"):
+            value = self._first_child(point, self.CHART_NS, "v")
+            values.append(self._node_text(value) if value is not None else "")
+        return values
+
+    def _ensure_ref(self, series: Element, parent_tag: str, ref_tag: str) -> Element:
+        parent = self._first_child(series, self.CHART_NS, parent_tag)
+        if parent is None:
+            parent = series.ownerDocument.createElementNS(self.CHART_NS, f"c:{parent_tag}")
+            series.appendChild(parent)
+
+        ref = self._first_child(parent, self.CHART_NS, ref_tag)
+        if ref is None:
+            ref = series.ownerDocument.createElementNS(self.CHART_NS, f"c:{ref_tag}")
+            parent.appendChild(ref)
+
+        return ref
+
+    def _ensure_cache(self, ref: Element, cache_tag: str) -> Element:
+        cache = self._first_child(ref, self.CHART_NS, cache_tag)
+        if cache is None:
+            cache = ref.ownerDocument.createElementNS(self.CHART_NS, f"c:{cache_tag}")
+            ref.appendChild(cache)
+        return cache
+
+    def _set_formula(self, ref: Element, formula: str) -> None:
+        formula_element = self._first_child(ref, self.CHART_NS, "f")
+        if formula_element is None:
+            formula_element = ref.ownerDocument.createElementNS(self.CHART_NS, "c:f")
+            first_cache = self._first_cache_child(ref)
+            if first_cache is not None:
+                ref.insertBefore(formula_element, first_cache)
+            else:
+                ref.appendChild(formula_element)
+        self._replace_text_node(formula_element, formula)
+
+    def _replace_cache_points(self, cache: Element, values: list[Any]) -> None:
+        point_count = self._first_child(cache, self.CHART_NS, "ptCount")
+        if point_count is None:
+            point_count = cache.ownerDocument.createElementNS(self.CHART_NS, "c:ptCount")
+            first_point = self._first_child(cache, self.CHART_NS, "pt")
+            if first_point is not None:
+                cache.insertBefore(point_count, first_point)
+            else:
+                cache.appendChild(point_count)
+
+        point_count.setAttribute("val", str(len(values)))
+
+        for point in list(self._children(cache, self.CHART_NS, "pt")):
+            cache.removeChild(point)
+
+        for index, value in enumerate(values):
+            point = cache.ownerDocument.createElementNS(self.CHART_NS, "c:pt")
+            point.setAttribute("idx", str(index))
+            value_element = cache.ownerDocument.createElementNS(self.CHART_NS, "c:v")
+            value_element.appendChild(
+                cache.ownerDocument.createTextNode(self._format_cache_value(value))
+            )
+            point.appendChild(value_element)
+            cache.appendChild(point)
+
+    def _first_cache_child(self, ref: Element) -> Element | None:
+        for child in self._element_children(ref):
+            if child.namespaceURI == self.CHART_NS and child.localName in {"strCache", "numCache"}:
+                return child
+        return None
+
+    def _set_val_attribute(self, element: Element | None, value: int) -> None:
+        if element is not None:
+            element.setAttribute("val", str(value))
+
+    def _first_formula_sheet(self, chart_doc: Document) -> str | None:
+        for formula in self._descendants(chart_doc, self.CHART_NS, "f"):
+            formula_text = self._node_text(formula)
+            if "!" in formula_text:
+                return formula_text.split("!", 1)[0]
+        return None
+
+    def _cell_formula(self, sheet_name: str, column: str, row: int) -> str:
+        return f"{sheet_name}!${column}${row}"
+
+    def _range_formula(self, sheet_name: str, column: str, start_row: int, end_row: int) -> str:
+        return f"{sheet_name}!${column}${start_row}:${column}${end_row}"
+
+    def _excel_column(self, one_based_index: int) -> str:
+        column = ""
+        index = one_based_index
+        while index:
+            index, remainder = divmod(index - 1, 26)
+            column = chr(ord("A") + remainder) + column
+        return column
+
+    def _children(self, element: Element, namespace_uri: str, local_name: str) -> list[Element]:
+        return [
+            child
+            for child in self._element_children(element)
+            if child.namespaceURI == namespace_uri and child.localName == local_name
+        ]
+
+    def _first_child(
+        self,
+        element: Element | Document | None,
+        namespace_uri: str,
+        local_name: str,
+    ) -> Element | None:
+        if element is None:
+            return None
+        for child in self._element_children(element):
+            if child.namespaceURI == namespace_uri and child.localName == local_name:
+                return child
+        return None
+
+    def _descendants(
+        self,
+        element: Element | Document,
+        namespace_uri: str,
+        local_name: str,
+    ) -> list[Element]:
+        return list(element.getElementsByTagNameNS(namespace_uri, local_name))
+
+    def _first_descendant(
+        self,
+        element: Element | Document | None,
+        namespace_uri: str,
+        local_name: str,
+    ) -> Element | None:
+        if element is None:
+            return None
+        descendants = element.getElementsByTagNameNS(namespace_uri, local_name)
+        return descendants[0] if descendants else None
+
+    def _element_children(self, element: Element | Document) -> list[Element]:
+        return [child for child in element.childNodes if child.nodeType == Node.ELEMENT_NODE]
+
+    def _int_attr(self, element: Element | None, attr_name: str) -> int | None:
+        if element is None or not element.hasAttribute(attr_name):
+            return None
+        return int(element.getAttribute(attr_name))
+
+    def _node_text(self, element: Element | None) -> str:
+        if element is None:
+            return ""
+        return "".join(
+            child.data
+            for child in element.childNodes
+            if child.nodeType in {Node.TEXT_NODE, Node.CDATA_SECTION_NODE}
+        )
+
+    def _replace_text_node(self, element: Element, value: str) -> None:
+        for child in list(element.childNodes):
+            element.removeChild(child)
+        element.appendChild(element.ownerDocument.createTextNode(value))
+
+    def _format_cache_value(self, value: Any) -> str:
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value)
+
+    def _parse_number(self, value: str) -> int | float | str:
+        try:
+            number = float(value)
+        except ValueError:
+            return value
+        if number.is_integer():
+            return int(number)
+        return number
+
+    def _write_document(self, path: Path, doc: Document) -> None:
+        with path.open("w", encoding="utf-8") as file:
+            doc.writexml(file, encoding="utf-8")

--- a/features/visualization/pptx/slide_editor.py
+++ b/features/visualization/pptx/slide_editor.py
@@ -1,4 +1,4 @@
-"""DrawingML 규칙을 준수하는 슬라이드 XML 편집기."""
+"""슬라이드 XML Slot 추출과 Fill 적용을 담당하는 OOXML 편집기."""
 
 from pathlib import Path
 from typing import Any
@@ -13,6 +13,13 @@ class SlideEditor:
     디자이너 서식을 보존하면서 텍스트와 차트 데이터만 교체하는 편집기.
 
     식별자는 PowerPoint 가 자동 부여한 `cNvPr/@id` 만 사용한다.
+
+    Attributes:
+        PML_NS: PresentationML 네임스페이스 URI
+        DRAWINGML_NS: DrawingML 네임스페이스 URI
+        CHART_NS: DrawingML Chart 네임스페이스 URI
+        REL_NS: Office relationship 네임스페이스 URI
+        PKG_REL_NS: OOXML package relationship 네임스페이스 URI
     """
 
     PML_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
@@ -21,14 +28,19 @@ class SlideEditor:
     REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
     PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 
-    _TITLE_PLACEHOLDER_TYPES = {"title", "ctrTitle", "subTitle"}
+    _TITLE_PLACEHOLDER_TYPES = frozenset({"title", "ctrTitle", "subTitle"})
 
     def extract_slots(self, slide_xml_path: str) -> list[dict[str, Any]]:
         """
         슬라이드 XML 에서 텍스트 도형과 차트 Slot 디스크립터를 추출한다.
 
+        Args:
+            slide_xml_path: 편집 대상 `slideN.xml` 파일 경로
+
         Returns:
-            shape_id, 좌표/크기(EMU), 현재 텍스트, 폰트 크기, kind 를 담은 dict 목록
+            list[dict[str, Any]]: Slot 디스크립터 목록. 각 항목은 `shape_id`,
+            `shape_name`, `x_emu`, `y_emu`, `w_emu`, `h_emu`, `current_text`,
+            `is_title_placeholder`, `font_size_pt`, `kind` 를 포함한다.
         """
         doc = parse(slide_xml_path)
         sp_tree = self._first_descendant(doc, self.PML_NS, "spTree")
@@ -52,8 +64,13 @@ class SlideEditor:
         """
         평평한 shape_id -> fill 맵을 슬라이드 XML 에 적용한다.
 
-        `text` 와 `remove` 는 슬라이드 XML 을 수정하고, `chart` 는 rels 로 연결된
-        chartN.xml 의 네이티브 캐시를 수정한다.
+        Args:
+            slide_xml_path: 편집 대상 `slideN.xml` 파일 경로
+            fills: `shape_id` 를 key 로 하는 Fill 맵. 각 값은 `action`,
+                `text`, `font_size_override`, `is_title`, `data` 를 포함할 수 있다.
+
+        Raises:
+            ValueError: 차트 관계, 차트 타입, series 데이터가 유효하지 않은 경우
         """
         doc = parse(slide_xml_path)
         sp_tree = self._first_descendant(doc, self.PML_NS, "spTree")

--- a/features/visualization/pptx/slide_editor.py
+++ b/features/visualization/pptx/slide_editor.py
@@ -347,12 +347,22 @@ class SlideEditor:
     def _text_body_content(self, tx_body: Element) -> str:
         lines = []
         for paragraph in self._children(tx_body, self.DRAWINGML_NS, "p"):
-            parts = [
-                self._node_text(text_node)
-                for text_node in self._descendants(paragraph, self.DRAWINGML_NS, "t")
-            ]
-            lines.append("".join(parts))
+            lines.append(self._text_with_breaks(paragraph))
         return "\n".join(lines)
+
+    def _text_with_breaks(self, element: Element) -> str:
+        parts = []
+        for child in element.childNodes:
+            if child.nodeType != Node.ELEMENT_NODE:
+                continue
+
+            if child.namespaceURI == self.DRAWINGML_NS and child.localName == "br":
+                parts.append("\n")
+            elif child.namespaceURI == self.DRAWINGML_NS and child.localName == "t":
+                parts.append(self._node_text(child))
+            else:
+                parts.append(self._text_with_breaks(child))
+        return "".join(parts)
 
     def _first_font_size_pt(self, tx_body: Element) -> float | None:
         for tag_name in ("rPr", "defRPr", "endParaRPr"):
@@ -374,7 +384,26 @@ class SlideEditor:
         run_props = self._first_descendant(tx_body, self.DRAWINGML_NS, "rPr")
         if run_props is not None:
             return run_props.cloneNode(deep=True)
+
+        for tag_name in ("defRPr", "endParaRPr"):
+            fallback_props = self._first_descendant(tx_body, self.DRAWINGML_NS, tag_name)
+            if fallback_props is not None:
+                return self._clone_as_run_props(fallback_props, doc)
+
         return doc.createElementNS(self.DRAWINGML_NS, "a:rPr")
+
+    def _clone_as_run_props(self, source_props: Element, doc: Document) -> Element:
+        run_props = doc.createElementNS(self.DRAWINGML_NS, "a:rPr")
+        for index in range(source_props.attributes.length):
+            attr = source_props.attributes.item(index)
+            if attr.namespaceURI:
+                run_props.setAttributeNS(attr.namespaceURI, attr.name, attr.value)
+            else:
+                run_props.setAttribute(attr.name, attr.value)
+
+        for child in source_props.childNodes:
+            run_props.appendChild(child.cloneNode(deep=True))
+        return run_props
 
     def _create_text_body(self, doc: Document) -> Element:
         tx_body = doc.createElementNS(self.PML_NS, "p:txBody")
@@ -417,22 +446,34 @@ class SlideEditor:
 
         for relationship in relationships:
             if relationship.getAttribute("Id") == rel_id:
+                if relationship.getAttribute("TargetMode") == "External":
+                    raise ValueError("외부 차트 관계는 지원하지 않습니다.")
                 return relationship.getAttribute("Target") or None
 
         return None
 
     def _resolve_part_path(self, source_xml_path: Path, target: str) -> Path:
         normalized_target = target.replace("\\", "/")
-        if not normalized_target.startswith("/"):
-            return (source_xml_path.parent / normalized_target).resolve()
+        package_root = self._package_root_for_part(source_xml_path)
+        if normalized_target.startswith("/"):
+            candidate = package_root / normalized_target.lstrip("/")
+        else:
+            candidate = source_xml_path.parent / normalized_target
 
-        package_target = normalized_target.lstrip("/")
-        for parent in (source_xml_path.parent, *source_xml_path.parents):
-            candidate = parent / package_target
-            if candidate.exists():
-                return candidate.resolve()
+        resolved = candidate.resolve()
+        if not resolved.is_relative_to(package_root):
+            raise ValueError("차트 대상 경로가 패키지 범위를 벗어났습니다.")
+        return resolved
 
-        return (source_xml_path.parent / package_target).resolve()
+    def _package_root_for_part(self, part_path: Path) -> Path:
+        resolved_part_path = part_path.resolve()
+        for parent in (resolved_part_path.parent, *resolved_part_path.parents):
+            if parent.name == "ppt":
+                return parent.parent.resolve()
+
+        if len(resolved_part_path.parents) >= 3:
+            return resolved_part_path.parents[2].resolve()
+        return resolved_part_path.parent.resolve()
 
     def _chart_summary(self, chart_path: Path) -> dict[str, Any]:
         chart_doc = parse(str(chart_path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "asyncpg>=0.31.0",
+    "defusedxml>=0.7.1",
     "fastapi>=0.128.0",
     "httpx>=0.28.1",
     "langchain>=1.2.3",

--- a/tests/test_features/test_visualization/test_slide_editor.py
+++ b/tests/test_features/test_visualization/test_slide_editor.py
@@ -1,6 +1,7 @@
 """SlideEditor XML 편집 테스트."""
 
 from pathlib import Path
+from xml.dom.minidom import Document, Element
 
 from defusedxml.minidom import parse
 
@@ -11,7 +12,7 @@ DRAWINGML_NS = SlideEditor.DRAWINGML_NS
 CHART_NS = SlideEditor.CHART_NS
 
 
-def make_sample_package(tmp_path: Path) -> tuple[Path, Path]:
+def _make_sample_package(tmp_path: Path) -> tuple[Path, Path]:
     """슬라이드 XML, rels, chart XML 을 포함한 최소 PPTX unpack 구조를 만든다."""
     slides_dir = tmp_path / "ppt" / "slides"
     rels_dir = slides_dir / "_rels"
@@ -175,28 +176,28 @@ def make_sample_package(tmp_path: Path) -> tuple[Path, Path]:
     return slide_path, chart_path
 
 
-def node_text(element) -> str:
+def _node_text(element: Element) -> str:
     return "".join(child.data for child in element.childNodes if child.nodeType == child.TEXT_NODE)
 
 
-def shape_by_id(doc, shape_id: str):
+def _shape_by_id(doc: Document, shape_id: str) -> Element:
     for shape in doc.getElementsByTagNameNS(PML_NS, "sp"):
         c_nv_pr = shape.getElementsByTagNameNS(PML_NS, "cNvPr")[0]
         if c_nv_pr.getAttribute("id") == shape_id:
             return shape
-    raise AssertionError(f"shape not found: {shape_id}")
+    raise AssertionError(f"도형을 찾을 수 없습니다: {shape_id}")
 
 
-def cache_values(cache) -> list[str]:
+def _cache_values(cache: Element) -> list[str]:
     values = []
     for point in cache.getElementsByTagNameNS(CHART_NS, "pt"):
-        values.append(node_text(point.getElementsByTagNameNS(CHART_NS, "v")[0]))
+        values.append(_node_text(point.getElementsByTagNameNS(CHART_NS, "v")[0]))
     return values
 
 
-def test_extract_slots_reads_text_and_chart_metadata(tmp_path):
+def test_extract_slots_reads_text_and_chart_metadata(tmp_path: Path) -> None:
     """텍스트/차트 Slot 과 EMU, 폰트 크기, 차트 캐시를 추출한다."""
-    slide_path, _ = make_sample_package(tmp_path)
+    slide_path, _ = _make_sample_package(tmp_path)
 
     slots = {slot["shape_id"]: slot for slot in SlideEditor().extract_slots(str(slide_path))}
 
@@ -221,9 +222,9 @@ def test_extract_slots_reads_text_and_chart_metadata(tmp_path):
     assert slots["8"]["h_emu"] == 2743200
 
 
-def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path):
+def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path: Path) -> None:
     """텍스트 교체 후 도형 서식은 보존하고 폰트 오버라이드를 반영한다."""
-    slide_path, _ = make_sample_package(tmp_path)
+    slide_path, _ = _make_sample_package(tmp_path)
 
     SlideEditor().apply_fills(
         str(slide_path),
@@ -238,14 +239,14 @@ def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path):
     )
 
     doc = parse(str(slide_path))
-    title_shape = shape_by_id(doc, "2")
+    title_shape = _shape_by_id(doc, "2")
     shape_props = title_shape.getElementsByTagNameNS(PML_NS, "spPr")[0]
     paragraphs = title_shape.getElementsByTagNameNS(DRAWINGML_NS, "p")
     texts = title_shape.getElementsByTagNameNS(DRAWINGML_NS, "t")
 
     assert shape_props.getElementsByTagNameNS(DRAWINGML_NS, "gradFill")
     assert shape_props.getElementsByTagNameNS(DRAWINGML_NS, "outerShdw")
-    assert [node_text(text) for text in texts] == ["  새 제목", "두 번째 줄"]
+    assert [_node_text(text) for text in texts] == ["  새 제목", "두 번째 줄"]
     assert [text.getAttribute("xml:space") for text in texts] == ["preserve", "preserve"]
 
     for paragraph in paragraphs:
@@ -260,9 +261,9 @@ def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path):
         assert color.getAttribute("val") == "123456"
 
 
-def test_apply_remove_deletes_shape_tree(tmp_path):
+def test_apply_remove_deletes_shape_tree(tmp_path: Path) -> None:
     """remove action 은 대상 p:sp 전체를 제거한다."""
-    slide_path, _ = make_sample_package(tmp_path)
+    slide_path, _ = _make_sample_package(tmp_path)
 
     SlideEditor().apply_fills(str(slide_path), {"3": {"action": "remove"}})
 
@@ -276,9 +277,9 @@ def test_apply_remove_deletes_shape_tree(tmp_path):
     assert "삭제될 본문" not in slide_path.read_text(encoding="utf-8")
 
 
-def test_apply_chart_updates_cache_formulas_and_keeps_chart_type(tmp_path):
+def test_apply_chart_updates_cache_formulas_and_keeps_chart_type(tmp_path: Path) -> None:
     """chart action 은 캐시와 수식을 함께 갱신하고 차트 타입은 유지한다."""
-    slide_path, chart_path = make_sample_package(tmp_path)
+    slide_path, chart_path = _make_sample_package(tmp_path)
 
     SlideEditor().apply_fills(
         str(slide_path),
@@ -308,13 +309,13 @@ def test_apply_chart_updates_cache_formulas_and_keeps_chart_type(tmp_path):
         CHART_NS, "strCache"
     )[0]
     num_cache = series.getElementsByTagNameNS(CHART_NS, "numCache")[0]
-    formulas = [node_text(formula) for formula in doc.getElementsByTagNameNS(CHART_NS, "f")]
+    formulas = [_node_text(formula) for formula in doc.getElementsByTagNameNS(CHART_NS, "f")]
 
-    assert cache_values(tx_cache) == ["개선 후"]
+    assert _cache_values(tx_cache) == ["개선 후"]
     assert tx_cache.getElementsByTagNameNS(CHART_NS, "ptCount")[0].getAttribute("val") == "1"
-    assert cache_values(cat_cache) == ["전환율", "이탈률", "잔존율"]
+    assert _cache_values(cat_cache) == ["전환율", "이탈률", "잔존율"]
     assert cat_cache.getElementsByTagNameNS(CHART_NS, "ptCount")[0].getAttribute("val") == "3"
-    assert cache_values(num_cache) == ["148", "32", "91"]
+    assert _cache_values(num_cache) == ["148", "32", "91"]
     assert num_cache.getElementsByTagNameNS(CHART_NS, "ptCount")[0].getAttribute("val") == "3"
     assert "Sheet1!$B$1" in formulas
     assert "Sheet1!$A$2:$A$4" in formulas

--- a/tests/test_features/test_visualization/test_slide_editor.py
+++ b/tests/test_features/test_visualization/test_slide_editor.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from xml.dom.minidom import Document, Element
 
+import pytest
 from defusedxml.minidom import parse
 
 from features.visualization.pptx import SlideEditor
@@ -222,6 +223,63 @@ def test_extract_slots_reads_text_and_chart_metadata(tmp_path: Path) -> None:
     assert slots["8"]["h_emu"] == 2743200
 
 
+def test_extract_slots_preserves_soft_line_breaks(tmp_path: Path) -> None:
+    """같은 문단 안의 a:br 을 current_text 줄바꿈으로 보존한다."""
+    slide_path, _ = _make_sample_package(tmp_path)
+    slide_xml = slide_path.read_text(encoding="utf-8").replace(
+        "<a:t>여기에 프로젝트명</a:t>",
+        """<a:t>첫 줄</a:t>
+            </a:r>
+            <a:br/>
+            <a:r>
+              <a:t>둘째 줄</a:t>""",
+    )
+    slide_path.write_text(slide_xml, encoding="utf-8")
+
+    slots = {slot["shape_id"]: slot for slot in SlideEditor().extract_slots(str(slide_path))}
+
+    assert slots["2"]["current_text"] == "첫 줄\n둘째 줄"
+
+
+def test_extract_slots_rejects_external_chart_relationship(tmp_path: Path) -> None:
+    """외부 차트 relationship 은 읽지 않는다."""
+    slide_path, _ = _make_sample_package(tmp_path)
+    rels_path = slide_path.parent / "_rels" / "slide1.xml.rels"
+    rels_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId7"
+                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+                Target="https://example.com/chart.xml"
+                TargetMode="External"/>
+</Relationships>
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="외부 차트 관계"):
+        SlideEditor().extract_slots(str(slide_path))
+
+
+def test_extract_slots_rejects_chart_target_outside_package(tmp_path: Path) -> None:
+    """패키지 루트 밖으로 나가는 chart target 은 거부한다."""
+    slide_path, _ = _make_sample_package(tmp_path)
+    rels_path = slide_path.parent / "_rels" / "slide1.xml.rels"
+    rels_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId7"
+                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+                Target="../../../outside/chart1.xml"/>
+</Relationships>
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="패키지 범위"):
+        SlideEditor().extract_slots(str(slide_path))
+
+
 def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path: Path) -> None:
     """텍스트 교체 후 도형 서식은 보존하고 폰트 오버라이드를 반영한다."""
     slide_path, _ = _make_sample_package(tmp_path)
@@ -259,6 +317,48 @@ def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path: Path
         assert run_props.getAttribute("b") == "1"
         assert latin.getAttribute("typeface") == "Pretendard"
         assert color.getAttribute("val") == "123456"
+
+
+def test_apply_text_uses_default_run_props_when_run_props_missing(tmp_path: Path) -> None:
+    """rPr 이 없으면 defRPr 서식을 a:rPr 로 정규화해 사용한다."""
+    slide_path, _ = _make_sample_package(tmp_path)
+    slide_xml = slide_path.read_text(encoding="utf-8")
+    slide_xml = slide_xml.replace(
+        '<a:pPr algn="ctr"/>',
+        """<a:pPr algn="ctr">
+              <a:defRPr sz="3600">
+                <a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill>
+                <a:latin typeface="FallbackFont"/>
+              </a:defRPr>
+            </a:pPr>""",
+        1,
+    )
+    slide_xml = slide_xml.replace(
+        """              <a:rPr lang="ko-KR" sz="4000" b="0">
+                <a:solidFill><a:srgbClr val="123456"/></a:solidFill>
+                <a:latin typeface="Pretendard"/>
+              </a:rPr>
+""",
+        "",
+        1,
+    )
+    slide_path.write_text(slide_xml, encoding="utf-8")
+
+    SlideEditor().apply_fills(
+        str(slide_path),
+        {"2": {"action": "text", "text": "기본 서식 유지"}},
+    )
+
+    doc = parse(str(slide_path))
+    title_shape = _shape_by_id(doc, "2")
+    run_props = title_shape.getElementsByTagNameNS(DRAWINGML_NS, "rPr")[0]
+    latin = run_props.getElementsByTagNameNS(DRAWINGML_NS, "latin")[0]
+    color = run_props.getElementsByTagNameNS(DRAWINGML_NS, "srgbClr")[0]
+
+    assert run_props.tagName == "a:rPr"
+    assert run_props.getAttribute("sz") == "3600"
+    assert latin.getAttribute("typeface") == "FallbackFont"
+    assert color.getAttribute("val") == "ABCDEF"
 
 
 def test_apply_remove_deletes_shape_tree(tmp_path: Path) -> None:

--- a/tests/test_features/test_visualization/test_slide_editor.py
+++ b/tests/test_features/test_visualization/test_slide_editor.py
@@ -1,0 +1,321 @@
+"""SlideEditor XML 편집 테스트."""
+
+from pathlib import Path
+
+from defusedxml.minidom import parse
+
+from features.visualization.pptx import SlideEditor
+
+PML_NS = SlideEditor.PML_NS
+DRAWINGML_NS = SlideEditor.DRAWINGML_NS
+CHART_NS = SlideEditor.CHART_NS
+
+
+def make_sample_package(tmp_path: Path) -> tuple[Path, Path]:
+    """슬라이드 XML, rels, chart XML 을 포함한 최소 PPTX unpack 구조를 만든다."""
+    slides_dir = tmp_path / "ppt" / "slides"
+    rels_dir = slides_dir / "_rels"
+    charts_dir = tmp_path / "ppt" / "charts"
+    rels_dir.mkdir(parents=True)
+    charts_dir.mkdir(parents=True)
+
+    slide_path = slides_dir / "slide1.xml"
+    chart_path = charts_dir / "chart1.xml"
+
+    slide_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:spTree>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Designer Renamed Title"/>
+          <p:cNvSpPr/>
+          <p:nvPr><p:ph type="title"/></p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="685800" y="457200"/>
+            <a:ext cx="7772400" cy="914400"/>
+          </a:xfrm>
+          <a:gradFill>
+            <a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst>
+          </a:gradFill>
+          <a:effectLst><a:outerShdw blurRad="38100"/></a:effectLst>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr algn="ctr"/>
+            <a:r>
+              <a:rPr lang="ko-KR" sz="4000" b="0">
+                <a:solidFill><a:srgbClr val="123456"/></a:solidFill>
+                <a:latin typeface="Pretendard"/>
+              </a:rPr>
+              <a:t>여기에 프로젝트명</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Body Shape"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="914400" y="1600200"/>
+            <a:ext cx="5486400" cy="1371600"/>
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr algn="l"/>
+            <a:r><a:rPr sz="1800"/><a:t>삭제될 본문</a:t></a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:graphicFrame>
+        <p:nvGraphicFramePr>
+          <p:cNvPr id="8" name="Main Chart"/>
+          <p:cNvGraphicFramePr/>
+          <p:nvPr/>
+        </p:nvGraphicFramePr>
+        <p:xfrm>
+          <a:off x="1524000" y="3200400"/>
+          <a:ext cx="6096000" cy="2743200"/>
+        </p:xfrm>
+        <a:graphic>
+          <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+            <c:chart r:id="rId7"/>
+          </a:graphicData>
+        </a:graphic>
+      </p:graphicFrame>
+    </p:spTree>
+  </p:cSld>
+</p:sld>
+""",
+        encoding="utf-8",
+    )
+
+    (rels_dir / "slide1.xml.rels").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId7"
+                Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+                Target="../charts/chart1.xml"/>
+</Relationships>
+""",
+        encoding="utf-8",
+    )
+
+    chart_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:p><a:r><a:t>기존 차트</a:t></a:r></a:p></c:rich></c:tx>
+    </c:title>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:tx>
+            <c:strRef>
+              <c:f>Sheet1!$B$1</c:f>
+              <c:strCache>
+                <c:ptCount val="1"/>
+                <c:pt idx="0"><c:v>기존</c:v></c:pt>
+              </c:strCache>
+            </c:strRef>
+          </c:tx>
+          <c:cat>
+            <c:strRef>
+              <c:f>Sheet1!$A$2:$A$3</c:f>
+              <c:strCache>
+                <c:ptCount val="2"/>
+                <c:pt idx="0"><c:v>A</c:v></c:pt>
+                <c:pt idx="1"><c:v>B</c:v></c:pt>
+              </c:strCache>
+            </c:strRef>
+          </c:cat>
+          <c:val>
+            <c:numRef>
+              <c:f>Sheet1!$B$2:$B$3</c:f>
+              <c:numCache>
+                <c:formatCode>General</c:formatCode>
+                <c:ptCount val="2"/>
+                <c:pt idx="0"><c:v>10</c:v></c:pt>
+                <c:pt idx="1"><c:v>20</c:v></c:pt>
+              </c:numCache>
+            </c:numRef>
+          </c:val>
+        </c:ser>
+        <c:axId val="10"/>
+        <c:axId val="20"/>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>
+""",
+        encoding="utf-8",
+    )
+
+    return slide_path, chart_path
+
+
+def node_text(element) -> str:
+    return "".join(child.data for child in element.childNodes if child.nodeType == child.TEXT_NODE)
+
+
+def shape_by_id(doc, shape_id: str):
+    for shape in doc.getElementsByTagNameNS(PML_NS, "sp"):
+        c_nv_pr = shape.getElementsByTagNameNS(PML_NS, "cNvPr")[0]
+        if c_nv_pr.getAttribute("id") == shape_id:
+            return shape
+    raise AssertionError(f"shape not found: {shape_id}")
+
+
+def cache_values(cache) -> list[str]:
+    values = []
+    for point in cache.getElementsByTagNameNS(CHART_NS, "pt"):
+        values.append(node_text(point.getElementsByTagNameNS(CHART_NS, "v")[0]))
+    return values
+
+
+def test_extract_slots_reads_text_and_chart_metadata(tmp_path):
+    """텍스트/차트 Slot 과 EMU, 폰트 크기, 차트 캐시를 추출한다."""
+    slide_path, _ = make_sample_package(tmp_path)
+
+    slots = {slot["shape_id"]: slot for slot in SlideEditor().extract_slots(str(slide_path))}
+
+    assert set(slots) == {"2", "3", "8"}
+    assert slots["2"]["shape_name"] == "Designer Renamed Title"
+    assert slots["2"]["x_emu"] == 685800
+    assert slots["2"]["y_emu"] == 457200
+    assert slots["2"]["w_emu"] == 7772400
+    assert slots["2"]["h_emu"] == 914400
+    assert slots["2"]["current_text"] == "여기에 프로젝트명"
+    assert slots["2"]["is_title_placeholder"] is True
+    assert slots["2"]["font_size_pt"] == 40.0
+    assert slots["2"]["kind"] == "text"
+
+    assert slots["8"]["kind"] == "chart"
+    assert slots["8"]["chart_rel_id"] == "rId7"
+    assert slots["8"]["chart_type"] == "bar"
+    assert slots["8"]["current_text"] == "기존 차트"
+    assert slots["8"]["categories"] == ["A", "B"]
+    assert slots["8"]["series"] == [{"name": "기존", "values": [10, 20]}]
+    assert slots["8"]["x_emu"] == 1524000
+    assert slots["8"]["h_emu"] == 2743200
+
+
+def test_apply_text_preserves_shape_and_text_style_with_overrides(tmp_path):
+    """텍스트 교체 후 도형 서식은 보존하고 폰트 오버라이드를 반영한다."""
+    slide_path, _ = make_sample_package(tmp_path)
+
+    SlideEditor().apply_fills(
+        str(slide_path),
+        {
+            "2": {
+                "action": "text",
+                "text": "  새 제목\n두 번째 줄",
+                "font_size_override": 28,
+                "is_title": True,
+            }
+        },
+    )
+
+    doc = parse(str(slide_path))
+    title_shape = shape_by_id(doc, "2")
+    shape_props = title_shape.getElementsByTagNameNS(PML_NS, "spPr")[0]
+    paragraphs = title_shape.getElementsByTagNameNS(DRAWINGML_NS, "p")
+    texts = title_shape.getElementsByTagNameNS(DRAWINGML_NS, "t")
+
+    assert shape_props.getElementsByTagNameNS(DRAWINGML_NS, "gradFill")
+    assert shape_props.getElementsByTagNameNS(DRAWINGML_NS, "outerShdw")
+    assert [node_text(text) for text in texts] == ["  새 제목", "두 번째 줄"]
+    assert [text.getAttribute("xml:space") for text in texts] == ["preserve", "preserve"]
+
+    for paragraph in paragraphs:
+        paragraph_props = paragraph.getElementsByTagNameNS(DRAWINGML_NS, "pPr")[0]
+        run_props = paragraph.getElementsByTagNameNS(DRAWINGML_NS, "rPr")[0]
+        latin = run_props.getElementsByTagNameNS(DRAWINGML_NS, "latin")[0]
+        color = run_props.getElementsByTagNameNS(DRAWINGML_NS, "srgbClr")[0]
+        assert paragraph_props.getAttribute("algn") == "ctr"
+        assert run_props.getAttribute("sz") == "2800"
+        assert run_props.getAttribute("b") == "1"
+        assert latin.getAttribute("typeface") == "Pretendard"
+        assert color.getAttribute("val") == "123456"
+
+
+def test_apply_remove_deletes_shape_tree(tmp_path):
+    """remove action 은 대상 p:sp 전체를 제거한다."""
+    slide_path, _ = make_sample_package(tmp_path)
+
+    SlideEditor().apply_fills(str(slide_path), {"3": {"action": "remove"}})
+
+    doc = parse(str(slide_path))
+    shape_ids = [
+        shape.getElementsByTagNameNS(PML_NS, "cNvPr")[0].getAttribute("id")
+        for shape in doc.getElementsByTagNameNS(PML_NS, "sp")
+    ]
+
+    assert shape_ids == ["2"]
+    assert "삭제될 본문" not in slide_path.read_text(encoding="utf-8")
+
+
+def test_apply_chart_updates_cache_formulas_and_keeps_chart_type(tmp_path):
+    """chart action 은 캐시와 수식을 함께 갱신하고 차트 타입은 유지한다."""
+    slide_path, chart_path = make_sample_package(tmp_path)
+
+    SlideEditor().apply_fills(
+        str(slide_path),
+        {
+            "8": {
+                "action": "chart",
+                "data": {
+                    "categories": ["전환율", "이탈률", "잔존율"],
+                    "series": [{"name": "개선 후", "values": [148, 32, 91]}],
+                },
+                "font_size_override": 99,
+                "is_title": True,
+            }
+        },
+    )
+
+    doc = parse(str(chart_path))
+    bar_charts = doc.getElementsByTagNameNS(CHART_NS, "barChart")
+    assert len(bar_charts) == 1
+    assert not doc.getElementsByTagNameNS(CHART_NS, "lineChart")
+
+    series = bar_charts[0].getElementsByTagNameNS(CHART_NS, "ser")[0]
+    tx_cache = series.getElementsByTagNameNS(CHART_NS, "tx")[0].getElementsByTagNameNS(
+        CHART_NS, "strCache"
+    )[0]
+    cat_cache = series.getElementsByTagNameNS(CHART_NS, "cat")[0].getElementsByTagNameNS(
+        CHART_NS, "strCache"
+    )[0]
+    num_cache = series.getElementsByTagNameNS(CHART_NS, "numCache")[0]
+    formulas = [node_text(formula) for formula in doc.getElementsByTagNameNS(CHART_NS, "f")]
+
+    assert cache_values(tx_cache) == ["개선 후"]
+    assert tx_cache.getElementsByTagNameNS(CHART_NS, "ptCount")[0].getAttribute("val") == "1"
+    assert cache_values(cat_cache) == ["전환율", "이탈률", "잔존율"]
+    assert cat_cache.getElementsByTagNameNS(CHART_NS, "ptCount")[0].getAttribute("val") == "3"
+    assert cache_values(num_cache) == ["148", "32", "91"]
+    assert num_cache.getElementsByTagNameNS(CHART_NS, "ptCount")[0].getAttribute("val") == "3"
+    assert "Sheet1!$B$1" in formulas
+    assert "Sheet1!$A$2:$A$4" in formulas
+    assert "Sheet1!$B$2:$B$4" in formulas

--- a/uv.lock
+++ b/uv.lock
@@ -301,6 +301,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -348,6 +357,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "langchain" },
@@ -378,6 +388,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain", specifier = ">=1.2.3" },


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #207

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `features.visualization.pptx.SlideEditor` 추가
- `extract_slots()`로 텍스트 도형과 차트 graphicFrame의 Slot 메타데이터 추출
- `apply_fills()`로 텍스트 교체, 도형 제거, 차트 캐시 갱신 처리
- `defusedxml` 의존성 추가 및 샘플 OOXML 기반 테스트 작성

## 📸 스크린샷

- CLI 검증 결과로 대체

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 통과: `uv run pytest -q` (`515 passed`)
- 통과: `uv run ruff check features/visualization/pptx tests/test_features/test_visualization/test_slide_editor.py`
- 통과: `uv run ruff format --check features/visualization/pptx tests/test_features/test_visualization/test_slide_editor.py`
- 참고: 전체 `uv run ruff check .` / `uv run ruff format --check .`는 기존 미수정 파일의 lint/format 이슈로 실패합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PPTX 슬라이드에서 텍스트, 이미지, 차트의 메타데이터를 추출하고 편집할 수 있는 슬라이드 편집 기능 추가
  * 차트의 범주·시리즈 데이터 및 텍스트 내용을 슬라이드에서 갱신하는 기능 추가

* **Dependencies**
  * defusedxml 의존성 추가

* **Tests**
  * 슬라이드 추출 및 편집 동작을 검증하는 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->