### PR TITLE
[Feat] 템플릿 등록 파이프라인 스크립트 구현 [1.08]

### DIFF
--- a/docs/architecture/pptx-gen-plan-v6.md
+++ b/docs/architecture/pptx-gen-plan-v6.md
@@ -463,7 +463,7 @@ Expected Output:
 ┌──────────────────────────────────────────────────────┐
 │  [워커] Step 4: 패킹 + 검증 (모든 슬라이드 편집 완료 후 1회)│
 │                                                       │
-│  ① pack.py --original template_blue.pptx               │
+│  ① pack.py --original template.pptx                    │
 │     - XML condense (a:t 제외)                          │
 │     - ZIP DEFLATE로 패키징                              │
 │     - 원본 대비 검증                                    │

--- a/docs/architecture/template-system.md
+++ b/docs/architecture/template-system.md
@@ -165,8 +165,9 @@ python scripts/templates/build_meta.py \
 
 # 내부적으로 수행하는 일:
 #   1) soffice 로 PDF 변환 후 pdftoppm 으로 슬라이드별 JPG 추출
+#      (기본 위치: 배포 디렉터리 밖의 work dir, --work-dir 로 override 가능)
 #   2) 그리드 썸네일 생성 (templates/blue/thumbnail.jpg)
-#   3) markitdown 으로 슬라이드별 임시 텍스트 추출
+#   3) markitdown 으로 슬라이드별 임시 텍스트 추출 (기본 위치: work dir/slide_text.md)
 #   4) LLM 에 (썸네일 + 텍스트) 묶음 입력 →
 #      슬라이드별 { category, description, best_for } 초안 생성
 #   5) 같은 카테고리끼리 묶어 id 알파벳 자동 부여
@@ -179,6 +180,8 @@ python scripts/templates/validate_template.py ./templates/blue
 
 # 검증 내용:
 #   - meta.json 스키마 (필수 필드 누락 X)
+#   - template_file 이 경로 없이 정확히 template.pptx 인지
+#   - thumbnail.jpg 가 존재하고 비어 있지 않은지
 #   - category 가 templates/_schema/categories.json 안에 있는지 (unknown 이면 실패 — 운영자가 실제 카테고리로 교체해야 통과)
 #   - slide_index 가 0..N-1 연속인지, PPTX 내 슬라이드 수와 일치하는지
 #   - 같은 템플릿 내 id 중복 없는지

--- a/docs/architecture/template-system.md
+++ b/docs/architecture/template-system.md
@@ -13,7 +13,7 @@ templates/
 ├── blue/
 │   ├── template.pptx          ← 파란색 조합, 30~40장 Source Slide 풀
 │   ├── meta.json              ← Source Slide 별 메타데이터
-│   └── thumbnail.jpg          ← 그리드 썸네일 (LLM 참고용)
+│   └── thumbnail.jpg          ← 그리드 썸네일 (런타임 선택 LLM/운영자 참고용)
 ├── green/
 │   ├── template.pptx          ← 초록색 조합 (같은 레이아웃, 다른 색)
 │   ├── meta.json
@@ -27,7 +27,7 @@ templates/
 ### 3.2 하나의 Template PPTX 내부
 
 ```
-template_blue.pptx (30~40장의 Source Slide 풀)
+templates/blue/template.pptx (30~40장의 Source Slide 풀)
 ├── Source Slide 1: 표지 레이아웃 A (cover_A)
 ├── Source Slide 2: 표지 레이아웃 B (cover_B)
 ├── Source Slide 3: 개요 레이아웃 A (overview_A)
@@ -115,12 +115,13 @@ template_blue.pptx (30~40장의 Source Slide 풀)
 }
 ```
 
-각 Source Slide 엔트리는 다음 5개 필드만 유지한다:
+빌더가 만든 초안에는 운영자 검토를 알리는 `_draft_notice` 가 추가될 수 있다.
+런타임 Source Slide 선택에 쓰이는 각 Source Slide 엔트리는 다음 5개 필드만 유지한다:
 
 | 필드 | 용도 |
 |---|---|
 | `slide_index` | Template PPTX 내부 Source Slide 순서 (0-based) |
-| `id` | 디자이너가 부여한 Source Slide 식별자 (예: `cover_A`) |
+| `id` | 등록 파이프라인이 자동 부여하고 운영자가 검토하는 Source Slide 식별자 (예: `cover_A`) |
 | `category` | §3.3 표준 Enum 중 하나 |
 | `description` | LLM 이 Source Slide 풀에서 선택할 때 참고하는 짧은 설명 |
 | `best_for` | 어떤 콘텐츠에 적합한지 한 줄 가이드 |
@@ -147,7 +148,7 @@ flowchart TD
     D --> S1["[1] 자동 추출 (스크립트, 운영자 1회 실행)<br/>· PPTX 슬라이드 수 / slide_index<br/>· 슬라이드별 임시 텍스트 (markitdown)<br/>· 슬라이드별 썸네일 + 그리드 썸네일"]
     S1 --> S2["[2] LLM 보조 — meta.json 초안 생성<br/>· 입력: 슬라이드별 (썸네일 + 임시 텍스트)<br/>· 출력: category 후보 + description + best_for<br/>· id 자동 부여 (같은 카테고리 내 알파벳 순)"]
     S2 --> S3["[3] 운영자 검토 (사람의 손)<br/>· category 분류 보정 (cover ↔ closing 등)<br/>· description / best_for 다듬기<br/>· id 직관성 검토<br/>· 시각적 문제 → 디자이너 회신"]
-    S3 --> S4["[4] 자동 검증 (스크립트, CI/CD)<br/>· category 표준 Enum 범위 내<br/>· slide_index ↔ 실제 슬라이드 수 일치<br/>· 같은 템플릿 내 id 중복 없음<br/>· 카테고리 분포 권장 범위 (경고만)"]
+    S3 --> S4["[4] 자동 검증 (운영자 또는 CI 잡)<br/>· template_file = template.pptx<br/>· thumbnail.jpg 존재<br/>· category 표준 Enum 범위 내<br/>· slide_index ↔ 실제 슬라이드 수 일치<br/>· 같은 템플릿 내 id 중복 없음<br/>· 카테고리 분포 권장 범위 (경고만)"]
     S4 --> S5["[5] GCS 업로드 (운영자 또는 CD 파이프라인)<br/>gs://folioo-visualizations/templates/{template_id}/<br/>template.pptx · meta.json · thumbnail.jpg"]
 ```
 
@@ -175,7 +176,7 @@ python scripts/templates/build_meta.py \
 
 # [3] 운영자가 IDE 에서 meta.json 직접 검토/수정 (사람의 손)
 
-# [4] 검증 — CI 에서도 실행
+# [4] 검증 — 운영자 또는 CI 잡에서 실행
 python scripts/templates/validate_template.py ./templates/blue
 
 # 검증 내용:
@@ -258,7 +259,7 @@ User (슬라이드마다 반복):
 3. 각 Slot 후보 자리에 실제로 들어갈 콘텐츠와 비슷한 예시 텍스트 입력
    (예: "여기에 프로젝트명", "도구: Figma, Notion" 등 — LLM 이 의미를 이해할 단서)
 4. 색상 바꿔서 다른 이름으로 저장 → 새 템플릿 파일
-5. meta.json 에 슬라이드별 한 줄 description + best_for 추가
+5. 색상별 template.pptx 를 운영자 등록 파이프라인에 전달
 
 → 도형마다 영문 이름을 부여하는 작업 X
 → max_chars 같은 후속 메타 수기 입력 X

--- a/features/visualization/templates/__init__.py
+++ b/features/visualization/templates/__init__.py
@@ -1,0 +1,34 @@
+"""템플릿 등록 파이프라인 유틸리티."""
+
+from .builder import (
+    BuildMetaOptions,
+    BuildMetaResult,
+    LlmSlideDraftGenerator,
+    MarkitdownSlideTextExtractor,
+    SlideDraft,
+    SlideDraftInput,
+    TextExtractionResult,
+    build_template_metadata,
+)
+from .categories import CategoryDefinition, CategorySchema, load_category_schema
+from .pptx import SlideText, count_pptx_slides, extract_slide_texts
+from .validation import TemplateValidationResult, validate_template_directory
+
+__all__ = [
+    "BuildMetaOptions",
+    "BuildMetaResult",
+    "CategoryDefinition",
+    "CategorySchema",
+    "LlmSlideDraftGenerator",
+    "MarkitdownSlideTextExtractor",
+    "SlideDraft",
+    "SlideDraftInput",
+    "SlideText",
+    "TemplateValidationResult",
+    "TextExtractionResult",
+    "build_template_metadata",
+    "count_pptx_slides",
+    "extract_slide_texts",
+    "load_category_schema",
+    "validate_template_directory",
+]

--- a/features/visualization/templates/builder.py
+++ b/features/visualization/templates/builder.py
@@ -1,0 +1,391 @@
+"""템플릿 PPTX에서 meta.json 초안을 생성하는 오프라인 빌더."""
+
+import base64
+import json
+import logging
+import re
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, Field
+
+from .categories import DEFAULT_CATEGORY_SCHEMA_PATH, CategorySchema, load_category_schema
+from .pptx import SlideText, count_pptx_slides, extract_slide_texts
+from .thumbnail import PillowThumbnailBuilder
+
+_DRAFT_NOTICE = (
+    "이 파일은 LLM이 생성한 템플릿 메타데이터 초안입니다. "
+    "운영자는 category, description, best_for, id를 검토한 뒤 배포해야 합니다. "
+    "slide_index와 template_file은 자동 생성 필드이므로 수정하지 마세요."
+)
+_LLM_IMAGE_MAX_SIZE = (1024, 1024)
+_LLM_IMAGE_QUALITY = 72
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BuildMetaOptions:
+    """meta.json 초안 생성 옵션."""
+
+    pptx_path: Path
+    template_id: str
+    primary_color: str
+    output_path: Path
+    theme_name: str | None = None
+    category_schema_path: Path | None = None
+    slides_dir: Path | None = None
+    thumbnail_path: Path | None = None
+    text_output_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class SlideDraftInput:
+    """LLM 초안 생성에 입력할 단일 Source Slide 정보."""
+
+    slide_index: int
+    image_path: Path
+    text: str
+
+
+@dataclass(frozen=True)
+class SlideDraft:
+    """단일 Source Slide 의미 메타데이터 초안."""
+
+    category: str
+    description: str
+    best_for: str
+
+
+@dataclass(frozen=True)
+class TextExtractionResult:
+    """markitdown/OOXML 기반 임시 텍스트 추출 결과."""
+
+    deck_text: str
+    slide_texts: tuple[SlideText, ...]
+
+
+@dataclass(frozen=True)
+class BuildMetaResult:
+    """meta.json 초안 생성 결과."""
+
+    meta_path: Path
+    slide_image_paths: tuple[Path, ...]
+    thumbnail_path: Path
+    text_output_path: Path
+
+
+class Renderer(Protocol):
+    """PPTX 렌더러 프로토콜."""
+
+    def render(self, pptx_path: Path | str, output_dir: Path | str):
+        """PPTX를 PDF/JPG로 렌더링한다."""
+
+
+class ThumbnailBuilder(Protocol):
+    """그리드 썸네일 생성기 프로토콜."""
+
+    def build(self, slide_images: Sequence[Path], output_path: Path) -> Path:
+        """슬라이드 이미지 목록으로 thumbnail.jpg를 생성한다."""
+
+
+class TextExtractor(Protocol):
+    """슬라이드 텍스트 추출기 프로토콜."""
+
+    def extract(self, pptx_path: Path) -> TextExtractionResult:
+        """PPTX에서 임시 텍스트를 추출한다."""
+
+
+class SlideDraftGenerator(Protocol):
+    """Source Slide 의미 메타데이터 초안 생성기 프로토콜."""
+
+    def generate(self, slide: SlideDraftInput, categories: CategorySchema) -> SlideDraft:
+        """단일 Source Slide 의미 필드 초안을 생성한다."""
+
+
+class MarkitdownSlideTextExtractor:
+    """markitdown 결과와 OOXML 슬라이드 텍스트를 함께 저장하는 추출기."""
+
+    def extract(self, pptx_path: Path) -> TextExtractionResult:
+        """markitdown으로 덱 텍스트를 만들고, OOXML에서 슬라이드별 텍스트를 추출한다."""
+        try:
+            from markitdown import MarkItDown
+        except ImportError as exc:
+            raise RuntimeError(
+                "markitdown이 설치되지 않았습니다. "
+                "uv sync --group template-tools 후 다시 실행하세요."
+            ) from exc
+
+        converted = MarkItDown().convert(str(pptx_path))
+        deck_text = str(getattr(converted, "text_content", "") or "").strip()
+        return TextExtractionResult(
+            deck_text=deck_text,
+            slide_texts=extract_slide_texts(pptx_path),
+        )
+
+
+class _SlideDraftOutput(BaseModel):
+    """LLM 구조화 출력."""
+
+    category: str = Field(description="표준 카테고리 키 또는 unknown")
+    description: str = Field(description="레이아웃과 구성을 요약한 한 줄 설명")
+    best_for: str = Field(description="어떤 콘텐츠에 적합한지 설명하는 한 줄 가이드")
+
+
+class LlmSlideDraftGenerator:
+    """OpenRouter LLM 기반 Source Slide 의미 필드 초안 생성기."""
+
+    def __init__(self, *, model: str | None = None, temperature: float = 0.1) -> None:
+        self.model = model
+        self.temperature = temperature
+
+    def generate(self, slide: SlideDraftInput, categories: CategorySchema) -> SlideDraft:
+        """썸네일과 임시 텍스트를 LLM에 입력해 Source Slide 초안을 생성한다."""
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        from common.llm.client import get_llm_uncached
+
+        llm = get_llm_uncached(model=self.model, temperature=self.temperature, timeout=120)
+        structured_llm = llm.with_structured_output(_SlideDraftOutput)
+        output = structured_llm.invoke(
+            [
+                SystemMessage(
+                    content=(
+                        "너는 PPT Source Slide 분류 전문가야. "
+                        "슬라이드 썸네일과 임시 텍스트를 보고 표준 카테고리 중 하나로 분류해. "
+                        "확실하지 않으면 unknown을 사용해. "
+                        "description과 best_for는 운영자가 검토할 초안으로 짧게 작성해."
+                    )
+                ),
+                HumanMessage(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": _format_llm_prompt_text(slide, categories),
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": _image_data_uri(slide.image_path)},
+                        },
+                    ]
+                ),
+            ]
+        )
+        return SlideDraft(
+            category=output.category.strip(),
+            description=output.description.strip(),
+            best_for=output.best_for.strip(),
+        )
+
+
+def build_template_metadata(
+    options: BuildMetaOptions,
+    *,
+    renderer: Renderer | None = None,
+    thumbnail_builder: ThumbnailBuilder | None = None,
+    text_extractor: TextExtractor | None = None,
+    draft_generator: SlideDraftGenerator | None = None,
+) -> BuildMetaResult:
+    """PPTX 렌더링, 텍스트 추출, LLM 초안 생성을 수행해 meta.json을 작성한다."""
+    _validate_options(options)
+
+    output_path = options.output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    slides_dir = options.slides_dir or output_path.parent / "slides"
+    thumbnail_path = options.thumbnail_path or output_path.parent / "thumbnail.jpg"
+    text_output_path = options.text_output_path or output_path.parent / "slide_text.md"
+
+    schema = load_category_schema(options.category_schema_path or DEFAULT_CATEGORY_SCHEMA_PATH)
+    slide_count = count_pptx_slides(options.pptx_path)
+    if slide_count == 0:
+        raise ValueError("PPTX에 Source Slide가 없습니다.")
+
+    active_renderer = renderer or _default_renderer()
+    render_result = active_renderer.render(options.pptx_path, slides_dir)
+    slide_image_paths = tuple(Path(path) for path in render_result.image_paths)
+    if len(slide_image_paths) != slide_count:
+        raise ValueError(
+            "렌더링된 슬라이드 이미지 수가 PPTX 슬라이드 수와 일치하지 않습니다. "
+            f"(PPTX: {slide_count}, 이미지: {len(slide_image_paths)})"
+        )
+
+    active_thumbnail_builder = thumbnail_builder or PillowThumbnailBuilder()
+    active_thumbnail_builder.build(slide_image_paths, thumbnail_path)
+
+    extraction = (text_extractor or MarkitdownSlideTextExtractor()).extract(options.pptx_path)
+    slide_text_map = {
+        slide_text.slide_index: slide_text.text for slide_text in extraction.slide_texts
+    }
+    _write_text_output(
+        text_output_path,
+        deck_text=extraction.deck_text,
+        slide_count=slide_count,
+        slide_text_map=slide_text_map,
+    )
+
+    active_draft_generator = draft_generator or LlmSlideDraftGenerator()
+    slide_entries = []
+    for slide_index in range(slide_count):
+        logger.info("Source Slide %s/%s meta 초안 생성 중", slide_index + 1, slide_count)
+        draft = active_draft_generator.generate(
+            SlideDraftInput(
+                slide_index=slide_index,
+                image_path=slide_image_paths[slide_index],
+                text=slide_text_map.get(slide_index, ""),
+            ),
+            schema,
+        )
+        slide_entries.append(
+            {
+                "slide_index": slide_index,
+                "category": draft.category,
+                "description": draft.description,
+                "best_for": draft.best_for,
+            }
+        )
+
+    slide_entries = _assign_ids(slide_entries)
+    metadata = {
+        "_draft_notice": _DRAFT_NOTICE,
+        "template_id": options.template_id,
+        "template_file": options.pptx_path.name,
+        "theme": {
+            "primary_color": options.primary_color,
+            "name": options.theme_name or options.template_id,
+        },
+        "slides": slide_entries,
+    }
+    output_path.write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    return BuildMetaResult(
+        meta_path=output_path,
+        slide_image_paths=slide_image_paths,
+        thumbnail_path=thumbnail_path,
+        text_output_path=text_output_path,
+    )
+
+
+def _validate_options(options: BuildMetaOptions) -> None:
+    if not options.pptx_path.is_file():
+        raise ValueError(f"PPTX 파일을 찾을 수 없습니다: {options.pptx_path}")
+    if options.pptx_path.suffix.lower() != ".pptx":
+        raise ValueError(f"PPTX 파일만 처리할 수 있습니다: {options.pptx_path}")
+    if not options.template_id.strip():
+        raise ValueError("template_id는 비어 있을 수 없습니다.")
+    if not options.primary_color.strip():
+        raise ValueError("primary_color는 비어 있을 수 없습니다.")
+
+
+def _default_renderer() -> Renderer:
+    try:
+        from features.visualization.pptx import PptxRenderer
+    except ImportError as exc:
+        raise RuntimeError("PPTX 렌더러를 불러올 수 없습니다.") from exc
+    return PptxRenderer()
+
+
+def _assign_ids(slide_entries: list[dict[str, object]]) -> list[dict[str, object]]:
+    category_counts: dict[str, int] = defaultdict(int)
+    entries_with_ids: list[dict[str, object]] = []
+    for entry in slide_entries:
+        category = str(entry["category"])
+        category_counts[category] += 1
+        entries_with_ids.append(
+            {
+                "slide_index": entry["slide_index"],
+                "id": f"{_id_prefix(category)}_{_alphabetic_suffix(category_counts[category])}",
+                "category": entry["category"],
+                "description": entry["description"],
+                "best_for": entry["best_for"],
+            }
+        )
+    return entries_with_ids
+
+
+def _id_prefix(category: str) -> str:
+    prefix = re.sub(r"[^a-z0-9]+", "_", category.lower()).strip("_")
+    return prefix or "unknown"
+
+
+def _alphabetic_suffix(number: int) -> str:
+    if number <= 0:
+        raise ValueError("number는 1 이상이어야 합니다.")
+
+    chars: list[str] = []
+    current = number
+    while current:
+        current, remainder = divmod(current - 1, 26)
+        chars.append(chr(ord("A") + remainder))
+    return "".join(reversed(chars))
+
+
+def _write_text_output(
+    output_path: Path,
+    *,
+    deck_text: str,
+    slide_count: int,
+    slide_text_map: dict[int, str],
+) -> None:
+    lines = [
+        "# Template Text Draft",
+        "",
+        "이 파일은 meta.json 초안 작성을 위한 임시 텍스트입니다.",
+        "",
+        "## Markitdown Deck Text",
+        "",
+        deck_text.strip() or "(비어 있음)",
+        "",
+        "## Slide Text",
+        "",
+    ]
+    for slide_index in range(slide_count):
+        lines.extend(
+            [
+                f"### Slide {slide_index + 1}",
+                "",
+                slide_text_map.get(slide_index, "").strip() or "(비어 있음)",
+                "",
+            ]
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _format_llm_prompt_text(slide: SlideDraftInput, categories: CategorySchema) -> str:
+    category_lines = "\n".join(
+        f"- {definition.key}: {definition.description}".rstrip()
+        for definition in categories.definitions
+    )
+    return (
+        f"표준 카테고리 목록:\n{category_lines}\n\n"
+        f"슬라이드 번호: {slide.slide_index + 1}\n"
+        f"임시 텍스트:\n{slide.text or '(비어 있음)'}\n\n"
+        "다음 JSON 스키마에 맞는 값을 생성해줘: "
+        '{"category": "...", "description": "...", "best_for": "..."}'
+    )
+
+
+def _image_data_uri(image_path: Path) -> str:
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise RuntimeError(
+            "LLM vision 입력 이미지 최적화를 위해 Pillow가 필요합니다. "
+            "uv sync --group template-tools 후 다시 실행하세요."
+        ) from exc
+
+    with Image.open(image_path) as image:
+        preview = image.convert("RGB")
+        preview.thumbnail(_LLM_IMAGE_MAX_SIZE)
+        buffer = BytesIO()
+        preview.save(buffer, format="JPEG", quality=_LLM_IMAGE_QUALITY, optimize=True)
+
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}"

--- a/features/visualization/templates/builder.py
+++ b/features/visualization/templates/builder.py
@@ -1,9 +1,11 @@
 """템플릿 PPTX에서 meta.json 초안을 생성하는 오프라인 빌더."""
 
 import base64
+import hashlib
 import json
 import logging
 import re
+import tempfile
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -24,6 +26,8 @@ _DRAFT_NOTICE = (
 )
 _LLM_IMAGE_MAX_SIZE = (1024, 1024)
 _LLM_IMAGE_QUALITY = 72
+_TEMPLATE_FILE_NAME = "template.pptx"
+_DEFAULT_WORK_ROOT_NAME = "folioo-template-registration"
 logger = logging.getLogger(__name__)
 
 
@@ -40,6 +44,7 @@ class BuildMetaOptions:
     slides_dir: Path | None = None
     thumbnail_path: Path | None = None
     text_output_path: Path | None = None
+    work_dir: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -200,9 +205,10 @@ def build_template_metadata(
 
     output_path = options.output_path
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    slides_dir = options.slides_dir or output_path.parent / "slides"
+    work_dir = options.work_dir or _default_work_dir(options)
+    slides_dir = options.slides_dir or work_dir / "slides"
     thumbnail_path = options.thumbnail_path or output_path.parent / "thumbnail.jpg"
-    text_output_path = options.text_output_path or output_path.parent / "slide_text.md"
+    text_output_path = options.text_output_path or work_dir / "slide_text.md"
 
     schema = load_category_schema(options.category_schema_path or DEFAULT_CATEGORY_SCHEMA_PATH)
     slide_count = count_pptx_slides(options.pptx_path)
@@ -258,7 +264,7 @@ def build_template_metadata(
     metadata = {
         "_draft_notice": _DRAFT_NOTICE,
         "template_id": options.template_id,
-        "template_file": options.pptx_path.name,
+        "template_file": _TEMPLATE_FILE_NAME,
         "theme": {
             "primary_color": options.primary_color,
             "name": options.theme_name or options.template_id,
@@ -295,6 +301,17 @@ def _default_renderer() -> Renderer:
     except ImportError as exc:
         raise RuntimeError("PPTX 렌더러를 불러올 수 없습니다.") from exc
     return PptxRenderer()
+
+
+def _default_work_dir(options: BuildMetaOptions) -> Path:
+    parent_key = str(options.output_path.parent.resolve())
+    digest = hashlib.sha1(parent_key.encode("utf-8")).hexdigest()[:12]
+    template_segment = re.sub(r"[^a-zA-Z0-9_-]+", "_", options.template_id).strip("_")
+    return (
+        Path(tempfile.gettempdir())
+        / _DEFAULT_WORK_ROOT_NAME
+        / f"{template_segment or 'template'}-{digest}"
+    )
 
 
 def _assign_ids(slide_entries: list[dict[str, object]]) -> list[dict[str, object]]:

--- a/features/visualization/templates/builder.py
+++ b/features/visualization/templates/builder.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from pydantic import BaseModel, Field
 
@@ -141,16 +141,13 @@ class LlmSlideDraftGenerator:
     def __init__(self, *, model: str | None = None, temperature: float = 0.1) -> None:
         self.model = model
         self.temperature = temperature
+        self._structured_llm: Any | None = None
 
     def generate(self, slide: SlideDraftInput, categories: CategorySchema) -> SlideDraft:
         """썸네일과 임시 텍스트를 LLM에 입력해 Source Slide 초안을 생성한다."""
         from langchain_core.messages import HumanMessage, SystemMessage
 
-        from common.llm.client import get_llm_uncached
-
-        llm = get_llm_uncached(model=self.model, temperature=self.temperature, timeout=120)
-        structured_llm = llm.with_structured_output(_SlideDraftOutput)
-        output = structured_llm.invoke(
+        output = self._get_structured_llm().invoke(
             [
                 SystemMessage(
                     content=(
@@ -179,6 +176,15 @@ class LlmSlideDraftGenerator:
             description=output.description.strip(),
             best_for=output.best_for.strip(),
         )
+
+    def _get_structured_llm(self) -> Any:
+        """구조화 출력 LLM을 지연 생성해 슬라이드별 재사용한다."""
+        if self._structured_llm is None:
+            from common.llm.client import get_llm_uncached
+
+            llm = get_llm_uncached(model=self.model, temperature=self.temperature, timeout=120)
+            self._structured_llm = llm.with_structured_output(_SlideDraftOutput)
+        return self._structured_llm
 
 
 def build_template_metadata(
@@ -238,10 +244,11 @@ def build_template_metadata(
             ),
             schema,
         )
+        category = _category_for_metadata(draft.category, slide_index, schema)
         slide_entries.append(
             {
                 "slide_index": slide_index,
-                "category": draft.category,
+                "category": category,
                 "description": draft.description,
                 "best_for": draft.best_for,
             }
@@ -295,17 +302,33 @@ def _assign_ids(slide_entries: list[dict[str, object]]) -> list[dict[str, object
     entries_with_ids: list[dict[str, object]] = []
     for entry in slide_entries:
         category = str(entry["category"])
-        category_counts[category] += 1
+        prefix = _id_prefix(category)
+        category_counts[prefix] += 1
         entries_with_ids.append(
             {
                 "slide_index": entry["slide_index"],
-                "id": f"{_id_prefix(category)}_{_alphabetic_suffix(category_counts[category])}",
+                "id": f"{prefix}_{_alphabetic_suffix(category_counts[prefix])}",
                 "category": entry["category"],
                 "description": entry["description"],
                 "best_for": entry["best_for"],
             }
         )
     return entries_with_ids
+
+
+def _category_for_metadata(
+    raw_category: str,
+    slide_index: int,
+    schema: CategorySchema,
+) -> str:
+    category = raw_category.strip().lower()
+    if category == "unknown" or category not in schema.key_set:
+        logger.warning(
+            "Source Slide %s category 초안 검토 필요: %r",
+            slide_index + 1,
+            raw_category,
+        )
+    return category
 
 
 def _id_prefix(category: str) -> str:

--- a/features/visualization/templates/categories.py
+++ b/features/visualization/templates/categories.py
@@ -1,0 +1,108 @@
+"""Source Slide 표준 카테고리 스키마 로더."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CATEGORY_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3] / "templates" / "_schema" / "categories.json"
+)
+
+
+@dataclass(frozen=True)
+class CategoryDefinition:
+    """Source Slide 카테고리 정의."""
+
+    key: str
+    description: str = ""
+    recommended_min: int | None = None
+    recommended_max: int | None = None
+
+
+@dataclass(frozen=True)
+class CategorySchema:
+    """카테고리 Enum 과 권장 분포 정보를 담는 스키마."""
+
+    definitions: tuple[CategoryDefinition, ...]
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        """스키마에 등록된 카테고리 키 목록."""
+        return tuple(definition.key for definition in self.definitions)
+
+    @property
+    def key_set(self) -> frozenset[str]:
+        """카테고리 키 set."""
+        return frozenset(self.keys)
+
+    def definition_for(self, key: str) -> CategoryDefinition | None:
+        """카테고리 키에 맞는 정의를 반환한다."""
+        for definition in self.definitions:
+            if definition.key == key:
+                return definition
+        return None
+
+
+def load_category_schema(path: Path | str = DEFAULT_CATEGORY_SCHEMA_PATH) -> CategorySchema:
+    """카테고리 스키마 JSON 파일을 로드한다."""
+    schema_path = Path(path)
+    try:
+        raw = json.loads(schema_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"카테고리 스키마 파일을 읽을 수 없습니다: {schema_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"카테고리 스키마 JSON 형식이 올바르지 않습니다: {schema_path}") from exc
+
+    raw_categories = raw.get("categories") if isinstance(raw, dict) else raw
+    if not isinstance(raw_categories, list) or not raw_categories:
+        raise ValueError("카테고리 스키마에는 비어 있지 않은 categories 배열이 필요합니다.")
+
+    definitions = tuple(_parse_category(item) for item in raw_categories)
+    keys = [definition.key for definition in definitions]
+    duplicate_keys = sorted({key for key in keys if keys.count(key) > 1})
+    if duplicate_keys:
+        raise ValueError(f"카테고리 스키마에 중복 key가 있습니다: {', '.join(duplicate_keys)}")
+
+    return CategorySchema(definitions=definitions)
+
+
+def _parse_category(item: Any) -> CategoryDefinition:
+    if isinstance(item, str):
+        key = item.strip()
+        if not key:
+            raise ValueError("카테고리 key는 비어 있을 수 없습니다.")
+        return CategoryDefinition(key=key)
+
+    if not isinstance(item, dict):
+        raise ValueError("categories 항목은 문자열 또는 객체여야 합니다.")
+
+    key = str(item.get("key", "")).strip()
+    if not key:
+        raise ValueError("카테고리 key는 비어 있을 수 없습니다.")
+
+    recommended_min = _optional_int(item.get("recommended_min"), field_name="recommended_min")
+    recommended_max = _optional_int(item.get("recommended_max"), field_name="recommended_max")
+    if (
+        recommended_min is not None
+        and recommended_max is not None
+        and recommended_min > recommended_max
+    ):
+        raise ValueError(f"{key} 카테고리의 recommended_min이 recommended_max보다 큽니다.")
+
+    return CategoryDefinition(
+        key=key,
+        description=str(item.get("description", "")).strip(),
+        recommended_min=recommended_min,
+        recommended_max=recommended_max,
+    )
+
+
+def _optional_int(value: Any, *, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} 값은 정수여야 합니다.")
+    if value < 0:
+        raise ValueError(f"{field_name} 값은 0 이상이어야 합니다.")
+    return value

--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -1,0 +1,138 @@
+"""PPTX 패키지에서 슬라이드 순서와 텍스트를 추출하는 유틸리티."""
+
+import posixpath
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree.ElementTree import Element, ParseError
+
+from defusedxml import ElementTree
+
+_PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+_DRAWINGML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+_SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
+_SLIDE_FILE_PATTERN = re.compile(r"^ppt/slides/slide(\d+)\.xml$")
+
+
+@dataclass(frozen=True)
+class SlideText:
+    """PPTX 슬라이드별 임시 텍스트."""
+
+    slide_index: int
+    text: str
+
+
+def count_pptx_slides(pptx_path: Path | str) -> int:
+    """PPTX 내부 Source Slide 개수를 반환한다."""
+    return len(_ordered_slide_part_names(Path(pptx_path)))
+
+
+def extract_slide_texts(pptx_path: Path | str) -> tuple[SlideText, ...]:
+    """PPTX 슬라이드 XML에서 슬라이드별 텍스트를 순서대로 추출한다."""
+    source = Path(pptx_path)
+    slide_names = _ordered_slide_part_names(source)
+    slide_texts: list[SlideText] = []
+
+    with _open_pptx(source) as zf:
+        for index, slide_name in enumerate(slide_names):
+            try:
+                slide_xml = zf.read(slide_name)
+            except KeyError as exc:
+                raise ValueError(f"PPTX 슬라이드 XML을 찾을 수 없습니다: {slide_name}") from exc
+
+            root = _parse_xml(slide_xml, f"{source}:{slide_name}")
+            texts = [
+                (text_node.text or "").strip()
+                for text_node in root.findall(f".//{{{_DRAWINGML_NS}}}t")
+                if (text_node.text or "").strip()
+            ]
+            slide_texts.append(SlideText(slide_index=index, text="\n".join(texts)))
+
+    return tuple(slide_texts)
+
+
+def _ordered_slide_part_names(pptx_path: Path) -> tuple[str, ...]:
+    if pptx_path.suffix.lower() != ".pptx":
+        raise ValueError(f"PPTX 파일만 처리할 수 있습니다: {pptx_path}")
+
+    with _open_pptx(pptx_path) as zf:
+        names = set(zf.namelist())
+        if "ppt/presentation.xml" not in names:
+            raise ValueError("PPTX에 ppt/presentation.xml이 없습니다.")
+
+        try:
+            presentation_root = _parse_xml(
+                zf.read("ppt/presentation.xml"),
+                f"{pptx_path}:ppt/presentation.xml",
+            )
+        except KeyError as exc:
+            raise ValueError("PPTX에 ppt/presentation.xml이 없습니다.") from exc
+
+        rid_to_target = _load_slide_relationships(zf, pptx_path)
+        slide_names: list[str] = []
+        for slide_id in presentation_root.findall(f".//{{{_PRESENTATION_NS}}}sldId"):
+            rid = slide_id.attrib.get(f"{{{_REL_NS}}}id")
+            if not rid:
+                continue
+            target = rid_to_target.get(rid)
+            if target is None:
+                continue
+            slide_names.append(_normalize_presentation_target(target))
+
+        if slide_names:
+            return tuple(slide_names)
+
+        return tuple(sorted(_fallback_slide_part_names(names), key=_slide_number))
+
+
+def _load_slide_relationships(
+    zf: zipfile.ZipFile,
+    pptx_path: Path,
+) -> dict[str, str]:
+    try:
+        rels_xml = zf.read("ppt/_rels/presentation.xml.rels")
+    except KeyError:
+        return {}
+
+    rels_root = _parse_xml(rels_xml, f"{pptx_path}:ppt/_rels/presentation.xml.rels")
+    return {
+        rel.attrib.get("Id", ""): rel.attrib.get("Target", "")
+        for rel in rels_root.findall(f".//{{{_PACKAGE_RELATIONSHIPS_NS}}}Relationship")
+        if rel.attrib.get("Type") == _SLIDE_RELATIONSHIP_TYPE
+    }
+
+
+def _normalize_presentation_target(target: str) -> str:
+    if target.startswith("/"):
+        return posixpath.normpath(target.lstrip("/"))
+    return posixpath.normpath(posixpath.join("ppt", target))
+
+
+def _fallback_slide_part_names(names: set[str]) -> list[str]:
+    return [name for name in names if _SLIDE_FILE_PATTERN.fullmatch(name)]
+
+
+def _slide_number(name: str) -> int:
+    match = _SLIDE_FILE_PATTERN.fullmatch(name)
+    return int(match.group(1)) if match else 0
+
+
+def _open_pptx(path: Path) -> zipfile.ZipFile:
+    if not path.is_file():
+        raise ValueError(f"PPTX 파일을 찾을 수 없습니다: {path}")
+    try:
+        return zipfile.ZipFile(path, "r")
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"PPTX ZIP 패키지 형식이 올바르지 않습니다: {path}") from exc
+
+
+def _parse_xml(data: bytes, label: str) -> Element:
+    try:
+        return ElementTree.fromstring(data)
+    except ParseError as exc:
+        raise ValueError(f"XML 파싱에 실패했습니다: {label}") from exc

--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -77,11 +77,11 @@ def _ordered_slide_part_names(pptx_path: Path) -> tuple[str, ...]:
         for slide_id in presentation_root.findall(f".//{{{_PRESENTATION_NS}}}sldId"):
             rid = slide_id.attrib.get(f"{{{_REL_NS}}}id")
             if not rid:
-                continue
+                raise ValueError("PPTX slide id에 relationship id가 없습니다.")
             target = rid_to_target.get(rid)
             if target is None:
-                continue
-            slide_names.append(_normalize_presentation_target(target))
+                raise ValueError(f"PPTX presentation relationship을 찾을 수 없습니다: {rid}")
+            slide_names.append(_resolve_slide_part_name(target, names))
 
         if slide_names:
             return tuple(slide_names)
@@ -110,6 +110,24 @@ def _normalize_presentation_target(target: str) -> str:
     if target.startswith("/"):
         return posixpath.normpath(target.lstrip("/"))
     return posixpath.normpath(posixpath.join("ppt", target))
+
+
+def _resolve_slide_part_name(target: str, names: set[str]) -> str:
+    slide_name = _normalize_presentation_target(target)
+    if not _is_slide_part_name(slide_name):
+        raise ValueError(
+            f"PPTX slide relationship target은 ppt/slides/*.xml이어야 합니다: {target}"
+        )
+    if slide_name not in names:
+        raise ValueError(f"PPTX 슬라이드 XML을 찾을 수 없습니다: {slide_name}")
+    return slide_name
+
+
+def _is_slide_part_name(part_name: str) -> bool:
+    if not part_name.startswith("ppt/slides/"):
+        return False
+    slide_file_name = part_name.removeprefix("ppt/slides/")
+    return bool(slide_file_name) and "/" not in slide_file_name and slide_file_name.endswith(".xml")
 
 
 def _open_pptx(path: Path) -> zipfile.ZipFile:

--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -1,13 +1,13 @@
 """PPTX 패키지에서 슬라이드 순서와 텍스트를 추출하는 유틸리티."""
 
 import posixpath
-import re
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from xml.etree.ElementTree import Element, ParseError
 
 from defusedxml import ElementTree
+from defusedxml.common import DefusedXmlException
 
 _PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
 _DRAWINGML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
@@ -16,7 +16,6 @@ _PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/rela
 _SLIDE_RELATIONSHIP_TYPE = (
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
 )
-_SLIDE_FILE_PATTERN = re.compile(r"^ppt/slides/slide(\d+)\.xml$")
 
 
 @dataclass(frozen=True)
@@ -87,7 +86,7 @@ def _ordered_slide_part_names(pptx_path: Path) -> tuple[str, ...]:
         if slide_names:
             return tuple(slide_names)
 
-        return tuple(sorted(_fallback_slide_part_names(names), key=_slide_number))
+        raise ValueError("PPTX 슬라이드 순서를 확인할 presentation relationship이 없습니다.")
 
 
 def _load_slide_relationships(
@@ -113,15 +112,6 @@ def _normalize_presentation_target(target: str) -> str:
     return posixpath.normpath(posixpath.join("ppt", target))
 
 
-def _fallback_slide_part_names(names: set[str]) -> list[str]:
-    return [name for name in names if _SLIDE_FILE_PATTERN.fullmatch(name)]
-
-
-def _slide_number(name: str) -> int:
-    match = _SLIDE_FILE_PATTERN.fullmatch(name)
-    return int(match.group(1)) if match else 0
-
-
 def _open_pptx(path: Path) -> zipfile.ZipFile:
     if not path.is_file():
         raise ValueError(f"PPTX 파일을 찾을 수 없습니다: {path}")
@@ -134,5 +124,5 @@ def _open_pptx(path: Path) -> zipfile.ZipFile:
 def _parse_xml(data: bytes, label: str) -> Element:
     try:
         return ElementTree.fromstring(data)
-    except ParseError as exc:
+    except (ParseError, DefusedXmlException) as exc:
         raise ValueError(f"XML 파싱에 실패했습니다: {label}") from exc

--- a/features/visualization/templates/thumbnail.py
+++ b/features/visualization/templates/thumbnail.py
@@ -16,6 +16,14 @@ class PillowThumbnailBuilder:
         gap: int = 16,
         max_columns: int = 4,
     ) -> None:
+        if not isinstance(cell_width, int) or not isinstance(cell_height, int):
+            raise ValueError("cell_width와 cell_height는 정수여야 합니다.")
+        if cell_width <= 0 or cell_height <= 0:
+            raise ValueError("cell_width와 cell_height는 1 이상이어야 합니다.")
+        if not isinstance(gap, int) or gap < 0:
+            raise ValueError("gap은 0 이상의 정수여야 합니다.")
+        if not isinstance(max_columns, int) or max_columns <= 0:
+            raise ValueError("max_columns는 1 이상의 정수여야 합니다.")
         self.cell_width = cell_width
         self.cell_height = cell_height
         self.gap = gap

--- a/features/visualization/templates/thumbnail.py
+++ b/features/visualization/templates/thumbnail.py
@@ -1,0 +1,68 @@
+"""슬라이드 그리드 썸네일 생성."""
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+
+
+class PillowThumbnailBuilder:
+    """Pillow 기반 그리드 thumbnail.jpg 생성기."""
+
+    def __init__(
+        self,
+        *,
+        cell_width: int = 360,
+        cell_height: int = 220,
+        gap: int = 16,
+        max_columns: int = 4,
+    ) -> None:
+        self.cell_width = cell_width
+        self.cell_height = cell_height
+        self.gap = gap
+        self.max_columns = max_columns
+
+    def build(self, slide_images: Sequence[Path], output_path: Path) -> Path:
+        """슬라이드 이미지를 그리드로 배치해 JPG 썸네일을 만든다."""
+        if not slide_images:
+            raise ValueError("thumbnail.jpg를 만들 슬라이드 이미지가 없습니다.")
+
+        try:
+            from PIL import Image, ImageDraw, ImageOps
+        except ImportError as exc:
+            raise RuntimeError(
+                "thumbnail.jpg 생성을 위해 Pillow가 필요합니다. "
+                "uv sync --group template-tools 후 다시 실행하세요."
+            ) from exc
+
+        columns = min(self.max_columns, math.ceil(math.sqrt(len(slide_images))))
+        rows = math.ceil(len(slide_images) / columns)
+        label_height = 28
+        width = self.gap + columns * (self.cell_width + self.gap)
+        height = self.gap + rows * (self.cell_height + label_height + self.gap)
+        canvas = Image.new("RGB", (width, height), color="white")
+        draw = ImageDraw.Draw(canvas)
+
+        for index, image_path in enumerate(slide_images):
+            row = index // columns
+            column = index % columns
+            x = self.gap + column * (self.cell_width + self.gap)
+            y = self.gap + row * (self.cell_height + label_height + self.gap)
+
+            with Image.open(image_path) as image:
+                preview = ImageOps.contain(
+                    image.convert("RGB"), (self.cell_width, self.cell_height)
+                )
+                offset_x = x + (self.cell_width - preview.width) // 2
+                offset_y = y + (self.cell_height - preview.height) // 2
+                canvas.paste(preview, (offset_x, offset_y))
+
+            draw.rectangle(
+                [x, y, x + self.cell_width, y + self.cell_height],
+                outline=(220, 220, 220),
+                width=1,
+            )
+            draw.text((x, y + self.cell_height + 6), f"Slide {index + 1}", fill=(80, 80, 80))
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        canvas.save(output_path, format="JPEG", quality=88, optimize=True)
+        return output_path

--- a/features/visualization/templates/validation.py
+++ b/features/visualization/templates/validation.py
@@ -95,16 +95,15 @@ def _validate_required_schema(metadata: dict[str, Any], errors: list[str]) -> No
         errors.append("theme 필드는 객체여야 합니다.")
     elif isinstance(theme, dict):
         for field in _REQUIRED_THEME_FIELDS:
-            if not _has_non_empty_value(theme.get(field)):
-                errors.append(f"필수 필드 누락: theme.{field}")
+            _validate_required_string(theme.get(field), f"theme.{field}", errors)
 
     slides = metadata.get("slides")
     if "slides" in metadata and not isinstance(slides, list):
         errors.append("slides 필드는 배열이어야 합니다.")
 
     for field in ("template_id", "template_file"):
-        if field in metadata and not _has_non_empty_value(metadata.get(field)):
-            errors.append(f"필수 필드 누락: {field}")
+        if field in metadata:
+            _validate_required_string(metadata.get(field), field, errors)
 
 
 def _validate_slides(
@@ -125,8 +124,11 @@ def _validate_slides(
             continue
 
         for field in _REQUIRED_SLIDE_FIELDS:
-            if field not in raw_slide or not _has_non_empty_value(raw_slide.get(field)):
+            if field not in raw_slide or raw_slide.get(field) is None:
                 errors.append(f"필수 필드 누락: {label}.{field}")
+
+        for field in ("id", "category", "description", "best_for"):
+            _validate_required_string(raw_slide.get(field), f"{label}.{field}", errors)
 
         slide_index = raw_slide.get("slide_index")
         if isinstance(slide_index, bool) or not isinstance(slide_index, int):
@@ -186,7 +188,6 @@ def _append_distribution_warnings(
             )
 
 
-def _has_non_empty_value(value: Any) -> bool:
-    if isinstance(value, str):
-        return bool(value.strip())
-    return value is not None
+def _validate_required_string(value: Any, label: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label}는 비어 있지 않은 문자열이어야 합니다.")

--- a/features/visualization/templates/validation.py
+++ b/features/visualization/templates/validation.py
@@ -12,6 +12,8 @@ from .pptx import count_pptx_slides
 _REQUIRED_TOP_LEVEL_FIELDS = ("template_id", "template_file", "theme", "slides")
 _REQUIRED_THEME_FIELDS = ("primary_color", "name")
 _REQUIRED_SLIDE_FIELDS = ("slide_index", "id", "category", "description", "best_for")
+_TEMPLATE_FILE_NAME = "template.pptx"
+_THUMBNAIL_FILE_NAME = "thumbnail.jpg"
 
 
 @dataclass(frozen=True)
@@ -37,6 +39,8 @@ def validate_template_directory(
     errors: list[str] = []
     warnings: list[str] = []
 
+    _validate_non_empty_file(root / _THUMBNAIL_FILE_NAME, _THUMBNAIL_FILE_NAME, errors)
+
     meta_path = root / "meta.json"
     metadata = _load_meta_json(meta_path, errors)
     schema = _load_schema(category_schema_path, errors)
@@ -48,11 +52,13 @@ def validate_template_directory(
     template_file = metadata.get("template_file")
     pptx_slide_count: int | None = None
     if isinstance(template_file, str) and template_file.strip():
-        pptx_path = root / template_file
-        try:
-            pptx_slide_count = count_pptx_slides(pptx_path)
-        except ValueError as exc:
-            errors.append(str(exc))
+        _validate_template_file(template_file, errors)
+        if template_file == _TEMPLATE_FILE_NAME:
+            pptx_path = root / _TEMPLATE_FILE_NAME
+            try:
+                pptx_slide_count = count_pptx_slides(pptx_path)
+            except ValueError as exc:
+                errors.append(str(exc))
 
     slides = metadata.get("slides")
     if isinstance(slides, list):
@@ -85,6 +91,17 @@ def _load_schema(path: Path | str, errors: list[str]) -> CategorySchema | None:
         return None
 
 
+def _validate_non_empty_file(path: Path, label: str, errors: list[str]) -> None:
+    try:
+        if not path.is_file():
+            errors.append(f"{label} 파일을 찾을 수 없습니다: {path}")
+            return
+        if path.stat().st_size == 0:
+            errors.append(f"{label} 파일이 비어 있습니다: {path}")
+    except OSError as exc:
+        errors.append(f"{label} 파일을 확인할 수 없습니다: {exc}")
+
+
 def _validate_required_schema(metadata: dict[str, Any], errors: list[str]) -> None:
     for field in _REQUIRED_TOP_LEVEL_FIELDS:
         if field not in metadata:
@@ -104,6 +121,11 @@ def _validate_required_schema(metadata: dict[str, Any], errors: list[str]) -> No
     for field in ("template_id", "template_file"):
         if field in metadata:
             _validate_required_string(metadata.get(field), field, errors)
+
+
+def _validate_template_file(value: str, errors: list[str]) -> None:
+    if value != _TEMPLATE_FILE_NAME:
+        errors.append("template_file은 경로 없이 template.pptx여야 합니다.")
 
 
 def _validate_slides(

--- a/features/visualization/templates/validation.py
+++ b/features/visualization/templates/validation.py
@@ -1,0 +1,192 @@
+"""템플릿 meta.json 검증."""
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .categories import DEFAULT_CATEGORY_SCHEMA_PATH, CategorySchema, load_category_schema
+from .pptx import count_pptx_slides
+
+_REQUIRED_TOP_LEVEL_FIELDS = ("template_id", "template_file", "theme", "slides")
+_REQUIRED_THEME_FIELDS = ("primary_color", "name")
+_REQUIRED_SLIDE_FIELDS = ("slide_index", "id", "category", "description", "best_for")
+
+
+@dataclass(frozen=True)
+class TemplateValidationResult:
+    """템플릿 검증 결과."""
+
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        """검증 실패가 없으면 True."""
+        return not self.errors
+
+
+def validate_template_directory(
+    template_dir: Path | str,
+    *,
+    category_schema_path: Path | str = DEFAULT_CATEGORY_SCHEMA_PATH,
+) -> TemplateValidationResult:
+    """템플릿 디렉터리의 template.pptx/meta.json 무결성을 검증한다."""
+    root = Path(template_dir)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    meta_path = root / "meta.json"
+    metadata = _load_meta_json(meta_path, errors)
+    schema = _load_schema(category_schema_path, errors)
+    if metadata is None or schema is None:
+        return TemplateValidationResult(errors=tuple(errors), warnings=tuple(warnings))
+
+    _validate_required_schema(metadata, errors)
+
+    template_file = metadata.get("template_file")
+    pptx_slide_count: int | None = None
+    if isinstance(template_file, str) and template_file.strip():
+        pptx_path = root / template_file
+        try:
+            pptx_slide_count = count_pptx_slides(pptx_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+
+    slides = metadata.get("slides")
+    if isinstance(slides, list):
+        _validate_slides(slides, schema, pptx_slide_count, errors, warnings)
+
+    return TemplateValidationResult(errors=tuple(errors), warnings=tuple(warnings))
+
+
+def _load_meta_json(path: Path, errors: list[str]) -> dict[str, Any] | None:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        errors.append(f"meta.json을 읽을 수 없습니다: {exc}")
+        return None
+    except json.JSONDecodeError as exc:
+        errors.append(f"meta.json JSON 형식이 올바르지 않습니다: {exc}")
+        return None
+
+    if not isinstance(loaded, dict):
+        errors.append("meta.json 최상위 값은 객체여야 합니다.")
+        return None
+    return loaded
+
+
+def _load_schema(path: Path | str, errors: list[str]) -> CategorySchema | None:
+    try:
+        return load_category_schema(path)
+    except ValueError as exc:
+        errors.append(str(exc))
+        return None
+
+
+def _validate_required_schema(metadata: dict[str, Any], errors: list[str]) -> None:
+    for field in _REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in metadata:
+            errors.append(f"필수 필드 누락: {field}")
+
+    theme = metadata.get("theme")
+    if "theme" in metadata and not isinstance(theme, dict):
+        errors.append("theme 필드는 객체여야 합니다.")
+    elif isinstance(theme, dict):
+        for field in _REQUIRED_THEME_FIELDS:
+            if not _has_non_empty_value(theme.get(field)):
+                errors.append(f"필수 필드 누락: theme.{field}")
+
+    slides = metadata.get("slides")
+    if "slides" in metadata and not isinstance(slides, list):
+        errors.append("slides 필드는 배열이어야 합니다.")
+
+    for field in ("template_id", "template_file"):
+        if field in metadata and not _has_non_empty_value(metadata.get(field)):
+            errors.append(f"필수 필드 누락: {field}")
+
+
+def _validate_slides(
+    slides: list[Any],
+    schema: CategorySchema,
+    pptx_slide_count: int | None,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    slide_indexes: list[int] = []
+    ids: list[str] = []
+    categories: list[str] = []
+
+    for position, raw_slide in enumerate(slides):
+        label = f"slides[{position}]"
+        if not isinstance(raw_slide, dict):
+            errors.append(f"{label} 항목은 객체여야 합니다.")
+            continue
+
+        for field in _REQUIRED_SLIDE_FIELDS:
+            if field not in raw_slide or not _has_non_empty_value(raw_slide.get(field)):
+                errors.append(f"필수 필드 누락: {label}.{field}")
+
+        slide_index = raw_slide.get("slide_index")
+        if isinstance(slide_index, bool) or not isinstance(slide_index, int):
+            errors.append(f"{label}.slide_index는 정수여야 합니다.")
+        else:
+            slide_indexes.append(slide_index)
+
+        slide_id = raw_slide.get("id")
+        if isinstance(slide_id, str):
+            ids.append(slide_id)
+
+        category = raw_slide.get("category")
+        if isinstance(category, str):
+            categories.append(category)
+            if category == "unknown":
+                errors.append(f"{label}.category는 unknown일 수 없습니다.")
+            elif category not in schema.key_set:
+                errors.append(f"{label}.category가 표준 Enum 밖입니다: {category}")
+
+    expected_indexes = list(range(len(slides)))
+    if slide_indexes != expected_indexes:
+        errors.append(
+            "slide_index는 slides 배열 순서대로 0..N-1 연속 값이어야 합니다. "
+            f"(기대: {expected_indexes}, 실제: {slide_indexes})"
+        )
+
+    if pptx_slide_count is not None and pptx_slide_count != len(slides):
+        errors.append(
+            "meta.json slides 수가 PPTX 슬라이드 수와 일치하지 않습니다. "
+            f"(meta.json: {len(slides)}, PPTX: {pptx_slide_count})"
+        )
+
+    duplicate_ids = sorted({slide_id for slide_id in ids if ids.count(slide_id) > 1})
+    if duplicate_ids:
+        errors.append(f"템플릿 내 id 중복: {', '.join(duplicate_ids)}")
+
+    _append_distribution_warnings(categories, schema, warnings)
+
+
+def _append_distribution_warnings(
+    categories: list[str],
+    schema: CategorySchema,
+    warnings: list[str],
+) -> None:
+    counts = Counter(category for category in categories if category in schema.key_set)
+    for definition in schema.definitions:
+        count = counts.get(definition.key, 0)
+        if definition.recommended_min is not None and count < definition.recommended_min:
+            warnings.append(
+                f"{definition.key} 카테고리 수가 권장 최소보다 적습니다. "
+                f"(현재: {count}, 권장: {definition.recommended_min} 이상)"
+            )
+        if definition.recommended_max is not None and count > definition.recommended_max:
+            warnings.append(
+                f"{definition.key} 카테고리 수가 권장 최대보다 많습니다. "
+                f"(현재: {count}, 권장: {definition.recommended_max} 이하)"
+            )
+
+
+def _has_non_empty_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    return value is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "ruff>=0.14.11",
 ]
+template-tools = [
+    "markitdown[pptx]>=0.1.3",
+    "pillow>=11.0.0",
+]
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"

--- a/scripts/templates/build_meta.py
+++ b/scripts/templates/build_meta.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+import tempfile
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+# 운영자 CLI는 repo root에서 `python scripts/...`로 직접 실행될 수 있어 import path를 보정한다.
 sys.path.insert(0, str(_REPO_ROOT))
 sys.path.insert(0, str(_REPO_ROOT / "apps" / "pptx-worker"))
 _DEFAULT_CATEGORY_SCHEMA_PATH = _REPO_ROOT / "templates" / "_schema" / "categories.json"
@@ -38,7 +40,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--pdftoppm-bin", default="pdftoppm", help="pdftoppm 실행 파일")
     parser.add_argument("--timeout-seconds", type=float, default=60.0, help="외부 명령 타임아웃")
     parser.add_argument("--dpi", type=int, default=150, help="슬라이드 JPG 렌더링 DPI")
-    parser.add_argument("--tmp-root", type=Path, default=Path("/tmp"), help="렌더링 임시 디렉터리")
+    parser.add_argument(
+        "--tmp-root",
+        type=Path,
+        default=Path(tempfile.gettempdir()),
+        help="렌더링 임시 디렉터리",
+    )
     return parser.parse_args(argv)
 
 

--- a/scripts/templates/build_meta.py
+++ b/scripts/templates/build_meta.py
@@ -34,6 +34,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--slides-dir", type=Path, help="슬라이드 JPG 출력 디렉터리")
     parser.add_argument("--thumbnail", type=Path, help="그리드 thumbnail.jpg 출력 경로")
     parser.add_argument("--text-output", type=Path, help="임시 텍스트 markdown 출력 경로")
+    parser.add_argument("--work-dir", type=Path, help="중간 산출물 기본 출력 디렉터리")
     parser.add_argument("--model", help="LLM 모델명 override")
     parser.add_argument("--temperature", type=float, default=0.1, help="LLM temperature")
     parser.add_argument("--soffice-bin", default="soffice", help="LibreOffice 실행 파일")
@@ -81,6 +82,7 @@ def main(argv: list[str] | None = None) -> int:
             slides_dir=args.slides_dir,
             thumbnail_path=args.thumbnail,
             text_output_path=args.text_output,
+            work_dir=args.work_dir,
         ),
         renderer=renderer,
         draft_generator=LlmSlideDraftGenerator(model=args.model, temperature=args.temperature),

--- a/scripts/templates/build_meta.py
+++ b/scripts/templates/build_meta.py
@@ -1,0 +1,92 @@
+"""템플릿 PPTX에서 Source Slide meta.json 초안을 생성하는 운영자용 CLI."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "apps" / "pptx-worker"))
+_DEFAULT_CATEGORY_SCHEMA_PATH = _REPO_ROOT / "templates" / "_schema" / "categories.json"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI 인자를 파싱한다."""
+    parser = argparse.ArgumentParser(
+        description="template.pptx에서 슬라이드 이미지, thumbnail.jpg, meta.json 초안을 생성합니다."
+    )
+    parser.add_argument("--pptx", type=Path, required=True, help="입력 template.pptx 경로")
+    parser.add_argument("--template-id", required=True, help="템플릿 ID")
+    parser.add_argument("--primary-color", required=True, help="테마 대표 색상")
+    parser.add_argument("--output", type=Path, required=True, help="출력 meta.json 경로")
+    parser.add_argument("--theme-name", help="테마 표시 이름. 생략 시 template-id 사용")
+    parser.add_argument(
+        "--categories",
+        type=Path,
+        default=_DEFAULT_CATEGORY_SCHEMA_PATH,
+        help="표준 카테고리 스키마 JSON 경로",
+    )
+    parser.add_argument("--slides-dir", type=Path, help="슬라이드 JPG 출력 디렉터리")
+    parser.add_argument("--thumbnail", type=Path, help="그리드 thumbnail.jpg 출력 경로")
+    parser.add_argument("--text-output", type=Path, help="임시 텍스트 markdown 출력 경로")
+    parser.add_argument("--model", help="LLM 모델명 override")
+    parser.add_argument("--temperature", type=float, default=0.1, help="LLM temperature")
+    parser.add_argument("--soffice-bin", default="soffice", help="LibreOffice 실행 파일")
+    parser.add_argument("--pdftoppm-bin", default="pdftoppm", help="pdftoppm 실행 파일")
+    parser.add_argument("--timeout-seconds", type=float, default=60.0, help="외부 명령 타임아웃")
+    parser.add_argument("--dpi", type=int, default=150, help="슬라이드 JPG 렌더링 DPI")
+    parser.add_argument("--tmp-root", type=Path, default=Path("/tmp"), help="렌더링 임시 디렉터리")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """스크립트 실행 진입점."""
+    from features.visualization.pptx import PptxRenderer, RenderOptions
+    from features.visualization.templates import (
+        BuildMetaOptions,
+        LlmSlideDraftGenerator,
+        build_template_metadata,
+    )
+
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    renderer = PptxRenderer(
+        options=RenderOptions(
+            soffice_bin=args.soffice_bin,
+            pdftoppm_bin=args.pdftoppm_bin,
+            timeout_seconds=args.timeout_seconds,
+            dpi=args.dpi,
+            tmp_root=args.tmp_root,
+        )
+    )
+    result = build_template_metadata(
+        BuildMetaOptions(
+            pptx_path=args.pptx,
+            template_id=args.template_id,
+            primary_color=args.primary_color,
+            output_path=args.output,
+            theme_name=args.theme_name,
+            category_schema_path=args.categories,
+            slides_dir=args.slides_dir,
+            thumbnail_path=args.thumbnail,
+            text_output_path=args.text_output,
+        ),
+        renderer=renderer,
+        draft_generator=LlmSlideDraftGenerator(model=args.model, temperature=args.temperature),
+    )
+
+    print("meta.json 초안 생성 완료")
+    print(f"- meta: {result.meta_path}")
+    print(f"- thumbnail: {result.thumbnail_path}")
+    print(f"- text: {result.text_output_path}")
+    print(f"- slide images: {len(result.slide_image_paths)}개")
+    print("주의: category, description, best_for, id는 운영자 검토 후 확정해야 합니다.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/templates/validate_template.py
+++ b/scripts/templates/validate_template.py
@@ -1,0 +1,47 @@
+"""템플릿 meta.json 무결성을 검증하는 운영자/CI용 CLI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+_DEFAULT_CATEGORY_SCHEMA_PATH = _REPO_ROOT / "templates" / "_schema" / "categories.json"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI 인자를 파싱한다."""
+    parser = argparse.ArgumentParser(description="템플릿 디렉터리의 meta.json을 검증합니다.")
+    parser.add_argument("template_dir", type=Path, help="template.pptx와 meta.json이 있는 디렉터리")
+    parser.add_argument(
+        "--categories",
+        type=Path,
+        default=_DEFAULT_CATEGORY_SCHEMA_PATH,
+        help="표준 카테고리 스키마 JSON 경로",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """스크립트 실행 진입점."""
+    from features.visualization.templates import validate_template_directory
+
+    args = parse_args(argv)
+    result = validate_template_directory(args.template_dir, category_schema_path=args.categories)
+
+    for warning in result.warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+    for error in result.errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+
+    if not result.ok:
+        return 1
+
+    print("템플릿 검증 통과")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/phase-1/08-template-registration-pipeline.md
+++ b/specs/phase-1/08-template-registration-pipeline.md
@@ -4,8 +4,8 @@
 디자이너가 완성한 `template.pptx` 로부터 `meta.json` 초안을 반자동 생성하고 그 무결성을 검증하는 오프라인 운영자/CI 스크립트를 구축해, Source Slide 풀을 런타임 시각화 워커가 신뢰할 수 있는 형태로 등록한다.
 
 ## Requirements
-- `scripts/templates/build_meta.py` 가 `template.pptx` 를 soffice→PDF→pdftoppm 으로 슬라이드별 JPG + 그리드 `thumbnail.jpg` 로 만들고, markitdown 으로 임시 텍스트를 추출한 뒤, (썸네일+텍스트)를 LLM 에 입력해 Source Slide 별 `{category, description, best_for}` 초안과 같은 카테고리 내 알파벳순 `id` 를 자동 부여한 `meta.json` 초안을 작성한다. 슬라이드별 JPG와 임시 텍스트는 기본적으로 배포 디렉터리 밖의 work dir에 둔다.
-- `scripts/templates/validate_template.py` 가 `meta.json` 필수 필드 스키마, `template_file` 이 경로 없이 정확히 `template.pptx` 인지, `thumbnail.jpg` 가 존재하고 비어 있지 않은지, `category` 가 `templates/_schema/categories.json` Enum 안에 있는지(unknown 이면 실패), `slide_index` 가 `0..N-1` 연속이며 PPTX 슬라이드 수와 일치하는지, 템플릿 내 `id` 중복이 없는지를 검증하고 CI 에서도 실행된다.
+- `scripts/templates/build_meta.py` 가 `template.pptx` 를 soffice→PDF→pdftoppm 으로 슬라이드별 JPG + 그리드 `thumbnail.jpg` 로 만들고, markitdown 으로 임시 텍스트를 추출한 뒤, (썸네일+텍스트)를 LLM 에 입력해 Source Slide 별 `{category, description, best_for}` 초안과 같은 카테고리 내 알파벳순 `id` 를 자동 부여한 `meta.json` 초안을 작성한다. 생성된 `meta.json` 은 운영자 검토용 초안임을 명시하고, 슬라이드별 JPG와 임시 텍스트는 기본적으로 배포 디렉터리 밖의 work dir에 둔다.
+- `scripts/templates/validate_template.py` 가 `meta.json` 필수 필드 스키마, `template_file` 이 경로 없이 정확히 `template.pptx` 인지, `thumbnail.jpg` 가 존재하고 비어 있지 않은지, `category` 가 `templates/_schema/categories.json` Enum 안에 있는지(unknown 이면 실패), `slide_index` 가 `0..N-1` 연속이며 PPTX 슬라이드 수와 일치하는지, 템플릿 내 `id` 중복이 없는지를 검증하고 운영자 또는 CI 잡에서 호출할 수 있게 한다.
 - `templates/_schema/categories.json` 을 §3.3 표준 카테고리 Enum(cover/toc/overview/problem/process/outcome/chart/visual/text/closing)의 단일 소스 오브 트루스로 둔다.
 - 의미 필드(`category`/`description`/`best_for`/`id`)는 LLM 초안 후 운영자가 검토·확정하는 반자동 산출물로 다루고, `slide_index`/`template_file` 은 자동 생성 후 운영자가 손대지 않는다.
 
@@ -14,5 +14,5 @@
 
 ## Verification
 - 샘플 `template.pptx` 로 `build_meta.py` 를 실행하면 슬라이드별 JPG·그리드 thumbnail·임시 텍스트가 생성되고, Source Slide 별 `{category, description, best_for}` 와 카테고리별 알파벳순 `id` 가 채워진 `meta.json` 초안이 디스크에 작성되는지 확인한다. 배포 디렉터리에는 `template.pptx`, `meta.json`, `thumbnail.jpg` 만 기본 산출물로 남는지 확인한다.
-- `validate_template.py` 가 필수 필드 누락·Enum 밖 category(unknown 포함)·`slide_index` 불연속·PPTX 슬라이드 수 불일치·중복 `id` 를 각각 실패로 잡아내는지 검증한다.
+- `validate_template.py` 가 필수 필드 누락·`template_file` 오류·`thumbnail.jpg` 누락/빈 파일·Enum 밖 category(unknown 포함)·`slide_index` 불연속·PPTX 슬라이드 수 불일치·중복 `id` 를 각각 실패로 잡아내는지 검증한다.
 - `category` 가 `templates/_schema/categories.json` 의 값과 일치할 때만 검증을 통과하고, Enum 을 확장하지 않은 신규 값은 실패하는지 확인한다.

--- a/specs/phase-1/08-template-registration-pipeline.md
+++ b/specs/phase-1/08-template-registration-pipeline.md
@@ -4,8 +4,8 @@
 디자이너가 완성한 `template.pptx` 로부터 `meta.json` 초안을 반자동 생성하고 그 무결성을 검증하는 오프라인 운영자/CI 스크립트를 구축해, Source Slide 풀을 런타임 시각화 워커가 신뢰할 수 있는 형태로 등록한다.
 
 ## Requirements
-- `scripts/templates/build_meta.py` 가 `template.pptx` 를 soffice→PDF→pdftoppm 으로 슬라이드별 JPG + 그리드 `thumbnail.jpg` 로 만들고, markitdown 으로 임시 텍스트를 추출한 뒤, (썸네일+텍스트)를 LLM 에 입력해 Source Slide 별 `{category, description, best_for}` 초안과 같은 카테고리 내 알파벳순 `id` 를 자동 부여한 `meta.json` 초안을 작성한다.
-- `scripts/templates/validate_template.py` 가 `meta.json` 필수 필드 스키마, `category` 가 `templates/_schema/categories.json` Enum 안에 있는지(unknown 이면 실패), `slide_index` 가 `0..N-1` 연속이며 PPTX 슬라이드 수와 일치하는지, 템플릿 내 `id` 중복이 없는지를 검증하고 CI 에서도 실행된다.
+- `scripts/templates/build_meta.py` 가 `template.pptx` 를 soffice→PDF→pdftoppm 으로 슬라이드별 JPG + 그리드 `thumbnail.jpg` 로 만들고, markitdown 으로 임시 텍스트를 추출한 뒤, (썸네일+텍스트)를 LLM 에 입력해 Source Slide 별 `{category, description, best_for}` 초안과 같은 카테고리 내 알파벳순 `id` 를 자동 부여한 `meta.json` 초안을 작성한다. 슬라이드별 JPG와 임시 텍스트는 기본적으로 배포 디렉터리 밖의 work dir에 둔다.
+- `scripts/templates/validate_template.py` 가 `meta.json` 필수 필드 스키마, `template_file` 이 경로 없이 정확히 `template.pptx` 인지, `thumbnail.jpg` 가 존재하고 비어 있지 않은지, `category` 가 `templates/_schema/categories.json` Enum 안에 있는지(unknown 이면 실패), `slide_index` 가 `0..N-1` 연속이며 PPTX 슬라이드 수와 일치하는지, 템플릿 내 `id` 중복이 없는지를 검증하고 CI 에서도 실행된다.
 - `templates/_schema/categories.json` 을 §3.3 표준 카테고리 Enum(cover/toc/overview/problem/process/outcome/chart/visual/text/closing)의 단일 소스 오브 트루스로 둔다.
 - 의미 필드(`category`/`description`/`best_for`/`id`)는 LLM 초안 후 운영자가 검토·확정하는 반자동 산출물로 다루고, `slide_index`/`template_file` 은 자동 생성 후 운영자가 손대지 않는다.
 
@@ -13,6 +13,6 @@
 런타임 워커(`apps/pptx-worker/`)와 분리된 오프라인 운영자/CI 도구로, soffice/pdftoppm/markitdown 도구 체인은 spec 04 와 공유하되 런타임 경로에는 두지 않는다(template-system.md §3.5). `build_meta.py` 는 §3.5.1 의 [1]+[2] 단계(자동 추출 + LLM 초안)를 한 번에 수행하고, 운영자 검토([3])와 `validate_template.py` 검증([4])을 거쳐 GCS 업로드([5])로 이어진다. 메타 작성 LLM 호출은 빌드 단계라 런타임 사용자 비용에 영향이 없다(§3.5.4). 카테고리 분포 권장 범위는 경고만 내고 실패시키지 않는다.
 
 ## Verification
-- 샘플 `template.pptx` 로 `build_meta.py` 를 실행하면 슬라이드별 JPG·그리드 thumbnail·임시 텍스트가 생성되고, Source Slide 별 `{category, description, best_for}` 와 카테고리별 알파벳순 `id` 가 채워진 `meta.json` 초안이 디스크에 작성되는지 확인한다.
+- 샘플 `template.pptx` 로 `build_meta.py` 를 실행하면 슬라이드별 JPG·그리드 thumbnail·임시 텍스트가 생성되고, Source Slide 별 `{category, description, best_for}` 와 카테고리별 알파벳순 `id` 가 채워진 `meta.json` 초안이 디스크에 작성되는지 확인한다. 배포 디렉터리에는 `template.pptx`, `meta.json`, `thumbnail.jpg` 만 기본 산출물로 남는지 확인한다.
 - `validate_template.py` 가 필수 필드 누락·Enum 밖 category(unknown 포함)·`slide_index` 불연속·PPTX 슬라이드 수 불일치·중복 `id` 를 각각 실패로 잡아내는지 검증한다.
 - `category` 가 `templates/_schema/categories.json` 의 값과 일치할 때만 검증을 통과하고, Enum 을 확장하지 않은 신규 값은 실패하는지 확인한다.

--- a/tasks/phase-1-pptx-worker/08-template-registration-pipeline.md
+++ b/tasks/phase-1-pptx-worker/08-template-registration-pipeline.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/08-template-registration-pipeline.md"
 depends_on: ["1.04"]
 blocks: []
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-05-27"
 owner: ""
 sprint: ""
 ---
@@ -21,22 +22,22 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] `scripts/templates/` · `templates/_schema/` 디렉터리 신규 생성
-- [ ] 메타 작성 보조 LLM(`common/llm`) + markitdown 사용 확인
+- [x] `scripts/templates/` · `templates/_schema/` 디렉터리 신규 생성
+- [x] 메타 작성 보조 LLM(`common/llm`) + markitdown 사용 확인
 
 ## 구현 체크리스트
 
-- [ ] `templates/_schema/categories.json` — §3.3 표준 Enum 단일 소스(cover/toc/overview/problem/process/outcome/chart/visual/text/closing)
-- [ ] `scripts/templates/build_meta.py` — soffice/pdftoppm JPG+그리드 thumbnail → markitdown 임시 텍스트 → LLM 초안{category,description,best_for} + 카테고리 내 알파벳 id → meta.json 초안
-- [ ] `scripts/templates/validate_template.py` — 필수 필드 스키마·category Enum(unknown 실패)·slide_index 0..N-1 연속 & PPTX 수 일치·id 중복 검증 (CI 실행)
-- [ ] 카테고리 분포 권장 범위는 경고만(실패 아님)
-- [ ] `slide_index`/`template_file` 자동(운영자 미수정), 의미 필드는 LLM 초안 후 운영자 검토
+- [x] `templates/_schema/categories.json` — §3.3 표준 Enum 단일 소스(cover/toc/overview/problem/process/outcome/chart/visual/text/closing)
+- [x] `scripts/templates/build_meta.py` — soffice/pdftoppm JPG+그리드 thumbnail → markitdown 임시 텍스트 → LLM 초안{category,description,best_for} + 카테고리 내 알파벳 id → meta.json 초안
+- [x] `scripts/templates/validate_template.py` — 필수 필드 스키마·category Enum(unknown 실패)·slide_index 0..N-1 연속 & PPTX 수 일치·id 중복 검증 (CI 실행)
+- [x] 카테고리 분포 권장 범위는 경고만(실패 아님)
+- [x] `slide_index`/`template_file` 자동(운영자 미수정), 의미 필드는 LLM 초안 후 운영자 검토
 
 ## Definition of Done
 
-- [ ] `build_meta.py` 가 JPG·그리드 썸네일·임시 텍스트 생성 + 알파벳 id 채운 meta.json 초안 작성 검증
-- [ ] `validate_template.py` 가 필수누락·Enum 밖·slide_index 불연속/불일치·중복 id 를 각각 실패로 잡음 검증
-- [ ] Enum 미확장 신규 category 가 실패하는지 검증
+- [x] `build_meta.py` 가 JPG·그리드 썸네일·임시 텍스트 생성 + 알파벳 id 채운 meta.json 초안 작성 검증
+- [x] `validate_template.py` 가 필수누락·Enum 밖·slide_index 불연속/불일치·중복 id 를 각각 실패로 잡음 검증
+- [x] Enum 미확장 신규 category 가 실패하는지 검증
 
 ## 리스크 / 메모
 

--- a/tasks/phase-1-pptx-worker/08-template-registration-pipeline.md
+++ b/tasks/phase-1-pptx-worker/08-template-registration-pipeline.md
@@ -28,15 +28,15 @@ sprint: ""
 ## 구현 체크리스트
 
 - [x] `templates/_schema/categories.json` — §3.3 표준 Enum 단일 소스(cover/toc/overview/problem/process/outcome/chart/visual/text/closing)
-- [x] `scripts/templates/build_meta.py` — soffice/pdftoppm JPG+그리드 thumbnail → markitdown 임시 텍스트 → LLM 초안{category,description,best_for} + 카테고리 내 알파벳 id → meta.json 초안
-- [x] `scripts/templates/validate_template.py` — 필수 필드 스키마·category Enum(unknown 실패)·slide_index 0..N-1 연속 & PPTX 수 일치·id 중복 검증 (CI 실행)
+- [x] `scripts/templates/build_meta.py` — soffice/pdftoppm JPG+그리드 thumbnail → markitdown 임시 텍스트 → LLM 초안{category,description,best_for} + 카테고리 내 알파벳 id → meta.json 초안, 중간 산출물은 기본적으로 배포 디렉터리 밖에 생성
+- [x] `scripts/templates/validate_template.py` — 필수 필드 스키마·template_file 고정·thumbnail 존재·category Enum(unknown 실패)·slide_index 0..N-1 연속 & PPTX 수 일치·id 중복 검증 (운영자/CI 잡 실행용)
 - [x] 카테고리 분포 권장 범위는 경고만(실패 아님)
 - [x] `slide_index`/`template_file` 자동(운영자 미수정), 의미 필드는 LLM 초안 후 운영자 검토
 
 ## Definition of Done
 
 - [x] `build_meta.py` 가 JPG·그리드 썸네일·임시 텍스트 생성 + 알파벳 id 채운 meta.json 초안 작성 검증
-- [x] `validate_template.py` 가 필수누락·Enum 밖·slide_index 불연속/불일치·중복 id 를 각각 실패로 잡음 검증
+- [x] `validate_template.py` 가 필수누락·template_file 오류·thumbnail 누락/빈 파일·Enum 밖·slide_index 불연속/불일치·중복 id 를 각각 실패로 잡음 검증
 - [x] Enum 미확장 신규 category 가 실패하는지 검증
 
 ## 리스크 / 메모

--- a/templates/_schema/categories.json
+++ b/templates/_schema/categories.json
@@ -1,0 +1,64 @@
+{
+  "categories": [
+    {
+      "key": "cover",
+      "description": "프로젝트명, 이름, 날짜를 보여주는 표지",
+      "recommended_min": 3,
+      "recommended_max": 4
+    },
+    {
+      "key": "toc",
+      "description": "전체 구성을 한눈에 보여주는 목차",
+      "recommended_min": 2,
+      "recommended_max": 3
+    },
+    {
+      "key": "overview",
+      "description": "배경, 기간, 역할, 팀 구성을 설명하는 프로젝트 개요",
+      "recommended_min": 3,
+      "recommended_max": 4
+    },
+    {
+      "key": "problem",
+      "description": "문제 상황과 과제를 설명하는 문제 정의",
+      "recommended_min": 2,
+      "recommended_max": 3
+    },
+    {
+      "key": "process",
+      "description": "진행 과정과 단계별 흐름을 설명하는 프로세스",
+      "recommended_min": 3,
+      "recommended_max": 4
+    },
+    {
+      "key": "outcome",
+      "description": "수치, KPI, Before/After 등 성과와 결과",
+      "recommended_min": 3,
+      "recommended_max": 4
+    },
+    {
+      "key": "chart",
+      "description": "데이터 시각화, 도표, 차트 중심 슬라이드",
+      "recommended_min": 4,
+      "recommended_max": 5
+    },
+    {
+      "key": "visual",
+      "description": "스크린샷, 목업, 작업물 등 이미지 중심 슬라이드",
+      "recommended_min": 3,
+      "recommended_max": 4
+    },
+    {
+      "key": "text",
+      "description": "회고와 러닝포인트 등 텍스트 중심 슬라이드",
+      "recommended_min": 2,
+      "recommended_max": 3
+    },
+    {
+      "key": "closing",
+      "description": "감사, 연락처 등 마무리 슬라이드",
+      "recommended_min": 2,
+      "recommended_max": 3
+    }
+  ]
+}

--- a/tests/test_features/test_visualization/test_template_registration.py
+++ b/tests/test_features/test_visualization/test_template_registration.py
@@ -1,0 +1,392 @@
+"""템플릿 등록 파이프라인 테스트."""
+
+import copy
+import json
+import zipfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from features.visualization.templates import (
+    BuildMetaOptions,
+    SlideDraft,
+    SlideDraftInput,
+    SlideText,
+    TextExtractionResult,
+    build_template_metadata,
+    count_pptx_slides,
+    extract_slide_texts,
+    validate_template_directory,
+)
+from scripts.templates.validate_template import main as validate_template_main
+
+_PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+_DRAWINGML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+_SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
+
+
+@dataclass(frozen=True)
+class FakeRenderResult:
+    """테스트용 렌더 결과."""
+
+    image_paths: tuple[Path, ...]
+
+
+class FakeRenderer:
+    """슬라이드 JPG 산출물을 만드는 렌더러 대역."""
+
+    def __init__(self, slide_count: int) -> None:
+        self.slide_count = slide_count
+        self.calls: list[tuple[Path, Path]] = []
+
+    def render(self, pptx_path: Path | str, output_dir: Path | str) -> FakeRenderResult:
+        source = Path(pptx_path)
+        target = Path(output_dir)
+        self.calls.append((source, target))
+        target.mkdir(parents=True, exist_ok=True)
+        paths = []
+        for index in range(1, self.slide_count + 1):
+            image_path = target / f"slide-{index:02d}.jpg"
+            image_path.write_bytes(f"jpg-{index}".encode())
+            paths.append(image_path)
+        return FakeRenderResult(image_paths=tuple(paths))
+
+
+class FakeThumbnailBuilder:
+    """그리드 thumbnail.jpg 산출물을 만드는 대역."""
+
+    def __init__(self) -> None:
+        self.slide_images: tuple[Path, ...] = ()
+
+    def build(self, slide_images: Sequence[Path], output_path: Path) -> Path:
+        self.slide_images = tuple(slide_images)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"thumbnail")
+        return output_path
+
+
+class FakeTextExtractor:
+    """임시 텍스트 추출기 대역."""
+
+    def __init__(self, slide_texts: tuple[SlideText, ...]) -> None:
+        self.slide_texts = slide_texts
+
+    def extract(self, pptx_path: Path) -> TextExtractionResult:
+        return TextExtractionResult(
+            deck_text=f"deck text: {pptx_path.name}", slide_texts=self.slide_texts
+        )
+
+
+class FakeDraftGenerator:
+    """Source Slide 의미 필드 초안 생성 대역."""
+
+    def __init__(self, drafts: list[SlideDraft]) -> None:
+        self.drafts = drafts
+        self.inputs: list[SlideDraftInput] = []
+
+    def generate(self, slide: SlideDraftInput, categories) -> SlideDraft:
+        assert "cover" in categories.key_set
+        self.inputs.append(slide)
+        return self.drafts[slide.slide_index]
+
+
+def test_count_pptx_slides_and_extract_slide_texts(tmp_path: Path) -> None:
+    """PPTX 슬라이드 수와 슬라이드별 텍스트를 덱 순서대로 추출한다."""
+    pptx_path = tmp_path / "template.pptx"
+    _make_template_pptx(pptx_path, slide_texts=["표지 제목", "개요\n역할"])
+
+    assert count_pptx_slides(pptx_path) == 2
+    assert extract_slide_texts(pptx_path) == (
+        SlideText(slide_index=0, text="표지 제목"),
+        SlideText(slide_index=1, text="개요\n역할"),
+    )
+
+
+def test_build_template_metadata_writes_assets_and_meta_draft(tmp_path: Path) -> None:
+    """build 흐름은 슬라이드 JPG, 썸네일, 임시 텍스트, meta.json 초안을 작성한다."""
+    template_dir = tmp_path / "blue"
+    pptx_path = template_dir / "template.pptx"
+    _make_template_pptx(pptx_path, slide_texts=["Cover", "Overview", "Second cover"])
+    renderer = FakeRenderer(slide_count=3)
+    thumbnail_builder = FakeThumbnailBuilder()
+    draft_generator = FakeDraftGenerator(
+        [
+            SlideDraft(category="cover", description="중앙 표지", best_for="짧은 프로젝트명"),
+            SlideDraft(category="overview", description="카드형 개요", best_for="역할과 기간"),
+            SlideDraft(category="cover", description="이미지 표지", best_for="시각적 첫인상"),
+        ]
+    )
+
+    result = build_template_metadata(
+        BuildMetaOptions(
+            pptx_path=pptx_path,
+            template_id="blue",
+            primary_color="#4A6CF7",
+            output_path=template_dir / "meta.json",
+            theme_name="블루 클린",
+        ),
+        renderer=renderer,
+        thumbnail_builder=thumbnail_builder,
+        text_extractor=FakeTextExtractor(
+            (
+                SlideText(slide_index=0, text="Cover"),
+                SlideText(slide_index=1, text="Overview"),
+                SlideText(slide_index=2, text="Second cover"),
+            )
+        ),
+        draft_generator=draft_generator,
+    )
+
+    metadata = json.loads(result.meta_path.read_text(encoding="utf-8"))
+    assert metadata["_draft_notice"]
+    assert metadata["template_id"] == "blue"
+    assert metadata["template_file"] == "template.pptx"
+    assert metadata["theme"] == {"primary_color": "#4A6CF7", "name": "블루 클린"}
+    assert [slide["slide_index"] for slide in metadata["slides"]] == [0, 1, 2]
+    assert [slide["id"] for slide in metadata["slides"]] == [
+        "cover_A",
+        "overview_A",
+        "cover_B",
+    ]
+    assert [slide["category"] for slide in metadata["slides"]] == [
+        "cover",
+        "overview",
+        "cover",
+    ]
+    assert [path.name for path in result.slide_image_paths] == [
+        "slide-01.jpg",
+        "slide-02.jpg",
+        "slide-03.jpg",
+    ]
+    assert result.thumbnail_path.read_bytes() == b"thumbnail"
+    assert "### Slide 2" in result.text_output_path.read_text(encoding="utf-8")
+    assert thumbnail_builder.slide_images == result.slide_image_paths
+    assert [slide.text for slide in draft_generator.inputs] == ["Cover", "Overview", "Second cover"]
+
+
+def test_validate_template_directory_accepts_valid_meta_with_distribution_warnings(
+    tmp_path: Path,
+) -> None:
+    """검증기는 유효한 meta.json을 통과시키고 카테고리 분포는 warning만 낸다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview"])
+    _write_meta(template_dir, slides=_valid_slides())
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is True
+    assert result.errors == ()
+    assert result.warnings
+
+
+@pytest.mark.parametrize(
+    ("case_name", "mutator", "expected_error"),
+    [
+        (
+            "required",
+            lambda slides: slides[0].pop("description"),
+            "필수 필드 누락: slides[0].description",
+        ),
+        (
+            "invalid_category",
+            lambda slides: slides[0].update(category="intro"),
+            "표준 Enum 밖",
+        ),
+        (
+            "unknown_category",
+            lambda slides: slides[0].update(category="unknown"),
+            "unknown일 수 없습니다",
+        ),
+        (
+            "slide_index_gap",
+            lambda slides: slides[1].update(slide_index=3),
+            "slide_index는 slides 배열 순서대로",
+        ),
+        (
+            "slide_index_order",
+            lambda slides: (
+                slides[0].update(slide_index=1),
+                slides[1].update(slide_index=0),
+            ),
+            "배열 순서대로",
+        ),
+        (
+            "duplicate_id",
+            lambda slides: slides[1].update(id="cover_A"),
+            "id 중복",
+        ),
+        (
+            "new_category_without_enum_extension",
+            lambda slides: slides[1].update(category="appendix"),
+            "표준 Enum 밖",
+        ),
+    ],
+)
+def test_validate_template_directory_rejects_invalid_meta(
+    tmp_path: Path,
+    case_name: str,
+    mutator,
+    expected_error: str,
+) -> None:
+    """검증기는 필수 누락, Enum 밖 category, unknown, index 불일치, id 중복을 실패 처리한다."""
+    del case_name
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview"])
+    slides = _valid_slides()
+    mutator(slides)
+    _write_meta(template_dir, slides=slides)
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any(expected_error in error for error in result.errors)
+
+
+def test_validate_template_directory_rejects_pptx_slide_count_mismatch(
+    tmp_path: Path,
+) -> None:
+    """meta.json slides 수가 실제 PPTX 슬라이드 수와 다르면 실패한다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview", "Extra"])
+    _write_meta(template_dir, slides=_valid_slides())
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("PPTX 슬라이드 수와 일치하지 않습니다" in error for error in result.errors)
+
+
+def test_validate_template_cli_returns_nonzero_on_validation_errors(tmp_path: Path) -> None:
+    """validate_template.py CLI는 검증 실패 시 non-zero를 반환한다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview"])
+    slides = _valid_slides()
+    slides[0]["category"] = "unknown"
+    _write_meta(template_dir, slides=slides)
+
+    assert validate_template_main([str(template_dir)]) == 1
+
+
+def _valid_slides() -> list[dict[str, object]]:
+    return [
+        {
+            "slide_index": 0,
+            "id": "cover_A",
+            "category": "cover",
+            "description": "표지",
+            "best_for": "첫 페이지",
+        },
+        {
+            "slide_index": 1,
+            "id": "overview_A",
+            "category": "overview",
+            "description": "개요",
+            "best_for": "요약",
+        },
+    ]
+
+
+def _write_meta(template_dir: Path, *, slides: list[dict[str, object]]) -> None:
+    template_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "_draft_notice": "운영자 검토 필요",
+        "template_id": "blue",
+        "template_file": "template.pptx",
+        "theme": {"primary_color": "#4A6CF7", "name": "블루 클린"},
+        "slides": copy.deepcopy(slides),
+    }
+    (template_dir / "meta.json").write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _make_template_pptx(path: Path, *, slide_texts: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    slide_count = len(slide_texts)
+    entries: dict[str, str] = {
+        "[Content_Types].xml": _content_types(slide_count),
+        "_rels/.rels": (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}">'
+            '<Relationship Id="rId1" '
+            'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+            'Target="ppt/presentation.xml"/>'
+            "</Relationships>"
+        ),
+        "ppt/presentation.xml": _presentation(slide_count),
+        "ppt/_rels/presentation.xml.rels": _presentation_rels(slide_count),
+    }
+    for index, slide_text in enumerate(slide_texts, start=1):
+        entries[f"ppt/slides/slide{index}.xml"] = _slide_xml(index, slide_text)
+        entries[f"ppt/slides/_rels/slide{index}.xml.rels"] = (
+            f'<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}"/>'
+        )
+
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+
+
+def _content_types(slide_count: int) -> str:
+    overrides = [
+        '<Override PartName="/ppt/presentation.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>'
+    ]
+    overrides.extend(
+        f'<Override PartName="/ppt/slides/slide{index}.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>'
+        for index in range(1, slide_count + 1)
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+        '<Default Extension="xml" ContentType="application/xml"/>'
+        f"{''.join(overrides)}</Types>"
+    )
+
+
+def _presentation(slide_count: int) -> str:
+    slide_ids = "".join(
+        f'<p:sldId id="{255 + index}" r:id="rId{index}"/>' for index in range(1, slide_count + 1)
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<p:presentation xmlns:p="{_PRESENTATION_NS}" xmlns:r="{_RELATIONSHIPS_NS}">'
+        f"<p:sldIdLst>{slide_ids}</p:sldIdLst>"
+        "</p:presentation>"
+    )
+
+
+def _presentation_rels(slide_count: int) -> str:
+    relationships = "".join(
+        f'<Relationship Id="rId{index}" Type="{_SLIDE_RELATIONSHIP_TYPE}" '
+        f'Target="slides/slide{index}.xml"/>'
+        for index in range(1, slide_count + 1)
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}">{relationships}</Relationships>'
+    )
+
+
+def _slide_xml(index: int, text: str) -> str:
+    paragraphs = "".join(f"<a:p><a:r><a:t>{line}</a:t></a:r></a:p>" for line in text.split("\n"))
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<p:sld xmlns:p="{_PRESENTATION_NS}" xmlns:a="{_DRAWINGML_NS}">'
+        "<p:cSld><p:spTree>"
+        f'<p:sp><p:nvSpPr><p:cNvPr id="{index}" name="Text {index}"/>'
+        "</p:nvSpPr><p:txBody>"
+        f"{paragraphs}"
+        "</p:txBody></p:sp>"
+        "</p:spTree></p:cSld>"
+        "</p:sld>"
+    )

--- a/tests/test_features/test_visualization/test_template_registration.py
+++ b/tests/test_features/test_visualization/test_template_registration.py
@@ -20,6 +20,7 @@ from features.visualization.templates import (
     extract_slide_texts,
     validate_template_directory,
 )
+from features.visualization.templates.thumbnail import PillowThumbnailBuilder
 from scripts.templates.validate_template import main as validate_template_main
 
 _PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
@@ -117,9 +118,9 @@ def test_build_template_metadata_writes_assets_and_meta_draft(tmp_path: Path) ->
     thumbnail_builder = FakeThumbnailBuilder()
     draft_generator = FakeDraftGenerator(
         [
-            SlideDraft(category="cover", description="중앙 표지", best_for="짧은 프로젝트명"),
+            SlideDraft(category="Cover", description="중앙 표지", best_for="짧은 프로젝트명"),
             SlideDraft(category="overview", description="카드형 개요", best_for="역할과 기간"),
-            SlideDraft(category="cover", description="이미지 표지", best_for="시각적 첫인상"),
+            SlideDraft(category="cover ", description="이미지 표지", best_for="시각적 첫인상"),
         ]
     )
 
@@ -199,6 +200,11 @@ def test_validate_template_directory_accepts_valid_meta_with_distribution_warnin
             "표준 Enum 밖",
         ),
         (
+            "non_string_category",
+            lambda slides: slides[0].update(category=123),
+            "slides[0].category는 비어 있지 않은 문자열",
+        ),
+        (
             "unknown_category",
             lambda slides: slides[0].update(category="unknown"),
             "unknown일 수 없습니다",
@@ -262,6 +268,62 @@ def test_validate_template_directory_rejects_pptx_slide_count_mismatch(
     assert any("PPTX 슬라이드 수와 일치하지 않습니다" in error for error in result.errors)
 
 
+@pytest.mark.parametrize(
+    ("mutator", "expected_error"),
+    [
+        (lambda metadata: metadata.update(template_id=123), "template_id는 비어 있지 않은 문자열"),
+        (
+            lambda metadata: metadata["theme"].update(primary_color=False),
+            "theme.primary_color는 비어 있지 않은 문자열",
+        ),
+    ],
+)
+def test_validate_template_directory_rejects_non_string_metadata_fields(
+    tmp_path: Path,
+    mutator,
+    expected_error: str,
+) -> None:
+    """검증기는 필수 문자열 필드의 타입 오류를 실패 처리한다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview"])
+    _write_meta(template_dir, slides=_valid_slides())
+    metadata = json.loads((template_dir / "meta.json").read_text(encoding="utf-8"))
+    mutator(metadata)
+    (template_dir / "meta.json").write_text(
+        json.dumps(metadata, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any(expected_error in error for error in result.errors)
+
+
+def test_count_pptx_slides_rejects_missing_presentation_relationships(tmp_path: Path) -> None:
+    """PPTX slide relationship이 없으면 파일명 순서 fallback 없이 실패한다."""
+    pptx_path = tmp_path / "template.pptx"
+    _make_template_pptx(pptx_path, slide_texts=["Cover"], include_relationships=False)
+
+    with pytest.raises(ValueError, match="presentation relationship"):
+        count_pptx_slides(pptx_path)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"cell_width": 0},
+        {"cell_height": 0},
+        {"gap": -1},
+        {"max_columns": 0},
+    ],
+)
+def test_pillow_thumbnail_builder_rejects_invalid_dimensions(kwargs: dict[str, int]) -> None:
+    """썸네일 생성기는 잘못된 치수 옵션을 즉시 실패 처리한다."""
+    with pytest.raises(ValueError):
+        PillowThumbnailBuilder(**kwargs)
+
+
 def test_validate_template_cli_returns_nonzero_on_validation_errors(tmp_path: Path) -> None:
     """validate_template.py CLI는 검증 실패 시 non-zero를 반환한다."""
     template_dir = tmp_path / "blue"
@@ -274,6 +336,11 @@ def test_validate_template_cli_returns_nonzero_on_validation_errors(tmp_path: Pa
 
 
 def _valid_slides() -> list[dict[str, object]]:
+    """유효한 meta.json slides fixture를 만든다.
+
+    Returns:
+        list[dict[str, object]]: 검증을 통과하는 Source Slide 메타데이터 목록.
+    """
     return [
         {
             "slide_index": 0,
@@ -293,6 +360,15 @@ def _valid_slides() -> list[dict[str, object]]:
 
 
 def _write_meta(template_dir: Path, *, slides: list[dict[str, object]]) -> None:
+    """테스트용 meta.json 파일을 작성한다.
+
+    Args:
+        template_dir: meta.json을 생성할 템플릿 디렉터리.
+        slides: meta.json의 slides 배열에 넣을 Source Slide 메타데이터.
+
+    Returns:
+        None: 파일 생성 부작용만 수행한다.
+    """
     template_dir.mkdir(parents=True, exist_ok=True)
     metadata = {
         "_draft_notice": "운영자 검토 필요",
@@ -307,7 +383,22 @@ def _write_meta(template_dir: Path, *, slides: list[dict[str, object]]) -> None:
     )
 
 
-def _make_template_pptx(path: Path, *, slide_texts: list[str]) -> None:
+def _make_template_pptx(
+    path: Path,
+    *,
+    slide_texts: list[str],
+    include_relationships: bool = True,
+) -> None:
+    """테스트용 최소 PPTX 패키지를 생성한다.
+
+    Args:
+        path: 생성할 PPTX 파일 경로.
+        slide_texts: 각 슬라이드 XML에 넣을 텍스트 목록.
+        include_relationships: presentation relationship 파일 포함 여부.
+
+    Returns:
+        None: PPTX ZIP 파일 생성 부작용만 수행한다.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     slide_count = len(slide_texts)
     entries: dict[str, str] = {
@@ -321,8 +412,9 @@ def _make_template_pptx(path: Path, *, slide_texts: list[str]) -> None:
             "</Relationships>"
         ),
         "ppt/presentation.xml": _presentation(slide_count),
-        "ppt/_rels/presentation.xml.rels": _presentation_rels(slide_count),
     }
+    if include_relationships:
+        entries["ppt/_rels/presentation.xml.rels"] = _presentation_rels(slide_count)
     for index, slide_text in enumerate(slide_texts, start=1):
         entries[f"ppt/slides/slide{index}.xml"] = _slide_xml(index, slide_text)
         entries[f"ppt/slides/_rels/slide{index}.xml.rels"] = (
@@ -335,6 +427,14 @@ def _make_template_pptx(path: Path, *, slide_texts: list[str]) -> None:
 
 
 def _content_types(slide_count: int) -> str:
+    """PPTX Content_Types XML을 만든다.
+
+    Args:
+        slide_count: 포함할 슬라이드 개수.
+
+    Returns:
+        str: `[Content_Types].xml`에 쓸 XML 문자열.
+    """
     overrides = [
         '<Override PartName="/ppt/presentation.xml" '
         'ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>'
@@ -354,6 +454,14 @@ def _content_types(slide_count: int) -> str:
 
 
 def _presentation(slide_count: int) -> str:
+    """presentation.xml 내용을 만든다.
+
+    Args:
+        slide_count: 포함할 슬라이드 개수.
+
+    Returns:
+        str: `ppt/presentation.xml`에 쓸 XML 문자열.
+    """
     slide_ids = "".join(
         f'<p:sldId id="{255 + index}" r:id="rId{index}"/>' for index in range(1, slide_count + 1)
     )
@@ -366,6 +474,14 @@ def _presentation(slide_count: int) -> str:
 
 
 def _presentation_rels(slide_count: int) -> str:
+    """presentation.xml.rels 내용을 만든다.
+
+    Args:
+        slide_count: 포함할 슬라이드 relationship 개수.
+
+    Returns:
+        str: `ppt/_rels/presentation.xml.rels`에 쓸 XML 문자열.
+    """
     relationships = "".join(
         f'<Relationship Id="rId{index}" Type="{_SLIDE_RELATIONSHIP_TYPE}" '
         f'Target="slides/slide{index}.xml"/>'
@@ -378,6 +494,15 @@ def _presentation_rels(slide_count: int) -> str:
 
 
 def _slide_xml(index: int, text: str) -> str:
+    """단일 슬라이드 XML 내용을 만든다.
+
+    Args:
+        index: 1부터 시작하는 슬라이드 번호.
+        text: 슬라이드 텍스트 도형에 넣을 텍스트.
+
+    Returns:
+        str: `ppt/slides/slideN.xml`에 쓸 XML 문자열.
+    """
     paragraphs = "".join(f"<a:p><a:r><a:t>{line}</a:t></a:r></a:p>" for line in text.split("\n"))
     return (
         '<?xml version="1.0" encoding="UTF-8"?>'

--- a/tests/test_features/test_visualization/test_template_registration.py
+++ b/tests/test_features/test_visualization/test_template_registration.py
@@ -110,7 +110,7 @@ def test_count_pptx_slides_and_extract_slide_texts(tmp_path: Path) -> None:
 
 
 def test_build_template_metadata_writes_assets_and_meta_draft(tmp_path: Path) -> None:
-    """build 흐름은 슬라이드 JPG, 썸네일, 임시 텍스트, meta.json 초안을 작성한다."""
+    """build 흐름은 배포 산출물과 중간 산출물을 분리해 작성한다."""
     template_dir = tmp_path / "blue"
     pptx_path = template_dir / "template.pptx"
     _make_template_pptx(pptx_path, slide_texts=["Cover", "Overview", "Second cover"])
@@ -165,8 +165,13 @@ def test_build_template_metadata_writes_assets_and_meta_draft(tmp_path: Path) ->
         "slide-02.jpg",
         "slide-03.jpg",
     ]
+    assert result.thumbnail_path == template_dir / "thumbnail.jpg"
     assert result.thumbnail_path.read_bytes() == b"thumbnail"
     assert "### Slide 2" in result.text_output_path.read_text(encoding="utf-8")
+    assert not result.text_output_path.is_relative_to(template_dir)
+    assert all(not path.is_relative_to(template_dir) for path in result.slide_image_paths)
+    assert not (template_dir / "slides").exists()
+    assert not (template_dir / "slide_text.md").exists()
     assert thumbnail_builder.slide_images == result.slide_image_paths
     assert [slide.text for slide in draft_generator.inputs] == ["Cover", "Overview", "Second cover"]
 
@@ -269,6 +274,26 @@ def test_validate_template_directory_rejects_pptx_slide_count_mismatch(
 
 
 @pytest.mark.parametrize(
+    "template_file",
+    ["ppt-for-test.pptx", "../shared.pptx", "/tmp/shared.pptx", "nested\\template.pptx"],
+)
+def test_validate_template_directory_rejects_invalid_template_file(
+    tmp_path: Path,
+    template_file: str,
+) -> None:
+    """검증기는 template_file을 경로 없는 template.pptx로 강제한다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview"])
+    _make_template_pptx(tmp_path / "shared.pptx", slide_texts=["Cover", "Overview"])
+    _write_meta(template_dir, slides=_valid_slides(), template_file=template_file)
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("template_file은 경로 없이 template.pptx" in error for error in result.errors)
+
+
+@pytest.mark.parametrize(
     ("mutator", "expected_error"),
     [
         (lambda metadata: metadata.update(template_id=123), "template_id는 비어 있지 않은 문자열"),
@@ -300,6 +325,29 @@ def test_validate_template_directory_rejects_non_string_metadata_fields(
     assert any(expected_error in error for error in result.errors)
 
 
+@pytest.mark.parametrize(
+    ("thumbnail_content", "expected_error"),
+    [
+        (None, "thumbnail.jpg 파일을 찾을 수 없습니다"),
+        (b"", "thumbnail.jpg 파일이 비어 있습니다"),
+    ],
+)
+def test_validate_template_directory_rejects_missing_or_empty_thumbnail(
+    tmp_path: Path,
+    thumbnail_content: bytes | None,
+    expected_error: str,
+) -> None:
+    """검증기는 배포 산출물 thumbnail.jpg 누락과 빈 파일을 실패 처리한다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(template_dir / "template.pptx", slide_texts=["Cover", "Overview"])
+    _write_meta(template_dir, slides=_valid_slides(), thumbnail_content=thumbnail_content)
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any(expected_error in error for error in result.errors)
+
+
 def test_count_pptx_slides_rejects_missing_presentation_relationships(tmp_path: Path) -> None:
     """PPTX slide relationship이 없으면 파일명 순서 fallback 없이 실패한다."""
     pptx_path = tmp_path / "template.pptx"
@@ -307,6 +355,39 @@ def test_count_pptx_slides_rejects_missing_presentation_relationships(tmp_path: 
 
     with pytest.raises(ValueError, match="presentation relationship"):
         count_pptx_slides(pptx_path)
+
+
+def test_count_pptx_slides_rejects_relationship_target_outside_slide_parts(
+    tmp_path: Path,
+) -> None:
+    """PPTX slide relationship target이 ppt/slides/*.xml 밖이면 실패한다."""
+    pptx_path = tmp_path / "template.pptx"
+    _make_template_pptx(
+        pptx_path,
+        slide_texts=["Cover"],
+        relationship_targets=["../media/image1.xml"],
+    )
+
+    with pytest.raises(ValueError, match=r"ppt/slides/\*\.xml"):
+        count_pptx_slides(pptx_path)
+
+
+def test_validate_template_directory_rejects_missing_slide_relationship_target(
+    tmp_path: Path,
+) -> None:
+    """검증기는 relationship이 가리키는 슬라이드 XML 누락을 실패 처리한다."""
+    template_dir = tmp_path / "blue"
+    _make_template_pptx(
+        template_dir / "template.pptx",
+        slide_texts=["Cover"],
+        relationship_targets=["slides/missing.xml"],
+    )
+    _write_meta(template_dir, slides=[_valid_slides()[0]])
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("PPTX 슬라이드 XML을 찾을 수 없습니다" in error for error in result.errors)
 
 
 @pytest.mark.parametrize(
@@ -359,12 +440,20 @@ def _valid_slides() -> list[dict[str, object]]:
     ]
 
 
-def _write_meta(template_dir: Path, *, slides: list[dict[str, object]]) -> None:
+def _write_meta(
+    template_dir: Path,
+    *,
+    slides: list[dict[str, object]],
+    template_file: str = "template.pptx",
+    thumbnail_content: bytes | None = b"thumbnail",
+) -> None:
     """테스트용 meta.json 파일을 작성한다.
 
     Args:
         template_dir: meta.json을 생성할 템플릿 디렉터리.
         slides: meta.json의 slides 배열에 넣을 Source Slide 메타데이터.
+        template_file: meta.json의 template_file 값.
+        thumbnail_content: thumbnail.jpg에 쓸 바이트. None이면 파일을 만들지 않는다.
 
     Returns:
         None: 파일 생성 부작용만 수행한다.
@@ -373,7 +462,7 @@ def _write_meta(template_dir: Path, *, slides: list[dict[str, object]]) -> None:
     metadata = {
         "_draft_notice": "운영자 검토 필요",
         "template_id": "blue",
-        "template_file": "template.pptx",
+        "template_file": template_file,
         "theme": {"primary_color": "#4A6CF7", "name": "블루 클린"},
         "slides": copy.deepcopy(slides),
     }
@@ -381,6 +470,8 @@ def _write_meta(template_dir: Path, *, slides: list[dict[str, object]]) -> None:
         json.dumps(metadata, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    if thumbnail_content is not None:
+        (template_dir / "thumbnail.jpg").write_bytes(thumbnail_content)
 
 
 def _make_template_pptx(
@@ -388,6 +479,7 @@ def _make_template_pptx(
     *,
     slide_texts: list[str],
     include_relationships: bool = True,
+    relationship_targets: list[str] | None = None,
 ) -> None:
     """테스트용 최소 PPTX 패키지를 생성한다.
 
@@ -395,6 +487,7 @@ def _make_template_pptx(
         path: 생성할 PPTX 파일 경로.
         slide_texts: 각 슬라이드 XML에 넣을 텍스트 목록.
         include_relationships: presentation relationship 파일 포함 여부.
+        relationship_targets: 각 슬라이드 relationship Target 값. 생략하면 기본 slideN.xml을 쓴다.
 
     Returns:
         None: PPTX ZIP 파일 생성 부작용만 수행한다.
@@ -414,7 +507,10 @@ def _make_template_pptx(
         "ppt/presentation.xml": _presentation(slide_count),
     }
     if include_relationships:
-        entries["ppt/_rels/presentation.xml.rels"] = _presentation_rels(slide_count)
+        entries["ppt/_rels/presentation.xml.rels"] = _presentation_rels(
+            slide_count,
+            relationship_targets=relationship_targets,
+        )
     for index, slide_text in enumerate(slide_texts, start=1):
         entries[f"ppt/slides/slide{index}.xml"] = _slide_xml(index, slide_text)
         entries[f"ppt/slides/_rels/slide{index}.xml.rels"] = (
@@ -473,18 +569,26 @@ def _presentation(slide_count: int) -> str:
     )
 
 
-def _presentation_rels(slide_count: int) -> str:
+def _presentation_rels(
+    slide_count: int,
+    *,
+    relationship_targets: list[str] | None = None,
+) -> str:
     """presentation.xml.rels 내용을 만든다.
 
     Args:
         slide_count: 포함할 슬라이드 relationship 개수.
+        relationship_targets: 각 relationship의 Target 값.
 
     Returns:
         str: `ppt/_rels/presentation.xml.rels`에 쓸 XML 문자열.
     """
+    targets = relationship_targets or [
+        f"slides/slide{index}.xml" for index in range(1, slide_count + 1)
+    ]
     relationships = "".join(
         f'<Relationship Id="rId{index}" Type="{_SLIDE_RELATIONSHIP_TYPE}" '
-        f'Target="slides/slide{index}.xml"/>'
+        f'Target="{targets[index - 1]}"/>'
         for index in range(1, slide_count + 1)
     )
     return (

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -75,6 +77,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
     { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
     { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
@@ -252,6 +267,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -356,6 +383,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "folioo-ai"
 version = "0.1.0"
 source = { virtual = "." }
@@ -390,6 +425,10 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+template-tools = [
+    { name = "markitdown", extra = ["pptx"] },
+    { name = "pillow" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -422,6 +461,10 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.14.11" },
+]
+template-tools = [
+    { name = "markitdown", extras = ["pptx"], specifier = ">=0.1.3" },
+    { name = "pillow", specifier = ">=11.0.0" },
 ]
 
 [[package]]
@@ -697,6 +740,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -1150,12 +1205,161 @@ wheels = [
 ]
 
 [[package]]
+name = "magika"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e4/35c323beb3280482c94299d61626116856ac2d4ec16ecef50afc4fdd4291/magika-0.6.3-py3-none-any.whl", hash = "sha256:eda443d08006ee495e02083b32e51b98cb3696ab595a7d13900d8e2ef506ec9d", size = 2969474, upload-time = "2025-10-30T15:22:25.298Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/132b0d7cd51c02c39fd52658a5896276c30c8cc2fd453270b19db8c40f7e/magika-0.6.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86901e64b05dde5faff408c9b8245495b2e1fd4c226e3393d3d2a3fee65c504b", size = 13358841, upload-time = "2025-10-30T15:22:27.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/5ed859be502903a68b7b393b17ae0283bf34195cfcca79ce2dc25b9290e7/magika-0.6.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3d9661eedbdf445ac9567e97e7ceefb93545d77a6a32858139ea966b5806fb64", size = 15367335, upload-time = "2025-10-30T15:22:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/f8ee7d644affa3b80efdd623a3d75865c8f058f3950cb87fb0c48e3559bc/magika-0.6.3-py3-none-win_amd64.whl", hash = "sha256:e57f75674447b20cab4db928ae58ab264d7d8582b55183a0b876711c2b2787f3", size = 12692831, upload-time = "2025-10-30T15:22:32.063Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
+name = "markitdown"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "defusedxml" },
+    { name = "magika" },
+    { name = "markdownify" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/b7/91fe0e2df07107ab701a15c8ad3213135707e4d6206ae9bd8f457a7ad86a/markitdown-0.1.6.tar.gz", hash = "sha256:e5bdbaffd971b29598c7c39ef0e9afce2f08c0751fbfa4e4257678ebaf8cfc7e", size = 50795, upload-time = "2026-05-26T22:43:59.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/30/8031f183ee86ea8ac4e7ea1296bab4cca1bee2fd036a26df69764eb7ca74/markitdown-0.1.6-py3-none-any.whl", hash = "sha256:07b2d5bf87b5c53e13a9f2fdc440df8ccc85e26f40c1e557781727b700049775", size = 70032, upload-time = "2026-05-26T22:44:03.209Z" },
+]
+
+[package.optional-dependencies]
+pptx = [
+    { name = "python-pptx" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/39/9335e0874f68f7d27103cbffc0e235e32e26759202df6085716375c078bb/onnxruntime-1.20.1-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:22b0655e2bf4f2161d52706e31f517a0e54939dc393e92577df51808a7edc8c9", size = 31007580, upload-time = "2024-11-21T00:49:07.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/9d/a42a84e10f1744dd27c6f2f9280cc3fb98f869dd19b7cd042e391ee2ab61/onnxruntime-1.20.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f56e898815963d6dc4ee1c35fc6c36506466eff6d16f3cb9848cea4e8c8172", size = 11952833, upload-time = "2024-11-21T00:49:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/47/42/2f71f5680834688a9c81becbe5c5bb996fd33eaed5c66ae0606c3b1d6a02/onnxruntime-1.20.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb71a814f66517a65628c9e4a2bb530a6edd2cd5d87ffa0af0f6f773a027d99e", size = 13333903, upload-time = "2024-11-21T00:49:12.984Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/aabfdf91d013320aa2fc46cf43c88ca0182860ff15df872b4552254a9680/onnxruntime-1.20.1-cp312-cp312-win32.whl", hash = "sha256:bd386cc9ee5f686ee8a75ba74037750aca55183085bf1941da8efcfe12d5b120", size = 9814562, upload-time = "2024-11-21T00:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/76979e0b744307d488c79e41051117634b956612cc731f1028eb17ee7294/onnxruntime-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:19c2d843eb074f385e8bbb753a40df780511061a63f9def1b216bf53860223fb", size = 11331482, upload-time = "2024-11-21T00:49:19.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/71/c5d980ac4189589267a06f758bd6c5667d07e55656bed6c6c0580733ad07/onnxruntime-1.20.1-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:cc01437a32d0042b606f462245c8bbae269e5442797f6213e36ce61d5abdd8cc", size = 31007574, upload-time = "2024-11-21T00:49:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13bbd9489be2a6944f4a940084bfe388f1100472f38c07080a46fbd4ab96/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb44b08e017a648924dbe91b82d89b0c105b1adcfe31e90d1dc06b8677ad37be", size = 11951459, upload-time = "2024-11-21T00:49:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/4454ae122874fd52bbb8a961262de81c5f932edeb1b72217f594c700d6ef/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bda6aebdf7917c1d811f21d41633df00c58aff2bef2f598f69289c1f1dabc4b3", size = 13331620, upload-time = "2024-11-21T00:49:28.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e0/50db43188ca1c945decaa8fc2a024c33446d31afed40149897d4f9de505f/onnxruntime-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:d30367df7e70f1d9fc5a6a68106f5961686d39b54d3221f760085524e8d38e16", size = 11331758, upload-time = "2024-11-21T00:49:31.417Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/55/3821c5fd60b52a6c82a00bba18531793c93c4addfe64fbf061e235c5617a/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9158465745423b2b5d97ed25aa7740c7d38d2993ee2e5c3bfacb0c4145c49d8", size = 11950342, upload-time = "2024-11-21T00:49:34.164Z" },
+    { url = "https://files.pythonhosted.org/packages/14/56/fd990ca222cef4f9f4a9400567b9a15b220dee2eafffb16b2adbc55c8281/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0df6f2df83d61f46e842dbcde610ede27218947c33e994545a22333491e72a3b", size = 13337040, upload-time = "2024-11-21T00:49:37.271Z" },
 ]
 
 [[package]]
@@ -1358,6 +1562,75 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
 ]
 
 [[package]]
@@ -1640,6 +1913,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1684,6 +1966,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-pptx"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
 ]
 
 [[package]]
@@ -1883,12 +2180,30 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -1925,6 +2240,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -2262,6 +2589,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #220

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `templates/_schema/categories.json` 추가
  - Source Slide 표준 category Enum을 단일 소스로 관리
  - category별 권장 분포 범위를 warning 기준으로 포함
- `features/visualization/templates/` 모듈 추가
  - PPTX 슬라이드 수/순서/텍스트 추출
  - `PptxRenderer` 재사용 기반 슬라이드 JPG 생성 연계
  - Pillow 기반 grid `thumbnail.jpg` 생성
  - markitdown 기반 임시 텍스트 추출
  - Vision LLM 기반 `{category, description, best_for}` 초안 생성
  - category별 알파벳 id 자동 부여
  - `meta.json` 필수 필드, category Enum, slide_index 순서, PPTX 슬라이드 수, id 중복 검증
- 운영자/CI용 CLI 추가
  - `scripts/templates/build_meta.py`
  - `scripts/templates/validate_template.py`
- `template-tools` dependency group 추가
  - `markitdown[pptx]`, `pillow`
- Task 1.08 문서를 완료 상태로 갱신
- build/validate 성공 및 실패 케이스 테스트 추가

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`163 files already formatted`)
  - `uv run pytest -q` 통과 (`582 passed`)
  - 샘플 `docs/ppt-for-test.pptx`로 `build_meta.py` 실행 성공
    - 슬라이드 이미지 33개 생성
    - `thumbnail.jpg`, `slide_text.md`, `meta.json` 생성
  - 생성된 `meta.json` 검증에서 `slides[0].category=unknown`을 실패로 감지 확인

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 이 파이프라인은 오프라인 운영자/CI 전용이며 런타임 사용자 요청 경로에 LLM 호출을 추가하지 않습니다.
- 실제 운영 실행 환경에는 Python 의존성 외에 OS 패키지 `libreoffice-impress`, `poppler-utils`, `fonts-noto-cjk`가 필요합니다.
- Cloud Run 워커는 시작 시 OS 패키지를 설치하지 않고 Docker 이미지 빌드 단계에서 포함해야 합니다.
- `unknown` category는 운영자 검토가 필요한 초안 상태로, `validate_template.py`에서 배포 전 실패로 처리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PPTX에서 템플릿 메타 초안(슬라이드 이미지·썸네일·meta.json) 자동 생성 파이프라인 추가
  * 슬라이드 텍스트 추출 및 LLM 기반 슬라이드 초안(category/description/best_for) 생성
  * 그리드 썸네일 생성 및 출력 위치 제어 옵션 제공
  * 템플릿 카테고리 스키마(JSON) 추가

* **Validation**
  * 템플릿 디렉터리의 meta.json, PPTX, thumbnail 검증 도구 추가(경고/오류 리포트)

* **Tests**
  * 템플릿 등록/검증 통합 테스트 스위트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->