### PR TITLE
[Feat] 시각 QA + Fix-and-Verify 루프 구현 [1.06]

### DIFF
--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -1,0 +1,704 @@
+"""시각 QA, fix-and-verify, 프리뷰 업로드 단계."""
+
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from common.llm.client import get_file_processor_llm
+from features.visualization.main_client import VisualizationMainClient
+from features.visualization.pptx import PptxRenderer, PptxToolchain, SlideEditor
+from features.visualization.storage.gcs_client import GcsClient
+
+IssueSeverity = Literal["warning", "error"]
+OutcomeStatus = Literal["ready", "error"]
+
+__all__ = [
+    "FixInstructionBuilder",
+    "IssueSeverity",
+    "LLMVisualFixer",
+    "OutcomeStatus",
+    "PreviewMetadata",
+    "SlidePreview",
+    "SlidePreviewOutcome",
+    "VisionLLM",
+    "VisualQA",
+    "VisualQAFixVerifyStep",
+    "VisualQAIssue",
+    "VisualQAPipelineResult",
+    "VisualQAResult",
+    "preview_metadata",
+]
+
+_MAX_TEXT_SUMMARY_CHARS = 1200
+_QA_SYSTEM_PROMPT = """렌더된 PPT 슬라이드 이미지를 검사하는 시각 QA 담당자입니다.
+응답은 반드시 JSON 객체 하나로만 작성하세요.
+스키마: {"passed": boolean, "issues": [{"code": string, "message": string, "severity": "warning"|"error", "retryable": boolean}]}
+검사 항목:
+1. 텍스트 오버플로우, 잘림, 화면 밖 이탈
+2. 요소 겹침
+3. 디자이너 안내 문구나 미교체 placeholder 잔존
+4. 읽기 어려울 정도로 작은 텍스트
+5. 전체 레이아웃 균형
+"""
+_FIX_SYSTEM_PROMPT = """PPTX OOXML 슬라이드의 자동 품질 보정 담당자입니다.
+응답은 반드시 JSON 객체 하나로만 작성하세요.
+스키마: {"fills": {"shape_id": {"action": "text", "text": string, "font_size_override": number|null, "is_title": boolean|null}}}
+지침:
+- 이슈 해결에 필요한 shape_id 만 수정하세요.
+- 숫자, 고유명사, 기술 스택, 성과 지표는 삭제하거나 변경하지 마세요.
+- 텍스트 요약이 불가피하면 의미를 보존하고 핵심 수치와 이름을 유지하세요.
+- 폰트 크기는 10pt 이상 48pt 이하로만 조정하세요.
+- 슬라이드 추가/삭제는 하지 마세요.
+"""
+
+
+class VisionLLM(Protocol):
+    """LangChain compatible vision LLM interface."""
+
+    def invoke(self, messages: list[object]) -> object:
+        """메시지를 처리하고 응답 객체를 반환한다."""
+
+
+class FixInstructionBuilder(Protocol):
+    """시각 QA 이슈를 SlideEditor fill 명령으로 변환한다."""
+
+    def build_fills(
+        self,
+        slide: SlidePreview,
+        qa_result: VisualQAResult,
+        *,
+        slide_xml_path: Path,
+        attempt: int,
+    ) -> dict[str, dict[str, Any]]:
+        """수정 대상 shape_id -> fill 맵을 반환한다."""
+
+
+@dataclass(frozen=True)
+class VisualQAIssue:
+    """단일 시각 QA 이슈."""
+
+    code: str
+    message: str
+    severity: IssueSeverity = "error"
+    retryable: bool = True
+
+
+@dataclass(frozen=True)
+class VisualQAResult:
+    """단일 슬라이드 시각 QA 결과."""
+
+    passed: bool
+    issues: tuple[VisualQAIssue, ...] = ()
+    raw_response: str = ""
+
+
+@dataclass(frozen=True)
+class SlidePreview:
+    """QA 단계가 처리할 렌더된 슬라이드 입력."""
+
+    slide_id: str
+    slide_order: int
+    slide_filename: str
+    image_path: Path
+    content_brief: str = ""
+    current_fills: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PreviewMetadata:
+    """업로드된 프리뷰 이미지 메타데이터."""
+
+    width: int
+    height: int
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class SlidePreviewOutcome:
+    """슬라이드별 QA 단계 최종 결과."""
+
+    slide_id: str
+    slide_order: int
+    status: OutcomeStatus
+    qa_attempts: int
+    gcs_preview_key: str | None = None
+    issues: tuple[VisualQAIssue, ...] = ()
+
+
+@dataclass(frozen=True)
+class VisualQAPipelineResult:
+    """QA 단계 전체 결과."""
+
+    outcomes: tuple[SlidePreviewOutcome, ...]
+    qa_checked_slide_orders: tuple[int, ...]
+    fix_attempts: int
+    pack_count: int
+    render_count: int
+
+    @property
+    def qa_performed(self) -> bool:
+        """완료 선언 전 시각 QA가 최소 1회 수행됐는지 반환한다."""
+        return bool(self.qa_checked_slide_orders)
+
+    def ensure_visual_qa_performed(self) -> None:
+        """시각 QA 없이 완료를 선언하려는 흐름을 차단한다."""
+        if not self.qa_performed:
+            raise RuntimeError("완료 선언 전 최소 1회 시각 QA가 필요합니다.")
+
+
+@dataclass
+class _PendingSlide:
+    slide: SlidePreview
+    image_path: Path
+    qa_attempts: int = 0
+    last_result: VisualQAResult | None = None
+
+
+class VisualQA:
+    """렌더된 슬라이드 이미지를 비전 LLM으로 검사한다."""
+
+    def __init__(self, llm: VisionLLM | None = None) -> None:
+        self._llm = llm
+
+    def check_slide(
+        self,
+        slide_image_path: str | Path,
+        expected_content: Mapping[str, Any] | None = None,
+    ) -> VisualQAResult:
+        """프리뷰 이미지를 검사하고 통과 여부와 이슈 목록을 반환한다."""
+        image_path = Path(slide_image_path)
+        if not image_path.is_file():
+            raise FileNotFoundError(f"슬라이드 프리뷰 이미지를 찾을 수 없습니다: {image_path}")
+
+        llm = self._llm or get_file_processor_llm()
+        messages = [
+            SystemMessage(content=_QA_SYSTEM_PROMPT),
+            HumanMessage(
+                content=[
+                    {
+                        "type": "text",
+                        "text": _build_qa_user_prompt(expected_content or {}),
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _image_data_url(image_path)},
+                    },
+                ]
+            ),
+        ]
+        response = llm.invoke(messages)
+        response_text = _normalize_response_text(getattr(response, "content", response))
+        return _parse_qa_response(response_text)
+
+
+class LLMVisualFixer:
+    """LLM 지시를 SlideEditor fill 맵으로 변환하는 기본 fix 빌더."""
+
+    def __init__(
+        self,
+        *,
+        llm: VisionLLM | None = None,
+        editor: SlideEditor | None = None,
+    ) -> None:
+        self._llm = llm
+        self._editor = editor or SlideEditor()
+
+    def build_fills(
+        self,
+        slide: SlidePreview,
+        qa_result: VisualQAResult,
+        *,
+        slide_xml_path: Path,
+        attempt: int,
+    ) -> dict[str, dict[str, Any]]:
+        """이슈와 현재 XML slot 정보를 기반으로 보정 fill 맵을 만든다."""
+        llm = self._llm or get_file_processor_llm()
+        slots = self._editor.extract_slots(str(slide_xml_path))
+        messages = [
+            SystemMessage(content=_FIX_SYSTEM_PROMPT),
+            HumanMessage(
+                content=_build_fix_user_prompt(
+                    slide=slide,
+                    issues=qa_result.issues,
+                    slots=slots,
+                    attempt=attempt,
+                )
+            ),
+        ]
+        response = llm.invoke(messages)
+        response_text = _normalize_response_text(getattr(response, "content", response))
+        return _parse_fix_response(response_text)
+
+
+class VisualQAFixVerifyStep:
+    """
+    Phase 1 Step 6: 시각 QA, 자동 수정 검증, 프리뷰 업로드, 슬라이드 콜백.
+
+    통과 슬라이드는 즉시 업로드하고, 이슈 슬라이드만 제한된 fix-and-verify 루프에서
+    재패키징/재렌더/재검사한다.
+    """
+
+    def __init__(
+        self,
+        *,
+        qa: VisualQA,
+        storage: GcsClient,
+        main_client: VisualizationMainClient,
+        editor: SlideEditor,
+        toolchain: PptxToolchain,
+        renderer: PptxRenderer,
+        fixer: FixInstructionBuilder | None = None,
+        max_fix_attempts: int = 2,
+        clock: Any | None = None,
+    ) -> None:
+        if max_fix_attempts < 0:
+            raise ValueError("max_fix_attempts는 0 이상이어야 합니다.")
+        self._qa = qa
+        self._storage = storage
+        self._main_client = main_client
+        self._editor = editor
+        self._toolchain = toolchain
+        self._renderer = renderer
+        self._fixer = fixer or LLMVisualFixer(editor=editor)
+        self._max_fix_attempts = max_fix_attempts
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    async def process(
+        self,
+        *,
+        job_id: str,
+        slides: list[SlidePreview],
+        unpacked_dir: str | Path,
+        working_pptx_path: str | Path,
+        fixed_pptx_path: str | Path,
+        render_output_dir: str | Path,
+    ) -> VisualQAPipelineResult:
+        """렌더된 슬라이드들을 QA 처리하고 슬라이드별 ready/error 콜백을 보낸다."""
+        if not slides:
+            raise ValueError("시각 QA 대상 슬라이드가 없습니다.")
+
+        unpacked_root = Path(unpacked_dir)
+        working_pptx = Path(working_pptx_path)
+        fixed_pptx = Path(fixed_pptx_path)
+        render_dir = Path(render_output_dir)
+        pending = {
+            slide.slide_order: _PendingSlide(slide=slide, image_path=slide.image_path)
+            for slide in sorted(slides, key=lambda item: item.slide_order)
+        }
+        outcomes: dict[int, SlidePreviewOutcome] = {}
+        checked_orders: list[int] = []
+        pack_count = 0
+        render_count = 0
+
+        failed_orders = await self._check_and_publish_passes(
+            job_id=job_id,
+            pending=pending,
+            candidate_orders=tuple(pending),
+            outcomes=outcomes,
+            checked_orders=checked_orders,
+        )
+
+        fix_attempts = 0
+        while failed_orders and fix_attempts < self._max_fix_attempts:
+            fix_attempts += 1
+            affected_orders = tuple(failed_orders)
+            self._apply_fixes(
+                pending=pending,
+                affected_orders=affected_orders,
+                unpacked_root=unpacked_root,
+                attempt=fix_attempts,
+            )
+            fixed_pptx.parent.mkdir(parents=True, exist_ok=True)
+            self._toolchain.pack(unpacked_root, fixed_pptx, original_pptx=working_pptx)
+            pack_count += 1
+
+            render_result = self._renderer.render(fixed_pptx, render_dir)
+            render_count += 1
+            rendered_by_page = {
+                rendered.page: rendered.image_path for rendered in render_result.slides
+            }
+            for slide_order in affected_orders:
+                if slide_order not in rendered_by_page:
+                    raise RuntimeError(
+                        f"재렌더 결과에 slide_order={slide_order} 이미지가 없습니다."
+                    )
+                pending[slide_order].image_path = rendered_by_page[slide_order]
+
+            failed_orders = await self._check_and_publish_passes(
+                job_id=job_id,
+                pending=pending,
+                candidate_orders=affected_orders,
+                outcomes=outcomes,
+                checked_orders=checked_orders,
+            )
+
+        for slide_order in failed_orders:
+            pending_slide = pending[slide_order]
+            qa_result = pending_slide.last_result or VisualQAResult(
+                passed=False,
+                issues=(VisualQAIssue(code="visual_qa_failed", message="시각 QA에 실패했습니다."),),
+            )
+            message = _format_issue_message(qa_result.issues)
+            await self._send_preview_error(job_id, pending_slide.slide, message=message)
+            outcomes[slide_order] = SlidePreviewOutcome(
+                slide_id=pending_slide.slide.slide_id,
+                slide_order=slide_order,
+                status="error",
+                qa_attempts=pending_slide.qa_attempts,
+                issues=qa_result.issues,
+            )
+
+        result = VisualQAPipelineResult(
+            outcomes=tuple(outcomes[key] for key in sorted(outcomes)),
+            qa_checked_slide_orders=tuple(checked_orders),
+            fix_attempts=fix_attempts,
+            pack_count=pack_count,
+            render_count=render_count,
+        )
+        result.ensure_visual_qa_performed()
+        return result
+
+    async def _check_and_publish_passes(
+        self,
+        *,
+        job_id: str,
+        pending: dict[int, _PendingSlide],
+        candidate_orders: tuple[int, ...],
+        outcomes: dict[int, SlidePreviewOutcome],
+        checked_orders: list[int],
+    ) -> list[int]:
+        failed_orders: list[int] = []
+        for slide_order in candidate_orders:
+            if slide_order in outcomes:
+                continue
+            pending_slide = pending[slide_order]
+            qa_result = self._qa.check_slide(
+                pending_slide.image_path,
+                _expected_content(pending_slide.slide),
+            )
+            pending_slide.qa_attempts += 1
+            pending_slide.last_result = qa_result
+            checked_orders.append(slide_order)
+            if qa_result.passed:
+                gcs_key = await self._upload_and_send_ready(job_id, pending_slide)
+                outcomes[slide_order] = SlidePreviewOutcome(
+                    slide_id=pending_slide.slide.slide_id,
+                    slide_order=slide_order,
+                    status="ready",
+                    qa_attempts=pending_slide.qa_attempts,
+                    gcs_preview_key=gcs_key,
+                )
+                continue
+            failed_orders.append(slide_order)
+        return failed_orders
+
+    def _apply_fixes(
+        self,
+        *,
+        pending: dict[int, _PendingSlide],
+        affected_orders: tuple[int, ...],
+        unpacked_root: Path,
+        attempt: int,
+    ) -> None:
+        for slide_order in affected_orders:
+            pending_slide = pending[slide_order]
+            qa_result = pending_slide.last_result
+            if qa_result is None:
+                raise RuntimeError(f"slide_order={slide_order} 의 QA 결과가 없습니다.")
+            slide_xml_path = _slide_xml_path(unpacked_root, pending_slide.slide.slide_filename)
+            fills = self._fixer.build_fills(
+                pending_slide.slide,
+                qa_result,
+                slide_xml_path=slide_xml_path,
+                attempt=attempt,
+            )
+            if not fills:
+                raise RuntimeError(f"slide_order={slide_order} 자동 수정 fill 이 비어 있습니다.")
+            self._editor.apply_fills(str(slide_xml_path), fills)
+
+    async def _upload_and_send_ready(self, job_id: str, pending_slide: _PendingSlide) -> str:
+        slide = pending_slide.slide
+        metadata = preview_metadata(pending_slide.image_path)
+        gcs_key = self._storage.upload_preview(job_id, slide.slide_order, pending_slide.image_path)
+        await self._main_client.send_slide_event(
+            job_id,
+            slide.slide_id,
+            event="slide_preview_ready",
+            slide_order=slide.slide_order,
+            idempotency_key=_idempotency_key(job_id, slide, "slide_preview_ready"),
+            occurred_at=self._now_iso(),
+            gcs_preview_key=gcs_key,
+            preview_width=metadata.width,
+            preview_height=metadata.height,
+            preview_byte_size=metadata.byte_size,
+        )
+        return gcs_key
+
+    async def _send_preview_error(
+        self,
+        job_id: str,
+        slide: SlidePreview,
+        *,
+        message: str,
+    ) -> None:
+        await self._main_client.send_slide_event(
+            job_id,
+            slide.slide_id,
+            event="slide_preview_error",
+            slide_order=slide.slide_order,
+            idempotency_key=_idempotency_key(job_id, slide, "slide_preview_error"),
+            occurred_at=self._now_iso(),
+            message=message,
+            retryable=True,
+        )
+
+    def _now_iso(self) -> str:
+        now = self._clock()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=UTC)
+        return now.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def preview_metadata(image_path: str | Path) -> PreviewMetadata:
+    """프리뷰 이미지의 width/height/byteSize 를 읽는다."""
+    path = Path(image_path)
+    data = path.read_bytes()
+    width, height = _image_dimensions(data)
+    return PreviewMetadata(width=width, height=height, byte_size=len(data))
+
+
+def _build_qa_user_prompt(expected_content: Mapping[str, Any]) -> str:
+    brief = expected_content.get("brief") or expected_content.get("content_brief") or "N/A"
+    texts_summary = expected_content.get("texts_summary") or "N/A"
+    return (
+        "이 PPT 슬라이드 이미지를 검사하세요.\n\n"
+        "예상 내용:\n"
+        f"- 슬라이드 요지: {brief}\n"
+        f"- 채워진 주요 텍스트: {texts_summary}\n\n"
+        "통과면 passed=true 와 빈 issues 를 반환하세요. "
+        "문제가 있으면 자동 수정 가능한 원인을 code/message 로 구체화하세요."
+    )
+
+
+def _build_fix_user_prompt(
+    *,
+    slide: SlidePreview,
+    issues: tuple[VisualQAIssue, ...],
+    slots: list[dict[str, Any]],
+    attempt: int,
+) -> str:
+    payload = {
+        "slide_order": slide.slide_order,
+        "content_brief": slide.content_brief,
+        "current_fills": slide.current_fills,
+        "issues": [
+            {
+                "code": issue.code,
+                "message": issue.message,
+                "severity": issue.severity,
+                "retryable": issue.retryable,
+            }
+            for issue in issues
+        ],
+        "slots": slots,
+        "attempt": attempt,
+    }
+    return (
+        "다음 QA 이슈를 해결하는 최소 fill 변경을 산출하세요.\n"
+        "숫자, 고유명사, 기술 스택, 성과 지표는 반드시 보존하세요.\n"
+        f"{json.dumps(payload, ensure_ascii=False, default=str)}"
+    )
+
+
+def _expected_content(slide: SlidePreview) -> dict[str, str]:
+    return {
+        "brief": slide.content_brief,
+        "texts_summary": _summarize_fills(slide.current_fills),
+    }
+
+
+def _summarize_fills(fills: Mapping[str, Any]) -> str:
+    texts: list[str] = []
+    for shape_id, fill in fills.items():
+        if not isinstance(fill, Mapping):
+            continue
+        text = fill.get("text")
+        if text is None:
+            continue
+        texts.append(f"{shape_id}: {text}")
+    summary = "\n".join(texts)
+    if len(summary) <= _MAX_TEXT_SUMMARY_CHARS:
+        return summary
+    return f"{summary[:_MAX_TEXT_SUMMARY_CHARS].rstrip()}\n...(요약 길이 제한)"
+
+
+def _image_data_url(image_path: Path) -> str:
+    content_type = mimetypes.guess_type(image_path.name)[0] or "image/jpeg"
+    encoded = base64.b64encode(image_path.read_bytes()).decode("utf-8")
+    return f"data:{content_type};base64,{encoded}"
+
+
+def _normalize_response_text(content: object) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        texts: list[str] = []
+        for item in content:
+            if isinstance(item, str) and item.strip():
+                texts.append(item.strip())
+            elif isinstance(item, Mapping):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    texts.append(text.strip())
+        return "\n".join(texts).strip()
+    return str(content).strip()
+
+
+def _parse_qa_response(response_text: str) -> VisualQAResult:
+    try:
+        payload = _loads_json_object(response_text)
+    except ValueError as exc:
+        return VisualQAResult(
+            passed=False,
+            issues=(
+                VisualQAIssue(
+                    code="qa_parse_error",
+                    message=f"시각 QA 응답을 해석할 수 없습니다: {exc}",
+                ),
+            ),
+            raw_response=response_text,
+        )
+
+    issues = tuple(_parse_issue(item) for item in payload.get("issues") or [])
+    passed = bool(payload.get("passed")) and not issues
+    return VisualQAResult(passed=passed, issues=issues, raw_response=response_text)
+
+
+def _parse_issue(item: object) -> VisualQAIssue:
+    if isinstance(item, str):
+        return VisualQAIssue(code="visual_issue", message=item)
+    if not isinstance(item, Mapping):
+        return VisualQAIssue(code="visual_issue", message=str(item))
+    severity = item.get("severity")
+    if severity not in {"warning", "error"}:
+        severity = "error"
+    return VisualQAIssue(
+        code=str(item.get("code") or "visual_issue"),
+        message=str(item.get("message") or item.get("detail") or "시각 QA 이슈가 발견되었습니다."),
+        severity=severity,
+        retryable=bool(item.get("retryable", True)),
+    )
+
+
+def _parse_fix_response(response_text: str) -> dict[str, dict[str, Any]]:
+    payload = _loads_json_object(response_text)
+    fills = payload.get("fills")
+    if not isinstance(fills, Mapping):
+        raise ValueError("자동 수정 응답에는 fills 객체가 필요합니다.")
+    normalized: dict[str, dict[str, Any]] = {}
+    for shape_id, fill in fills.items():
+        if not isinstance(fill, Mapping):
+            continue
+        normalized[str(shape_id)] = dict(fill)
+    return normalized
+
+
+def _loads_json_object(response_text: str) -> dict[str, Any]:
+    cleaned = _strip_json_fence(response_text)
+    try:
+        payload = json.loads(cleaned)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", cleaned, flags=re.DOTALL)
+        if match is None:
+            raise ValueError("JSON 객체를 찾을 수 없습니다.") from None
+        payload = json.loads(match.group(0))
+    if not isinstance(payload, dict):
+        raise ValueError("JSON 객체가 아닙니다.")
+    return payload
+
+
+def _strip_json_fence(text: str) -> str:
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    stripped = re.sub(r"^```(?:json)?\s*", "", stripped)
+    stripped = re.sub(r"\s*```$", "", stripped)
+    return stripped.strip()
+
+
+def _format_issue_message(issues: tuple[VisualQAIssue, ...]) -> str:
+    if not issues:
+        return "시각 QA를 통과하지 못했습니다."
+    return "; ".join(f"{issue.code}: {issue.message}" for issue in issues)
+
+
+def _slide_xml_path(unpacked_root: Path, slide_filename: str) -> Path:
+    path = unpacked_root / "ppt" / "slides" / slide_filename
+    if not path.is_file():
+        raise FileNotFoundError(f"슬라이드 XML을 찾을 수 없습니다: {path}")
+    return path
+
+
+def _idempotency_key(job_id: str, slide: SlidePreview, event: str) -> str:
+    return f"{job_id}:{slide.slide_id}:{slide.slide_order}:{event}"
+
+
+def _image_dimensions(data: bytes) -> tuple[int, int]:
+    if data.startswith(b"\x89PNG\r\n\x1a\n") and len(data) >= 24:
+        return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
+    if data.startswith(b"\xff\xd8"):
+        return _jpeg_dimensions(data)
+    raise ValueError("지원하지 않는 프리뷰 이미지 형식입니다.")
+
+
+def _jpeg_dimensions(data: bytes) -> tuple[int, int]:
+    index = 2
+    while index < len(data):
+        while index < len(data) and data[index] != 0xFF:
+            index += 1
+        while index < len(data) and data[index] == 0xFF:
+            index += 1
+        if index >= len(data):
+            break
+
+        marker = data[index]
+        index += 1
+        if marker in {0xD8, 0xD9} or 0xD0 <= marker <= 0xD7:
+            continue
+        if index + 2 > len(data):
+            break
+        segment_length = int.from_bytes(data[index : index + 2], "big")
+        if segment_length < 2 or index + segment_length > len(data):
+            break
+        if marker in {
+            0xC0,
+            0xC1,
+            0xC2,
+            0xC3,
+            0xC5,
+            0xC6,
+            0xC7,
+            0xC9,
+            0xCA,
+            0xCB,
+            0xCD,
+            0xCE,
+            0xCF,
+        }:
+            if segment_length < 7:
+                break
+            height = int.from_bytes(data[index + 3 : index + 5], "big")
+            width = int.from_bytes(data[index + 5 : index + 7], "big")
+            return width, height
+        index += segment_length
+    raise ValueError("JPEG 프리뷰 이미지 크기를 읽을 수 없습니다.")

--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
+import logging
 import mimetypes
 import re
 from collections.abc import Mapping
@@ -18,6 +20,8 @@ from common.llm.client import get_file_processor_llm
 from features.visualization.main_client import VisualizationMainClient
 from features.visualization.pptx import PptxRenderer, PptxToolchain, SlideEditor
 from features.visualization.storage.gcs_client import GcsClient
+
+logger = logging.getLogger(__name__)
 
 IssueSeverity = Literal["warning", "error"]
 OutcomeStatus = Literal["ready", "error"]
@@ -312,35 +316,43 @@ class VisualQAFixVerifyStep:
         while failed_orders and fix_attempts < self._max_fix_attempts:
             fix_attempts += 1
             affected_orders = tuple(failed_orders)
-            self._apply_fixes(
+            fixed_orders = await self._apply_fixes(
                 pending=pending,
                 affected_orders=affected_orders,
                 unpacked_root=unpacked_root,
                 attempt=fix_attempts,
             )
-            fixed_pptx.parent.mkdir(parents=True, exist_ok=True)
-            self._toolchain.pack(unpacked_root, fixed_pptx, original_pptx=working_pptx)
-            pack_count += 1
+            unfixed_orders = [
+                slide_order for slide_order in affected_orders if slide_order not in fixed_orders
+            ]
+            recheck_failed_orders: list[int] = []
 
-            render_result = self._renderer.render(fixed_pptx, render_dir)
-            render_count += 1
-            rendered_by_page = {
-                rendered.page: rendered.image_path for rendered in render_result.slides
-            }
-            for slide_order in affected_orders:
-                if slide_order not in rendered_by_page:
-                    raise RuntimeError(
-                        f"재렌더 결과에 slide_order={slide_order} 이미지가 없습니다."
-                    )
-                pending[slide_order].image_path = rendered_by_page[slide_order]
+            if fixed_orders:
+                fixed_pptx.parent.mkdir(parents=True, exist_ok=True)
+                self._toolchain.pack(unpacked_root, fixed_pptx, original_pptx=working_pptx)
+                pack_count += 1
 
-            failed_orders = await self._check_and_publish_passes(
-                job_id=job_id,
-                pending=pending,
-                candidate_orders=affected_orders,
-                outcomes=outcomes,
-                checked_orders=checked_orders,
-            )
+                render_result = self._renderer.render(fixed_pptx, render_dir)
+                render_count += 1
+                rendered_by_page = {
+                    rendered.page: rendered.image_path for rendered in render_result.slides
+                }
+                for slide_order in fixed_orders:
+                    if slide_order not in rendered_by_page:
+                        raise RuntimeError(
+                            f"재렌더 결과에 slide_order={slide_order} 이미지가 없습니다."
+                        )
+                    pending[slide_order].image_path = rendered_by_page[slide_order]
+
+                recheck_failed_orders = await self._check_and_publish_passes(
+                    job_id=job_id,
+                    pending=pending,
+                    candidate_orders=fixed_orders,
+                    outcomes=outcomes,
+                    checked_orders=checked_orders,
+                )
+
+            failed_orders = [*unfixed_orders, *recheck_failed_orders]
 
         for slide_order in failed_orders:
             pending_slide = pending[slide_order]
@@ -349,7 +361,12 @@ class VisualQAFixVerifyStep:
                 issues=(VisualQAIssue(code="visual_qa_failed", message="시각 QA에 실패했습니다."),),
             )
             message = _format_issue_message(qa_result.issues)
-            await self._send_preview_error(job_id, pending_slide.slide, message=message)
+            await self._send_preview_error(
+                job_id,
+                pending_slide.slide,
+                message=message,
+                retryable=_issues_retryable(qa_result.issues),
+            )
             outcomes[slide_order] = SlidePreviewOutcome(
                 slide_id=pending_slide.slide.slide_id,
                 slide_order=slide_order,
@@ -382,7 +399,8 @@ class VisualQAFixVerifyStep:
             if slide_order in outcomes:
                 continue
             pending_slide = pending[slide_order]
-            qa_result = self._qa.check_slide(
+            qa_result = await asyncio.to_thread(
+                self._qa.check_slide,
                 pending_slide.image_path,
                 _expected_content(pending_slide.slide),
             )
@@ -402,29 +420,52 @@ class VisualQAFixVerifyStep:
             failed_orders.append(slide_order)
         return failed_orders
 
-    def _apply_fixes(
+    async def _apply_fixes(
         self,
         *,
         pending: dict[int, _PendingSlide],
         affected_orders: tuple[int, ...],
         unpacked_root: Path,
         attempt: int,
-    ) -> None:
+    ) -> tuple[int, ...]:
+        fixed_orders: list[int] = []
         for slide_order in affected_orders:
             pending_slide = pending[slide_order]
             qa_result = pending_slide.last_result
             if qa_result is None:
                 raise RuntimeError(f"slide_order={slide_order} 의 QA 결과가 없습니다.")
             slide_xml_path = _slide_xml_path(unpacked_root, pending_slide.slide.slide_filename)
-            fills = self._fixer.build_fills(
-                pending_slide.slide,
-                qa_result,
-                slide_xml_path=slide_xml_path,
-                attempt=attempt,
-            )
-            if not fills:
-                raise RuntimeError(f"slide_order={slide_order} 자동 수정 fill 이 비어 있습니다.")
-            self._editor.apply_fills(str(slide_xml_path), fills)
+            try:
+                fills = await asyncio.to_thread(
+                    self._fixer.build_fills,
+                    pending_slide.slide,
+                    qa_result,
+                    slide_xml_path=slide_xml_path,
+                    attempt=attempt,
+                )
+                if not fills:
+                    raise ValueError("자동 수정 fill 이 비어 있습니다.")
+                await asyncio.to_thread(self._editor.apply_fills, str(slide_xml_path), fills)
+            except Exception as exc:
+                logger.warning(
+                    "visual QA fix failed: slide_order=%s attempt=%s error=%s",
+                    slide_order,
+                    attempt,
+                    exc,
+                )
+                pending_slide.last_result = VisualQAResult(
+                    passed=False,
+                    issues=(
+                        VisualQAIssue(
+                            code="fix_failed",
+                            message=f"자동 수정에 실패했습니다: {exc}",
+                            retryable=True,
+                        ),
+                    ),
+                )
+                continue
+            fixed_orders.append(slide_order)
+        return tuple(fixed_orders)
 
     async def _upload_and_send_ready(self, job_id: str, pending_slide: _PendingSlide) -> str:
         slide = pending_slide.slide
@@ -450,6 +491,7 @@ class VisualQAFixVerifyStep:
         slide: SlidePreview,
         *,
         message: str,
+        retryable: bool,
     ) -> None:
         await self._main_client.send_slide_event(
             job_id,
@@ -459,7 +501,7 @@ class VisualQAFixVerifyStep:
             idempotency_key=_idempotency_key(job_id, slide, "slide_preview_error"),
             occurred_at=self._now_iso(),
             message=message,
-            retryable=True,
+            retryable=retryable,
         )
 
     def _now_iso(self) -> str:
@@ -615,16 +657,20 @@ def _parse_fix_response(response_text: str) -> dict[str, dict[str, Any]]:
 
 def _loads_json_object(response_text: str) -> dict[str, Any]:
     cleaned = _strip_json_fence(response_text)
-    try:
-        payload = json.loads(cleaned)
-    except json.JSONDecodeError:
-        match = re.search(r"\{.*\}", cleaned, flags=re.DOTALL)
-        if match is None:
-            raise ValueError("JSON 객체를 찾을 수 없습니다.") from None
-        payload = json.loads(match.group(0))
-    if not isinstance(payload, dict):
-        raise ValueError("JSON 객체가 아닙니다.")
-    return payload
+    decoder = json.JSONDecoder()
+    starts = [index for index, char in enumerate(cleaned) if char == "{"]
+    if cleaned.startswith("{") and 0 not in starts:
+        starts.insert(0, 0)
+
+    for start in starts:
+        try:
+            payload, _ = decoder.raw_decode(cleaned, idx=start)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+
+    raise ValueError("JSON 객체를 찾을 수 없습니다.")
 
 
 def _strip_json_fence(text: str) -> str:
@@ -640,6 +686,12 @@ def _format_issue_message(issues: tuple[VisualQAIssue, ...]) -> str:
     if not issues:
         return "시각 QA를 통과하지 못했습니다."
     return "; ".join(f"{issue.code}: {issue.message}" for issue in issues)
+
+
+def _issues_retryable(issues: tuple[VisualQAIssue, ...]) -> bool:
+    if not issues:
+        return True
+    return any(issue.retryable for issue in issues)
 
 
 def _slide_xml_path(unpacked_root: Path, slide_filename: str) -> Path:

--- a/features/visualization/main_client.py
+++ b/features/visualization/main_client.py
@@ -153,6 +153,9 @@ class VisualizationMainClient(BaseClient):
         schema_version: int = 1,
         current_fills: dict[str, Any] | None = None,
         gcs_preview_key: str | None = None,
+        preview_width: int | None = None,
+        preview_height: int | None = None,
+        preview_byte_size: int | None = None,
         message: str | None = None,
         retryable: bool | None = None,
     ) -> None:
@@ -160,6 +163,7 @@ class VisualizationMainClient(BaseClient):
 
         event: slide_content_ready | slide_content_error |
                slide_preview_ready | slide_preview_error | slide_regenerated
+        preview_width / preview_height / preview_byte_size: preview_ready 메타데이터
         current_fills 내부 키는 snake_case 그대로 전송 (§11.0.3).
         """
         body: dict[str, Any] = {
@@ -173,6 +177,12 @@ class VisualizationMainClient(BaseClient):
             body["currentFills"] = current_fills
         if gcs_preview_key is not None:
             body["gcsPreviewKey"] = gcs_preview_key
+        if preview_width is not None:
+            body["width"] = preview_width
+        if preview_height is not None:
+            body["height"] = preview_height
+        if preview_byte_size is not None:
+            body["byteSize"] = preview_byte_size
         if message is not None:
             body["message"] = message
         if retryable is not None:

--- a/tasks/phase-1-pptx-worker/06-visual-qa-fix-verify.md
+++ b/tasks/phase-1-pptx-worker/06-visual-qa-fix-verify.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/06-visual-qa-fix-verify.md"
 depends_on: ["1.02", "1.03", "1.04", "1.11", "1.12"]
 blocks: ["1.05"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: 2026-05-27
 owner: ""
 sprint: ""
 ---
@@ -25,24 +26,24 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] LLM 비전 호출 클라이언트(`common/llm`) 확인
-- [ ] 오버플로우/미교체 안내문구 포함 샘플 프리뷰 이미지 픽스처
+- [x] LLM 비전 호출 클라이언트(`common/llm`) 확인
+- [x] 오버플로우/미교체 안내문구 포함 샘플 프리뷰 이미지 픽스처
 
 ## 구현 체크리스트
 
-- [ ] `VisualQA.check_slide()` — 오버플로우/잘림·겹침·미교체 안내문구·가독성·균형 검사 → 통과/이슈 목록
-- [ ] 통과 슬라이드: canonical key `previews/slide-{slide_order:02d}.jpg` PUT 후 `slide_preview_ready`(gcsPreviewKey·width·height·byteSize) 즉시 발신
-- [ ] 이슈 슬라이드: fix-and-verify 큐 → XML 일괄 수정 → pack 1회·PDF 변환 1회(배치) → 영향 슬라이드만 재 QA
-- [ ] 최대 2회 실패 시 `slide_preview_error`(message·retryable) 발신
-- [ ] 완료 전 최소 1회 시각 QA 강제, 재검증은 영향 슬라이드만
-- [ ] 자동 요약 가드: 숫자·고유명사·성과 지표 보존 프롬프트(§5.4.1), 자동 수정은 한도 미차감
+- [x] `VisualQA.check_slide()` — 오버플로우/잘림·겹침·미교체 안내문구·가독성·균형 검사 → 통과/이슈 목록
+- [x] 통과 슬라이드: canonical key `previews/slide-{slide_order:02d}.jpg` PUT 후 `slide_preview_ready`(gcsPreviewKey·width·height·byteSize) 즉시 발신
+- [x] 이슈 슬라이드: fix-and-verify 큐 → XML 일괄 수정 → pack 1회·PDF 변환 1회(배치) → 영향 슬라이드만 재 QA
+- [x] 최대 2회 실패 시 `slide_preview_error`(message·retryable) 발신
+- [x] 완료 전 최소 1회 시각 QA 강제, 재검증은 영향 슬라이드만
+- [x] 자동 요약 가드: 숫자·고유명사·성과 지표 보존 프롬프트(§5.4.1), 자동 수정은 한도 미차감
 
 ## Definition of Done
 
-- [ ] 이슈/정상 이미지 분류 정확도 검증
-- [ ] 통과 슬라이드 canonical key 업로드 + 슬라이드별 `slide_preview_ready` 발신 검증
-- [ ] 1차 수정 통과 시 업로드, 2회 실패 시 `slide_preview_error`(retryable) 검증
-- [ ] fix-and-verify 가 영향 슬라이드만 재 QA, pack/PDF 배치 1회 검증
+- [x] 이슈/정상 이미지 분류 정확도 검증
+- [x] 통과 슬라이드 canonical key 업로드 + 슬라이드별 `slide_preview_ready` 발신 검증
+- [x] 1차 수정 통과 시 업로드, 2회 실패 시 `slide_preview_error`(retryable) 검증
+- [x] fix-and-verify 가 영향 슬라이드만 재 QA, pack/PDF 배치 1회 검증
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_main_client.py
+++ b/tests/test_features/test_visualization/test_main_client.py
@@ -287,10 +287,16 @@ class TestSendSlideEvent:
                 idempotency_key="idem-3",
                 occurred_at="2026-05-25T10:01:00Z",
                 gcs_preview_key="jobs/job-1/previews/slide-02.jpg",
+                preview_width=1280,
+                preview_height=720,
+                preview_byte_size=123456,
             )
         body = mock_rwr.call_args.kwargs["json"]
         assert body["event"] == "slide_preview_ready"
         assert body["gcsPreviewKey"] == "jobs/job-1/previews/slide-02.jpg"
+        assert body["width"] == 1280
+        assert body["height"] == 720
+        assert body["byteSize"] == 123456
         assert "currentFills" not in body
 
     @pytest.mark.asyncio

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -132,6 +132,25 @@ class FakeFixer:
         }
 
 
+class FailingFixer:
+    """자동 수정 지시 생성 실패 대역."""
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def build_fills(
+        self,
+        slide: SlidePreview,
+        qa_result: VisualQAResult,
+        *,
+        slide_xml_path: Path,
+        attempt: int,
+    ) -> dict[str, dict[str, Any]]:
+        del qa_result, slide_xml_path, attempt
+        self.calls.append(slide.slide_order)
+        raise ValueError("LLM JSON 파싱 실패")
+
+
 class FakeToolchain:
     """PPTX pack 대역."""
 
@@ -197,6 +216,26 @@ def test_visual_qa_classifies_passed_and_issue_slides(tmp_path: Path) -> None:
     assert failed.issues[0].code == "placeholder"
     assert failed.issues[0].message == "안내 문구 잔존"
     assert len(llm.messages) == 2
+
+
+def test_visual_qa_parses_first_json_object_from_wrapped_response(tmp_path: Path) -> None:
+    """설명 텍스트와 여러 JSON 블록이 있어도 첫 JSON 객체를 안전하게 파싱한다."""
+    image_path = tmp_path / "slide-01.jpg"
+    _write_jpeg(image_path, width=800, height=450)
+    llm = FakeLLM(
+        [
+            (
+                '검사 결과입니다.\n{"passed": true, "issues": []}\n'
+                '{"passed": false, "issues": [{"code": "wrong"}]}'
+            )
+        ]
+    )
+    qa = VisualQA(llm=llm)
+
+    result = qa.check_slide(image_path, {"brief": "표지"})
+
+    assert result.passed is True
+    assert result.issues == ()
 
 
 def test_llm_visual_fixer_preserves_guardrails_in_prompt(tmp_path: Path) -> None:
@@ -354,6 +393,74 @@ async def test_failed_after_max_attempts_sends_retryable_preview_error(tmp_path:
     assert result.fix_attempts == 2
 
 
+@pytest.mark.asyncio
+async def test_failed_after_max_attempts_preserves_non_retryable_issue(
+    tmp_path: Path,
+) -> None:
+    """QA 이슈가 retryable=false 이면 preview error 콜백도 false 로 보낸다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    qa = FakeQA(
+        {
+            1: [
+                _failed("fatal_layout", retryable=False),
+                _failed("fatal_layout", retryable=False),
+            ]
+        }
+    )
+    step = context.make_step(qa=qa, renderer=FakeRenderer(pages=[1]), max_fix_attempts=1)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    event = context.main_client.events[0]
+    assert event["event"] == "slide_preview_error"
+    assert event["retryable"] is False
+    assert result.outcomes[0].issues[0].retryable is False
+
+
+@pytest.mark.asyncio
+async def test_fix_failure_reports_slide_error_without_aborting_job(tmp_path: Path) -> None:
+    """자동 수정 응답 파싱 실패는 전체 job 중단 대신 해당 슬라이드 error 로 보고한다."""
+    context = _make_step_context(tmp_path, slide_orders=[1, 2])
+    context.fixer = FailingFixer()
+    qa = FakeQA(
+        {
+            1: [_failed("overflow")],
+            2: [_passed()],
+        }
+    )
+    renderer = FakeRenderer(pages=[1, 2])
+    step = context.make_step(qa=qa, renderer=renderer, max_fix_attempts=1)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert context.fixer.calls == [1]
+    assert context.toolchain.pack_calls == []
+    assert renderer.calls == []
+    assert [event["event"] for event in context.main_client.events] == [
+        "slide_preview_ready",
+        "slide_preview_error",
+    ]
+    error_event = context.main_client.events[1]
+    assert error_event["slide_order"] == 1
+    assert error_event["retryable"] is True
+    assert "fix_failed" in error_event["message"]
+    assert [outcome.status for outcome in result.outcomes] == ["error", "ready"]
+
+
 def test_preview_metadata_reads_jpeg_dimensions_and_size(tmp_path: Path) -> None:
     """프리뷰 콜백용 이미지 메타데이터를 JPEG에서 읽는다."""
     image_path = tmp_path / "slide-01.jpg"
@@ -381,7 +488,13 @@ class StepContext:
     fixer: FakeFixer
     toolchain: FakeToolchain
 
-    def make_step(self, *, qa: FakeQA, renderer: FakeRenderer) -> VisualQAFixVerifyStep:
+    def make_step(
+        self,
+        *,
+        qa: FakeQA,
+        renderer: FakeRenderer,
+        max_fix_attempts: int = 2,
+    ) -> VisualQAFixVerifyStep:
         return VisualQAFixVerifyStep(
             qa=qa,
             storage=self.storage,
@@ -390,6 +503,7 @@ class StepContext:
             toolchain=self.toolchain,
             renderer=renderer,
             fixer=self.fixer,
+            max_fix_attempts=max_fix_attempts,
             clock=lambda: datetime(2026, 5, 27, 3, 0, tzinfo=UTC),
         )
 
@@ -437,10 +551,10 @@ def _passed() -> VisualQAResult:
     return VisualQAResult(passed=True)
 
 
-def _failed(code: str) -> VisualQAResult:
+def _failed(code: str, *, retryable: bool = True) -> VisualQAResult:
     return VisualQAResult(
         passed=False,
-        issues=(VisualQAIssue(code=code, message=f"{code} issue"),),
+        issues=(VisualQAIssue(code=code, message=f"{code} issue", retryable=retryable),),
     )
 
 

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -1,0 +1,468 @@
+"""시각 QA + fix-and-verify 단계 테스트."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from features.visualization.qa import (
+    LLMVisualFixer,
+    SlidePreview,
+    VisualQA,
+    VisualQAFixVerifyStep,
+    VisualQAIssue,
+    VisualQAResult,
+    preview_metadata,
+)
+from features.visualization.storage.gcs_client import preview_key
+
+
+@dataclass
+class LLMResponse:
+    """테스트용 LLM 응답."""
+
+    content: object
+
+
+class FakeLLM:
+    """순서대로 응답하는 LLM 대역."""
+
+    def __init__(self, responses: list[object]) -> None:
+        self.responses = responses
+        self.messages: list[list[object]] = []
+
+    def invoke(self, messages: list[object]) -> LLMResponse:
+        self.messages.append(messages)
+        if not self.responses:
+            raise AssertionError("LLM 응답이 소진되었습니다.")
+        return LLMResponse(self.responses.pop(0))
+
+
+class FakeSlotEditor:
+    """LLMVisualFixer 용 Slot 추출 대역."""
+
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+
+    def extract_slots(self, slide_xml_path: str) -> list[dict[str, Any]]:
+        self.paths.append(slide_xml_path)
+        return [
+            {
+                "shape_id": "2",
+                "current_text": "Folioo 매출 42% 개선",
+                "font_size_pt": 18,
+                "kind": "text",
+            }
+        ]
+
+
+class FakeQA:
+    """슬라이드 순서별 QA 응답 대역."""
+
+    def __init__(self, responses: dict[int, list[VisualQAResult]]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[int, dict[str, str]]] = []
+
+    def check_slide(
+        self, slide_image_path: Path, expected_content: dict[str, str]
+    ) -> VisualQAResult:
+        slide_order = _slide_order_from_path(slide_image_path)
+        self.calls.append((slide_order, expected_content))
+        if not self.responses[slide_order]:
+            raise AssertionError(f"slide_order={slide_order} QA 응답이 소진되었습니다.")
+        return self.responses[slide_order].pop(0)
+
+
+class FakeStorage:
+    """GCS 업로드 대역."""
+
+    def __init__(self) -> None:
+        self.uploads: list[tuple[str, int, Path]] = []
+
+    def upload_preview(self, job_id: str, slide_order: int, src: Path) -> str:
+        self.uploads.append((job_id, slide_order, src))
+        return preview_key(job_id, slide_order)
+
+
+class FakeMainClient:
+    """메인 콜백 클라이언트 대역."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def send_slide_event(self, job_id: str, slide_id: str, **kwargs: Any) -> None:
+        self.events.append({"job_id": job_id, "slide_id": slide_id, **kwargs})
+
+
+class FakeEditor:
+    """SlideEditor.apply_fills 대역."""
+
+    def __init__(self) -> None:
+        self.applied: list[tuple[str, dict[str, dict[str, Any]]]] = []
+
+    def apply_fills(self, slide_xml_path: str, fills: dict[str, dict[str, Any]]) -> None:
+        assert Path(slide_xml_path).is_file()
+        self.applied.append((slide_xml_path, fills))
+
+
+class FakeFixer:
+    """QA 이슈를 고정 fill 로 변환하는 대역."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int, tuple[VisualQAIssue, ...]]] = []
+
+    def build_fills(
+        self,
+        slide: SlidePreview,
+        qa_result: VisualQAResult,
+        *,
+        slide_xml_path: Path,
+        attempt: int,
+    ) -> dict[str, dict[str, Any]]:
+        assert slide_xml_path.is_file()
+        self.calls.append((slide.slide_order, attempt, qa_result.issues))
+        return {
+            "2": {
+                "action": "text",
+                "text": f"수정된 슬라이드 {slide.slide_order}",
+                "font_size_override": 14,
+            }
+        }
+
+
+class FakeToolchain:
+    """PPTX pack 대역."""
+
+    def __init__(self) -> None:
+        self.pack_calls: list[tuple[Path, Path, Path]] = []
+
+    def pack(self, unpacked_dir: Path, output_pptx: Path, *, original_pptx: Path) -> None:
+        self.pack_calls.append((unpacked_dir, output_pptx, original_pptx))
+        output_pptx.write_bytes(b"pptx")
+
+
+@dataclass(frozen=True)
+class FakeRenderedSlide:
+    """렌더된 슬라이드 대역."""
+
+    page: int
+    image_path: Path
+
+
+@dataclass(frozen=True)
+class FakeRenderResult:
+    """렌더 결과 대역."""
+
+    slides: tuple[FakeRenderedSlide, ...]
+
+
+class FakeRenderer:
+    """PPTX 렌더러 대역."""
+
+    def __init__(self, pages: list[int]) -> None:
+        self.pages = pages
+        self.calls: list[tuple[Path, Path]] = []
+
+    def render(self, pptx_path: Path, output_dir: Path) -> FakeRenderResult:
+        self.calls.append((pptx_path, output_dir))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        rendered = []
+        for page in self.pages:
+            image_path = output_dir / f"slide-{page:02d}.jpg"
+            _write_jpeg(image_path, width=960 + page, height=540 + page)
+            rendered.append(FakeRenderedSlide(page=page, image_path=image_path))
+        return FakeRenderResult(slides=tuple(rendered))
+
+
+def test_visual_qa_classifies_passed_and_issue_slides(tmp_path: Path) -> None:
+    """LLM JSON 응답을 통과/이슈 결과로 파싱한다."""
+    image_path = tmp_path / "slide-01.jpg"
+    _write_jpeg(image_path, width=800, height=450)
+    llm = FakeLLM(
+        [
+            '{"passed": true, "issues": []}',
+            '{"passed": false, "issues": [{"code": "placeholder", "message": "안내 문구 잔존"}]}',
+        ]
+    )
+    qa = VisualQA(llm=llm)
+
+    passed = qa.check_slide(image_path, {"brief": "표지", "texts_summary": "Folioo"})
+    failed = qa.check_slide(image_path, {"brief": "본문", "texts_summary": "여기에 프로젝트명"})
+
+    assert passed.passed is True
+    assert passed.issues == ()
+    assert failed.passed is False
+    assert failed.issues[0].code == "placeholder"
+    assert failed.issues[0].message == "안내 문구 잔존"
+    assert len(llm.messages) == 2
+
+
+def test_llm_visual_fixer_preserves_guardrails_in_prompt(tmp_path: Path) -> None:
+    """자동 수정 프롬프트가 숫자·고유명사·성과 지표 보존 가드를 포함한다."""
+    slide_xml = tmp_path / "slide1.xml"
+    slide_xml.write_text("<p:sld/>", encoding="utf-8")
+    llm = FakeLLM(
+        [
+            (
+                '{"fills": {"2": {"action": "text", '
+                '"text": "Folioo 매출 42% 개선", "font_size_override": 14}}}'
+            )
+        ]
+    )
+    fixer = LLMVisualFixer(llm=llm, editor=FakeSlotEditor())
+    slide = SlidePreview(
+        slide_id="slide-1",
+        slide_order=1,
+        slide_filename="slide1.xml",
+        image_path=tmp_path / "slide-01.jpg",
+        content_brief="Folioo 성과 요약",
+        current_fills={"2": {"text": "Folioo 매출 42% 개선"}},
+    )
+
+    fills = fixer.build_fills(
+        slide,
+        VisualQAResult(
+            passed=False,
+            issues=(VisualQAIssue(code="overflow", message="텍스트 넘침"),),
+        ),
+        slide_xml_path=slide_xml,
+        attempt=1,
+    )
+
+    assert fills["2"]["text"] == "Folioo 매출 42% 개선"
+    system_prompt = llm.messages[0][0].content
+    user_prompt = llm.messages[0][1].content
+    assert "숫자" in system_prompt
+    assert "고유명사" in system_prompt
+    assert "성과 지표" in system_prompt
+    assert "Folioo 매출 42% 개선" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_passed_slides_upload_preview_and_send_ready_callbacks(tmp_path: Path) -> None:
+    """정상 슬라이드는 canonical key 로 업로드되고 즉시 ready 콜백이 발신된다."""
+    context = _make_step_context(tmp_path, slide_orders=[1, 2])
+    qa = FakeQA(
+        {
+            1: [_passed()],
+            2: [_passed()],
+        }
+    )
+    step = context.make_step(qa=qa, renderer=FakeRenderer(pages=[1, 2]))
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert result.qa_performed is True
+    assert result.qa_checked_slide_orders == (1, 2)
+    assert [outcome.status for outcome in result.outcomes] == ["ready", "ready"]
+    assert [upload[:2] for upload in context.storage.uploads] == [("job-1", 1), ("job-1", 2)]
+    assert [event["event"] for event in context.main_client.events] == [
+        "slide_preview_ready",
+        "slide_preview_ready",
+    ]
+    first_event = context.main_client.events[0]
+    assert first_event["gcs_preview_key"] == "jobs/job-1/previews/slide-01.jpg"
+    assert first_event["preview_width"] == 801
+    assert first_event["preview_height"] == 451
+    assert first_event["preview_byte_size"] == len(context.slides[0].image_path.read_bytes())
+    assert context.toolchain.pack_calls == []
+
+
+@pytest.mark.asyncio
+async def test_issue_slides_are_fixed_as_batch_and_only_affected_slides_rechecked(
+    tmp_path: Path,
+) -> None:
+    """이슈 슬라이드만 fix-and-verify 대상이 되고 pack/render 는 배치 1회로 묶인다."""
+    context = _make_step_context(tmp_path, slide_orders=[1, 2, 3])
+    qa = FakeQA(
+        {
+            1: [_failed("overflow"), _passed()],
+            2: [_passed()],
+            3: [_failed("placeholder"), _passed()],
+        }
+    )
+    renderer = FakeRenderer(pages=[1, 2, 3])
+    step = context.make_step(qa=qa, renderer=renderer)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert [call[0] for call in qa.calls] == [1, 2, 3, 1, 3]
+    assert [call[0] for call in context.fixer.calls] == [1, 3]
+    assert len(context.editor.applied) == 2
+    assert result.fix_attempts == 1
+    assert result.pack_count == 1
+    assert result.render_count == 1
+    assert len(context.toolchain.pack_calls) == 1
+    assert len(renderer.calls) == 1
+    assert [event["slide_order"] for event in context.main_client.events] == [2, 1, 3]
+    assert all(event["event"] == "slide_preview_ready" for event in context.main_client.events)
+    assert [outcome.status for outcome in result.outcomes] == ["ready", "ready", "ready"]
+
+
+@pytest.mark.asyncio
+async def test_failed_after_max_attempts_sends_retryable_preview_error(tmp_path: Path) -> None:
+    """최대 수정 시도 후에도 실패하면 retryable preview error 로 보고한다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    qa = FakeQA(
+        {
+            1: [
+                _failed("overflow"),
+                _failed("overflow"),
+                _failed("overflow"),
+            ]
+        }
+    )
+    renderer = FakeRenderer(pages=[1])
+    step = context.make_step(qa=qa, renderer=renderer)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert context.storage.uploads == []
+    assert [call[0] for call in context.fixer.calls] == [1, 1]
+    assert len(context.toolchain.pack_calls) == 2
+    assert len(renderer.calls) == 2
+    assert len(context.main_client.events) == 1
+    event = context.main_client.events[0]
+    assert event["event"] == "slide_preview_error"
+    assert event["retryable"] is True
+    assert "overflow" in event["message"]
+    assert result.outcomes[0].status == "error"
+    assert result.outcomes[0].qa_attempts == 3
+    assert result.fix_attempts == 2
+
+
+def test_preview_metadata_reads_jpeg_dimensions_and_size(tmp_path: Path) -> None:
+    """프리뷰 콜백용 이미지 메타데이터를 JPEG에서 읽는다."""
+    image_path = tmp_path / "slide-01.jpg"
+    _write_jpeg(image_path, width=1280, height=720)
+
+    metadata = preview_metadata(image_path)
+
+    assert metadata.width == 1280
+    assert metadata.height == 720
+    assert metadata.byte_size == len(image_path.read_bytes())
+
+
+@dataclass
+class StepContext:
+    """Step 컨트롤러 테스트 fixture."""
+
+    unpacked_dir: Path
+    working_pptx: Path
+    fixed_pptx: Path
+    render_dir: Path
+    slides: list[SlidePreview]
+    storage: FakeStorage
+    main_client: FakeMainClient
+    editor: FakeEditor
+    fixer: FakeFixer
+    toolchain: FakeToolchain
+
+    def make_step(self, *, qa: FakeQA, renderer: FakeRenderer) -> VisualQAFixVerifyStep:
+        return VisualQAFixVerifyStep(
+            qa=qa,
+            storage=self.storage,
+            main_client=self.main_client,
+            editor=self.editor,
+            toolchain=self.toolchain,
+            renderer=renderer,
+            fixer=self.fixer,
+            clock=lambda: datetime(2026, 5, 27, 3, 0, tzinfo=UTC),
+        )
+
+
+def _make_step_context(tmp_path: Path, *, slide_orders: list[int]) -> StepContext:
+    unpacked_dir = tmp_path / "unpacked"
+    slides_dir = unpacked_dir / "ppt" / "slides"
+    slides_dir.mkdir(parents=True)
+    image_dir = tmp_path / "initial-images"
+    image_dir.mkdir()
+    slides: list[SlidePreview] = []
+    for slide_order in slide_orders:
+        slide_filename = f"slide{slide_order}.xml"
+        (slides_dir / slide_filename).write_text("<p:sld/>", encoding="utf-8")
+        image_path = image_dir / f"slide-{slide_order:02d}.jpg"
+        _write_jpeg(image_path, width=800 + slide_order, height=450 + slide_order)
+        slides.append(
+            SlidePreview(
+                slide_id=f"slide-{slide_order}",
+                slide_order=slide_order,
+                slide_filename=slide_filename,
+                image_path=image_path,
+                content_brief=f"슬라이드 {slide_order} 요약",
+                current_fills={"2": {"text": f"Folioo KPI {slide_order * 10}%"}},
+            )
+        )
+
+    working_pptx = tmp_path / "working.pptx"
+    working_pptx.write_bytes(b"pptx")
+    return StepContext(
+        unpacked_dir=unpacked_dir,
+        working_pptx=working_pptx,
+        fixed_pptx=tmp_path / "fixed.pptx",
+        render_dir=tmp_path / "rendered",
+        slides=slides,
+        storage=FakeStorage(),
+        main_client=FakeMainClient(),
+        editor=FakeEditor(),
+        fixer=FakeFixer(),
+        toolchain=FakeToolchain(),
+    )
+
+
+def _passed() -> VisualQAResult:
+    return VisualQAResult(passed=True)
+
+
+def _failed(code: str) -> VisualQAResult:
+    return VisualQAResult(
+        passed=False,
+        issues=(VisualQAIssue(code=code, message=f"{code} issue"),),
+    )
+
+
+def _slide_order_from_path(path: Path) -> int:
+    return int(path.stem.rsplit("-", maxsplit=1)[1])
+
+
+def _write_jpeg(path: Path, *, width: int, height: int) -> None:
+    """SOF0 width/height 를 포함한 최소 JPEG 바이트를 쓴다."""
+    sof0_payload = (
+        b"\x08"
+        + height.to_bytes(2, "big")
+        + width.to_bytes(2, "big")
+        + b"\x03"
+        + b"\x01\x11\x00"
+        + b"\x02\x11\x00"
+        + b"\x03\x11\x00"
+    )
+    path.write_bytes(
+        b"\xff\xd8"
+        + b"\xff\xc0"
+        + (len(sof0_payload) + 2).to_bytes(2, "big")
+        + sof0_payload
+        + b"\xff\xd9"
+    )


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #219

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `apps/pptx-worker/features/visualization/qa.py` 추가
  - `VisualQA.check_slide()`로 렌더된 슬라이드 이미지를 비전 LLM에 전달하고 통과/이슈 결과를 JSON으로 파싱
  - `LLMVisualFixer`로 QA 이슈를 SlideEditor fill 명령으로 변환
  - `VisualQAFixVerifyStep`로 통과 슬라이드 즉시 GCS 업로드 + `slide_preview_ready` 콜백 처리
  - 이슈 슬라이드만 XML 수정 → pack 1회 → render 1회 → 영향 슬라이드만 재 QA하는 fix-and-verify 루프 구현
  - 최대 2회 실패 시 `slide_preview_error`와 `retryable=true` 콜백 발신
- `VisualizationMainClient.send_slide_event()`에 프리뷰 메타데이터 `width`/`height`/`byteSize` 전달 지원 추가
- 자동 수정 프롬프트에 숫자·고유명사·기술 스택·성과 지표 보존 가드 반영
- Task 1.06 문서와 GitHub 이슈 체크리스트를 완료 상태로 갱신
- QA 분류, canonical preview 업로드, ready/error 콜백, 재검증 범위, batch pack/render 검증 테스트 추가

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과
  - `uv run pytest` 통과 (`576 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 워커는 signed URL을 발급하지 않고 `gcsPreviewKey`만 콜백합니다.
- 실제 LLM 비전 호출과 GCS PUT은 런타임의 OpenRouter/GCS 인증 설정에 의존합니다. 단위 테스트는 LLM·GCS·렌더러·toolchain 대역으로 계약을 검증합니다.
