### PR TITLE
[Feat] 시각화 워커 관측성·모니터링 메트릭 [1.09]

### DIFF
--- a/apps/pptx-worker/app/main.py
+++ b/apps/pptx-worker/app/main.py
@@ -1,5 +1,5 @@
 """PPTX 워커 FastAPI 진입점."""
 
-from pptx_worker.main import app, create_app, get_health
+from pptx_worker.main import app, create_app, get_health, get_metrics
 
-__all__ = ["app", "create_app", "get_health"]
+__all__ = ["app", "create_app", "get_health", "get_metrics"]

--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -265,7 +265,7 @@ class VisualizationTaskService:
         self._storage_factory = storage_factory or GcsClient
         self._toolchain_factory = toolchain_factory or PptxToolchain.from_env
         self._editor_factory = editor_factory or SlideEditor
-        self._renderer_factory = renderer_factory or PptxRenderer
+        self._renderer_factory = renderer_factory or _default_renderer_factory
         self._slide_plan_generator = slide_plan_generator or LLMSlidePlanGenerator()
         self._content_fill_generator = content_fill_generator or LLMContentFillGenerator()
         self._qa_step_factory = qa_step_factory or _default_qa_step_factory
@@ -777,6 +777,13 @@ def _default_qa_step_factory(
         toolchain=toolchain,  # type: ignore[arg-type]
         renderer=renderer,  # type: ignore[arg-type]
     )
+
+
+def _default_renderer_factory() -> PptxRenderer:
+    """워커 런타임 lifetime 카운터를 공유하는 렌더러를 만든다."""
+    from pptx_worker.runtime import get_worker_runtime
+
+    return PptxRenderer(counter=get_worker_runtime().processed_counter)
 
 
 async def _close_client(client: MainClient) -> None:

--- a/apps/pptx-worker/features/visualization/pptx/soffice_render.py
+++ b/apps/pptx-worker/features/visualization/pptx/soffice_render.py
@@ -7,12 +7,20 @@ import shutil
 import signal
 import subprocess
 import tempfile
+import time
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
 from typing import Protocol
+
+from pptx_worker.metrics import (
+    FailureReason,
+    WorkerMetricsRegistry,
+    get_worker_metrics,
+    safe_directory_size,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -117,9 +125,11 @@ class PptxRenderer:
         self,
         options: RenderOptions | None = None,
         counter: ConversionCounter | None = None,
+        metrics: WorkerMetricsRegistry | None = None,
     ) -> None:
         self._options = options or RenderOptions()
         self._counter = counter or InMemoryConversionCounter()
+        self._metrics = metrics or get_worker_metrics()
         self._validate_options(self._options)
 
     @property
@@ -148,55 +158,73 @@ class PptxRenderer:
             ValueError: 입력 경로, 옵션, 페이지 번호가 유효하지 않은 경우.
             PptxRenderError: 외부 변환 명령이 실패한 경우.
         """
+        started_at = time.perf_counter()
+        soffice_rss_bytes: int | None = None
         source_path = self._validate_pptx_path(Path(pptx_path))
         final_output_dir = Path(output_dir)
         self._validate_page(page)
         final_output_dir.mkdir(parents=True, exist_ok=True)
 
-        workdir_obj = tempfile.TemporaryDirectory(
-            prefix="folioo_render_",
-            dir=str(self._options.tmp_root),
-        )
-        with workdir_obj as raw_workdir:
-            workdir = Path(raw_workdir)
-            input_pptx = workdir / "input.pptx"
-            pdf_dir = workdir / "pdf"
-            image_dir = workdir / "jpg"
-            pdf_dir.mkdir()
-            image_dir.mkdir()
-            shutil.copy2(source_path, input_pptx)
+        try:
+            workdir_obj = tempfile.TemporaryDirectory(
+                prefix="folioo_render_",
+                dir=str(self._options.tmp_root),
+            )
+            with workdir_obj as raw_workdir:
+                workdir = Path(raw_workdir)
+                input_pptx = workdir / "input.pptx"
+                pdf_dir = workdir / "pdf"
+                image_dir = workdir / "jpg"
+                pdf_dir.mkdir()
+                image_dir.mkdir()
+                shutil.copy2(source_path, input_pptx)
 
-            temp_pdf, attempts = self._convert_pptx_to_pdf(input_pptx, pdf_dir, workdir)
-            temp_images = self._render_pdf_to_jpg(temp_pdf, image_dir, page)
+                temp_pdf, attempts, soffice_rss_bytes = self._convert_pptx_to_pdf(
+                    input_pptx, pdf_dir, workdir
+                )
+                temp_images = self._render_pdf_to_jpg(temp_pdf, image_dir, page)
 
-            final_pdf = final_output_dir / f"{source_path.stem}{_PDF_SUFFIX}"
-            self._clean_owned_outputs(final_output_dir, final_pdf)
-            shutil.copy2(temp_pdf, final_pdf)
-            slides = self._copy_images(temp_images, final_output_dir)
+                final_pdf = final_output_dir / f"{source_path.stem}{_PDF_SUFFIX}"
+                self._clean_owned_outputs(final_output_dir, final_pdf)
+                shutil.copy2(temp_pdf, final_pdf)
+                slides = self._copy_images(temp_images, final_output_dir)
 
-        conversion_count = self._counter.increment()
-        return RenderResult(
-            pdf_path=final_pdf,
-            slides=tuple(slides),
-            soffice_attempts=attempts,
-            conversion_count=conversion_count,
-        )
+            duration_seconds = time.perf_counter() - started_at
+            conversion_count = self._counter.increment()
+            self._metrics.observe_soffice_conversion_success(
+                duration_seconds=duration_seconds,
+                rss_bytes=soffice_rss_bytes,
+            )
+            return RenderResult(
+                pdf_path=final_pdf,
+                slides=tuple(slides),
+                soffice_attempts=attempts,
+                conversion_count=conversion_count,
+            )
+        except Exception as exc:
+            if isinstance(exc, PptxRenderError):
+                self._metrics.record_soffice_conversion_failure(_classify_render_failure(exc))
+            raise
+        finally:
+            self._metrics.set_tmp_disk_bytes_used(safe_directory_size(self._options.tmp_root))
 
     def _convert_pptx_to_pdf(
         self,
         input_pptx: Path,
         pdf_dir: Path,
         workdir: Path,
-    ) -> tuple[Path, int]:
+    ) -> tuple[Path, int, int | None]:
         attempts = 0
         last_error: PptxRenderError | None = None
+        rss_bytes: int | None = None
         for attempt in range(1, 3):
             attempts = attempt
             profile_dir = workdir / f"soffice-profile-{uuid.uuid4().hex}"
             profile_dir.mkdir()
             command = self._soffice_command(input_pptx, pdf_dir, profile_dir)
             try:
-                self._run_command(command, "soffice")
+                run_result = self._run_command(command, "soffice")
+                rss_bytes = _max_optional_int(rss_bytes, run_result.rss_bytes)
             except _CommandTimeoutError as exc:
                 last_error = PptxRenderError(
                     f"soffice 변환이 {self._options.timeout_seconds:g}초를 초과했습니다."
@@ -213,7 +241,7 @@ class PptxRenderer:
             pdf_path = pdf_dir / f"{input_pptx.stem}{_PDF_SUFFIX}"
             if not pdf_path.is_file():
                 raise PptxRenderError(f"soffice PDF 산출물을 찾을 수 없습니다: {pdf_path}")
-            return pdf_path, attempts
+            return pdf_path, attempts, rss_bytes
 
         if last_error is not None:
             raise last_error
@@ -264,7 +292,7 @@ class PptxRenderer:
             str(input_pptx),
         ]
 
-    def _run_command(self, command: Sequence[str], command_name: str) -> None:
+    def _run_command(self, command: Sequence[str], command_name: str) -> "_CommandRunResult":
         process = subprocess.Popen(
             list(command),
             stdout=subprocess.PIPE,
@@ -284,11 +312,26 @@ class PptxRenderer:
                 stderr=stderr,
             ) from exc
 
+        rss_bytes = _max_child_rss_bytes()
+        if command_name == "soffice":
+            fallback_count = count_font_fallback_warnings(stdout, stderr)
+            self._metrics.record_font_fallback_warnings(fallback_count)
+
         if process.returncode != 0:
-            raise PptxRenderError(
-                f"{command_name} 명령이 실패했습니다. "
-                f"(exit={process.returncode}, stderr={stderr.strip()!r})"
+            raise _CommandFailedError(
+                command_name=command_name,
+                command=command,
+                returncode=process.returncode,
+                stdout=stdout,
+                stderr=stderr,
+                rss_bytes=rss_bytes,
             )
+        return _CommandRunResult(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=process.returncode,
+            rss_bytes=rss_bytes,
+        )
 
     def _clean_owned_outputs(self, output_dir: Path, pdf_path: Path) -> None:
         """이번 렌더러가 소유하는 이전 PDF/JPG 산출물을 제거한다."""
@@ -378,3 +421,99 @@ class _CommandTimeoutError(PptxRenderError):
 
     def __str__(self) -> str:
         return f"{self.command_name} 명령이 타임아웃되었습니다."
+
+
+@dataclass(frozen=True)
+class _CommandRunResult:
+    """외부 명령 실행 결과."""
+
+    stdout: str | None
+    stderr: str | None
+    returncode: int
+    rss_bytes: int | None
+
+
+@dataclass(frozen=True)
+class _CommandFailedError(PptxRenderError):
+    """외부 명령 non-zero 종료."""
+
+    command_name: str
+    command: Sequence[str]
+    returncode: int
+    stdout: str | None
+    stderr: str | None
+    rss_bytes: int | None
+
+    @property
+    def is_oom(self) -> bool:
+        """OOM kill 로 추정되는 종료인지 반환한다."""
+        stderr = (self.stderr or "").lower()
+        stdout = (self.stdout or "").lower()
+        logs = f"{stdout}\n{stderr}"
+        return (
+            self.returncode in {-signal.SIGKILL, 128 + signal.SIGKILL}
+            or "out of memory" in logs
+            or "oom" in logs
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"{self.command_name} 명령이 실패했습니다. "
+            f"(exit={self.returncode}, stderr={(self.stderr or '').strip()!r})"
+        )
+
+
+def _classify_render_failure(exc: BaseException) -> FailureReason:
+    """렌더링 예외 체인을 timeout/oom/other 로 분류한다."""
+    current: BaseException | None = exc
+    while current is not None:
+        if isinstance(current, _CommandTimeoutError):
+            return "timeout"
+        if isinstance(current, _CommandFailedError) and current.is_oom:
+            return "oom"
+        current = current.__cause__
+    return "other"
+
+
+def count_font_fallback_warnings(*logs: str | None) -> int:
+    """LibreOffice 로그에서 폰트 fallback/substitution 경고 수를 계산한다."""
+    patterns = (
+        re.compile(r"\bfont\b.*\bfallback\b", re.IGNORECASE),
+        re.compile(r"\bfallback\b.*\bfont\b", re.IGNORECASE),
+        re.compile(r"\bfont\b.*\bsubstitut", re.IGNORECASE),
+        re.compile(r"\bsubstitut.*\bfont\b", re.IGNORECASE),
+        re.compile(r"\bmissing\b.*\bfont\b", re.IGNORECASE),
+        re.compile(r"\bfont\b.*\bnot found\b", re.IGNORECASE),
+    )
+    count = 0
+    for log in logs:
+        if not log:
+            continue
+        for line in log.splitlines():
+            if any(pattern.search(line) for pattern in patterns):
+                count += 1
+    return count
+
+
+def _max_optional_int(current: int | None, value: int | None) -> int | None:
+    if value is None:
+        return current
+    if current is None:
+        return value
+    return max(current, value)
+
+
+def _max_child_rss_bytes() -> int | None:
+    """종료된 child process 의 ru_maxrss 를 bytes 로 반환한다."""
+    try:
+        import resource
+    except ImportError:
+        return None
+
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    max_rss = int(usage.ru_maxrss)
+    if max_rss < 0:
+        return None
+    if os.uname().sysname == "Darwin":
+        return max_rss
+    return max_rss * 1024

--- a/apps/pptx-worker/features/visualization/pptx/soffice_render.py
+++ b/apps/pptx-worker/features/visualization/pptx/soffice_render.py
@@ -6,16 +6,18 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from threading import Lock
+from threading import Event, Lock, Thread
 from typing import Protocol
 
 from pptx_worker.metrics import (
+    WORKER_TMP_ROOT,
     FailureReason,
     WorkerMetricsRegistry,
     get_worker_metrics,
@@ -28,6 +30,14 @@ DEFAULT_MAX_CONVERSIONS_BEFORE_RECYCLE = 20
 _PPTX_SUFFIX = ".pptx"
 _PDF_SUFFIX = ".pdf"
 _JPG_SUFFIX = ".jpg"
+_FONT_FALLBACK_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bfont\b.*\bfallback\b", re.IGNORECASE),
+    re.compile(r"\bfallback\b.*\bfont\b", re.IGNORECASE),
+    re.compile(r"\bfont\b.*\bsubstitut", re.IGNORECASE),
+    re.compile(r"\bsubstitut.*\bfont\b", re.IGNORECASE),
+    re.compile(r"\bmissing\b.*\bfont\b", re.IGNORECASE),
+    re.compile(r"\bfont\b.*\bnot found\b", re.IGNORECASE),
+)
 
 
 class ConversionCounter(Protocol):
@@ -88,7 +98,7 @@ class RenderOptions:
     pdftoppm_bin: str = "pdftoppm"
     timeout_seconds: float = 60.0
     dpi: int = 150
-    tmp_root: Path = Path("/tmp")
+    tmp_root: Path = WORKER_TMP_ROOT
 
 
 @dataclass(frozen=True)
@@ -158,8 +168,8 @@ class PptxRenderer:
             ValueError: 입력 경로, 옵션, 페이지 번호가 유효하지 않은 경우.
             PptxRenderError: 외부 변환 명령이 실패한 경우.
         """
-        started_at = time.perf_counter()
         soffice_rss_bytes: int | None = None
+        soffice_duration_seconds = 0.0
         source_path = self._validate_pptx_path(Path(pptx_path))
         final_output_dir = Path(output_dir)
         self._validate_page(page)
@@ -179,9 +189,12 @@ class PptxRenderer:
                 image_dir.mkdir()
                 shutil.copy2(source_path, input_pptx)
 
-                temp_pdf, attempts, soffice_rss_bytes = self._convert_pptx_to_pdf(
-                    input_pptx, pdf_dir, workdir
-                )
+                (
+                    temp_pdf,
+                    attempts,
+                    soffice_rss_bytes,
+                    soffice_duration_seconds,
+                ) = self._convert_pptx_to_pdf(input_pptx, pdf_dir, workdir)
                 temp_images = self._render_pdf_to_jpg(temp_pdf, image_dir, page)
 
                 final_pdf = final_output_dir / f"{source_path.stem}{_PDF_SUFFIX}"
@@ -189,10 +202,9 @@ class PptxRenderer:
                 shutil.copy2(temp_pdf, final_pdf)
                 slides = self._copy_images(temp_images, final_output_dir)
 
-            duration_seconds = time.perf_counter() - started_at
             conversion_count = self._counter.increment()
             self._metrics.observe_soffice_conversion_success(
-                duration_seconds=duration_seconds,
+                duration_seconds=soffice_duration_seconds,
                 rss_bytes=soffice_rss_bytes,
             )
             return RenderResult(
@@ -202,8 +214,9 @@ class PptxRenderer:
                 conversion_count=conversion_count,
             )
         except Exception as exc:
-            if isinstance(exc, PptxRenderError):
-                self._metrics.record_soffice_conversion_failure(_classify_render_failure(exc))
+            failure_reason = _classify_render_exception(exc)
+            if failure_reason is not None:
+                self._metrics.record_soffice_conversion_failure(failure_reason)
             raise
         finally:
             self._metrics.set_tmp_disk_bytes_used(safe_directory_size(self._options.tmp_root))
@@ -213,7 +226,8 @@ class PptxRenderer:
         input_pptx: Path,
         pdf_dir: Path,
         workdir: Path,
-    ) -> tuple[Path, int, int | None]:
+    ) -> tuple[Path, int, int | None, float]:
+        started_at = time.perf_counter()
         attempts = 0
         last_error: PptxRenderError | None = None
         rss_bytes: int | None = None
@@ -241,7 +255,7 @@ class PptxRenderer:
             pdf_path = pdf_dir / f"{input_pptx.stem}{_PDF_SUFFIX}"
             if not pdf_path.is_file():
                 raise PptxRenderError(f"soffice PDF 산출물을 찾을 수 없습니다: {pdf_path}")
-            return pdf_path, attempts, rss_bytes
+            return pdf_path, attempts, rss_bytes, time.perf_counter() - started_at
 
         if last_error is not None:
             raise last_error
@@ -300,19 +314,23 @@ class PptxRenderer:
             text=True,
             **self._process_group_kwargs(),
         )
+        rss_sampler = _ProcessRssSampler(process.pid)
+        rss_sampler.start()
         try:
             stdout, stderr = process.communicate(timeout=self._options.timeout_seconds)
         except subprocess.TimeoutExpired as exc:
             self._kill_process_group(process)
             stdout, stderr = process.communicate()
+            rss_bytes = _rss_with_fallback(rss_sampler)
             raise _CommandTimeoutError(
                 command_name=command_name,
                 command=command,
                 stdout=stdout,
                 stderr=stderr,
+                rss_bytes=rss_bytes,
             ) from exc
 
-        rss_bytes = _max_child_rss_bytes()
+        rss_bytes = _rss_with_fallback(rss_sampler)
         if command_name == "soffice":
             fallback_count = count_font_fallback_warnings(stdout, stderr)
             self._metrics.record_font_fallback_warnings(fallback_count)
@@ -418,6 +436,10 @@ class _CommandTimeoutError(PptxRenderError):
     command: Sequence[str]
     stdout: str | None
     stderr: str | None
+    rss_bytes: int | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "args", (str(self),))
 
     def __str__(self) -> str:
         return f"{self.command_name} 명령이 타임아웃되었습니다."
@@ -444,6 +466,9 @@ class _CommandFailedError(PptxRenderError):
     stderr: str | None
     rss_bytes: int | None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "args", (str(self),))
+
     @property
     def is_oom(self) -> bool:
         """OOM kill 로 추정되는 종료인지 반환한다."""
@@ -463,6 +488,17 @@ class _CommandFailedError(PptxRenderError):
         )
 
 
+def _classify_render_exception(exc: BaseException) -> FailureReason | None:
+    """렌더링 단계에서 메트릭으로 집계할 실패 reason 을 반환한다."""
+    if isinstance(exc, PptxRenderError):
+        return _classify_render_failure(exc)
+    if isinstance(exc, MemoryError):
+        return "oom"
+    if isinstance(exc, OSError):
+        return "other"
+    return None
+
+
 def _classify_render_failure(exc: BaseException) -> FailureReason:
     """렌더링 예외 체인을 timeout/oom/other 로 분류한다."""
     current: BaseException | None = exc
@@ -477,20 +513,12 @@ def _classify_render_failure(exc: BaseException) -> FailureReason:
 
 def count_font_fallback_warnings(*logs: str | None) -> int:
     """LibreOffice 로그에서 폰트 fallback/substitution 경고 수를 계산한다."""
-    patterns = (
-        re.compile(r"\bfont\b.*\bfallback\b", re.IGNORECASE),
-        re.compile(r"\bfallback\b.*\bfont\b", re.IGNORECASE),
-        re.compile(r"\bfont\b.*\bsubstitut", re.IGNORECASE),
-        re.compile(r"\bsubstitut.*\bfont\b", re.IGNORECASE),
-        re.compile(r"\bmissing\b.*\bfont\b", re.IGNORECASE),
-        re.compile(r"\bfont\b.*\bnot found\b", re.IGNORECASE),
-    )
     count = 0
     for log in logs:
         if not log:
             continue
         for line in log.splitlines():
-            if any(pattern.search(line) for pattern in patterns):
+            if any(pattern.search(line) for pattern in _FONT_FALLBACK_PATTERNS):
                 count += 1
     return count
 
@@ -504,7 +532,12 @@ def _max_optional_int(current: int | None, value: int | None) -> int | None:
 
 
 def _max_child_rss_bytes() -> int | None:
-    """종료된 child process 의 ru_maxrss 를 bytes 로 반환한다."""
+    """종료된 모든 child process 의 ru_maxrss 를 fallback 용도로 반환한다.
+
+    Linux 에서는 기본적으로 /proc/<pid>/status 샘플링을 사용한다. 이 함수는
+    /proc 을 사용할 수 없는 환경에서만 쓰는 best-effort fallback 이며,
+    단일 child 가 아니라 현재 프로세스 생애 전체 child peak 일 수 있다.
+    """
     try:
         import resource
     except ImportError:
@@ -514,6 +547,81 @@ def _max_child_rss_bytes() -> int | None:
     max_rss = int(usage.ru_maxrss)
     if max_rss < 0:
         return None
-    if os.uname().sysname == "Darwin":
+    if sys.platform == "darwin":
         return max_rss
     return max_rss * 1024
+
+
+def _rss_with_fallback(sampler: "_ProcessRssSampler") -> int | None:
+    rss_bytes = sampler.stop()
+    if rss_bytes is not None:
+        return rss_bytes
+    return _max_child_rss_bytes()
+
+
+class _ProcessRssSampler:
+    """Linux /proc status 에서 단일 child process 의 peak RSS 를 샘플링한다."""
+
+    def __init__(self, pid: int, *, interval_seconds: float = 0.01) -> None:
+        self._status_path = Path(f"/proc/{pid}/status")
+        self._interval_seconds = interval_seconds
+        self._stop_event = Event()
+        self._thread: Thread | None = None
+        self._peak_bytes: int | None = None
+        self._lock = Lock()
+
+    def start(self) -> None:
+        """샘플링 스레드를 시작한다. /proc 이 없으면 no-op."""
+        if not self._status_path.is_file():
+            return
+        self._sample_once()
+        self._thread = Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> int | None:
+        """샘플링을 멈추고 관측된 peak RSS 를 반환한다."""
+        self._sample_once()
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=0.2)
+            self._thread = None
+        with self._lock:
+            return self._peak_bytes
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._interval_seconds):
+            self._sample_once()
+
+    def _sample_once(self) -> None:
+        rss_bytes = _read_linux_proc_status_peak_rss_bytes(self._status_path)
+        if rss_bytes is None:
+            return
+        with self._lock:
+            if self._peak_bytes is None or rss_bytes > self._peak_bytes:
+                self._peak_bytes = rss_bytes
+
+
+def _read_linux_proc_status_peak_rss_bytes(status_path: Path) -> int | None:
+    """Linux /proc/<pid>/status 에서 VmHWM 또는 VmRSS 를 bytes 로 읽는다."""
+    try:
+        lines = status_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+    fallback_rss: int | None = None
+    for line in lines:
+        if line.startswith("VmHWM:"):
+            return _parse_proc_status_kb_line(line)
+        if line.startswith("VmRSS:"):
+            fallback_rss = _parse_proc_status_kb_line(line)
+    return fallback_rss
+
+
+def _parse_proc_status_kb_line(line: str) -> int | None:
+    parts = line.split()
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[1]) * 1024
+    except ValueError:
+        return None

--- a/apps/pptx-worker/features/visualization/storage/gcs_client.py
+++ b/apps/pptx-worker/features/visualization/storage/gcs_client.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from google.cloud import storage
-from pptx_worker.metrics import get_worker_metrics, safe_directory_size
+from pptx_worker.metrics import WORKER_TMP_ROOT, get_worker_metrics, safe_directory_size
 
 logger = logging.getLogger(__name__)
 
@@ -262,10 +262,11 @@ def job_workdir(job_id: str) -> Generator[Path, None, None]:
         생성된 작업 디렉터리 경로.
     """
     safe_job_id = _validate_identifier(job_id, "job_id")
-    workdir = Path(tempfile.mkdtemp(prefix=f"job_{safe_job_id}_", dir="/tmp"))
+    WORKER_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    workdir = Path(tempfile.mkdtemp(prefix=f"job_{safe_job_id}_", dir=str(WORKER_TMP_ROOT)))
     try:
         yield workdir
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
-        get_worker_metrics().set_tmp_disk_bytes_used(safe_directory_size(Path("/tmp")))
+        get_worker_metrics().set_tmp_disk_bytes_used(safe_directory_size(WORKER_TMP_ROOT))
         logger.debug("cleaned up workdir %s", workdir)

--- a/apps/pptx-worker/features/visualization/storage/gcs_client.py
+++ b/apps/pptx-worker/features/visualization/storage/gcs_client.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from google.cloud import storage
+from pptx_worker.metrics import get_worker_metrics, safe_directory_size
 
 logger = logging.getLogger(__name__)
 
@@ -266,4 +267,5 @@ def job_workdir(job_id: str) -> Generator[Path, None, None]:
         yield workdir
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
+        get_worker_metrics().set_tmp_disk_bytes_used(safe_directory_size(Path("/tmp")))
         logger.debug("cleaned up workdir %s", workdir)

--- a/apps/pptx-worker/pptx_worker/main.py
+++ b/apps/pptx-worker/pptx_worker/main.py
@@ -3,8 +3,10 @@
 from typing import Any
 
 from fastapi import FastAPI
+from starlette.responses import PlainTextResponse
 
 from pptx_worker.api import router as api_router
+from pptx_worker.metrics import PROMETHEUS_CONTENT_TYPE, get_worker_metrics
 from pptx_worker.runtime import get_worker_runtime
 
 APP_VERSION = "0.1.0"
@@ -16,6 +18,17 @@ async def get_health() -> dict[str, Any]:
     health = await runtime.snapshot()
     health["version"] = APP_VERSION
     return health
+
+
+async def get_metrics() -> str:
+    """Prometheus text exposition 메트릭을 생성한다."""
+    runtime = get_worker_runtime()
+    snapshot = await runtime.snapshot()
+    return get_worker_metrics().render_prometheus(
+        worker_jobs_processed_total=int(snapshot["lifetime_processed"]),
+        worker_ready_for_recycle=bool(snapshot["ready_for_recycle"]),
+        worker_concurrent_active=int(snapshot["concurrent_active"]),
+    )
 
 
 def create_app() -> FastAPI:
@@ -35,6 +48,18 @@ def create_app() -> FastAPI:
     async def health() -> dict[str, Any]:
         return await get_health()
 
+    @app.get(
+        "/metrics",
+        response_class=PlainTextResponse,
+        status_code=200,
+        summary="워커 Prometheus 메트릭",
+    )
+    async def metrics() -> PlainTextResponse:
+        return PlainTextResponse(
+            await get_metrics(),
+            media_type=PROMETHEUS_CONTENT_TYPE,
+        )
+
     app.include_router(api_router)
     return app
 
@@ -42,4 +67,4 @@ def create_app() -> FastAPI:
 app = create_app()
 
 
-__all__ = ["app", "create_app", "get_health"]
+__all__ = ["app", "create_app", "get_health", "get_metrics"]

--- a/apps/pptx-worker/pptx_worker/metrics.py
+++ b/apps/pptx-worker/pptx_worker/metrics.py
@@ -1,0 +1,225 @@
+"""PPTX 워커 운영 메트릭."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import Literal
+
+FailureReason = Literal["timeout", "oom", "other"]
+
+FAILURE_REASONS: tuple[FailureReason, ...] = ("timeout", "oom", "other")
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+
+@dataclass(frozen=True, slots=True)
+class MetricsSnapshot:
+    """메트릭 테스트와 렌더링에 쓰는 현재 값 스냅샷."""
+
+    soffice_rss_bytes: int
+    soffice_conversion_duration_seconds: tuple[float, ...]
+    soffice_conversion_failures_total: dict[FailureReason, int]
+    worker_oom_kill_total: int
+    tmp_disk_bytes_used: int
+    font_fallback_warnings_total: int
+
+    def quantile(self, quantile: float) -> float:
+        """저장된 duration 에서 nearest-rank 분위수를 계산한다."""
+        if not self.soffice_conversion_duration_seconds:
+            return 0.0
+        values = sorted(self.soffice_conversion_duration_seconds)
+        index = max(0, math.ceil(quantile * len(values)) - 1)
+        return values[index]
+
+
+class WorkerMetricsRegistry:
+    """단일 워커 프로세스에서 쓰는 thread-safe 메트릭 저장소."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._soffice_rss_bytes = 0
+        self._soffice_conversion_durations: list[float] = []
+        self._soffice_conversion_failures = dict.fromkeys(FAILURE_REASONS, 0)
+        self._worker_oom_kill_total = 0
+        self._tmp_disk_bytes_used = 0
+        self._font_fallback_warnings_total = 0
+
+    def observe_soffice_conversion_success(
+        self,
+        *,
+        duration_seconds: float,
+        rss_bytes: int | None,
+    ) -> None:
+        """성공한 soffice 변환의 duration 과 RSS 를 기록한다."""
+        with self._lock:
+            self._soffice_conversion_durations.append(max(0.0, duration_seconds))
+            if rss_bytes is not None and rss_bytes >= 0:
+                self._soffice_rss_bytes = int(rss_bytes)
+
+    def record_soffice_conversion_failure(self, reason: str) -> FailureReason:
+        """soffice 변환 실패를 안정적인 reason 라벨로 기록한다."""
+        normalized = normalize_failure_reason(reason)
+        with self._lock:
+            self._soffice_conversion_failures[normalized] += 1
+        if normalized == "oom":
+            self.record_worker_oom_kill()
+        return normalized
+
+    def record_worker_oom_kill(self, count: int = 1) -> None:
+        """OOM kill 카운터를 증가시킨다."""
+        if count <= 0:
+            return
+        with self._lock:
+            self._worker_oom_kill_total += count
+
+    def record_font_fallback_warnings(self, count: int = 1) -> None:
+        """폰트 fallback 경고 카운터를 증가시킨다."""
+        if count <= 0:
+            return
+        with self._lock:
+            self._font_fallback_warnings_total += count
+
+    def set_tmp_disk_bytes_used(self, value: int) -> None:
+        """관측 시점의 임시 디스크 사용량 gauge 를 설정한다."""
+        with self._lock:
+            self._tmp_disk_bytes_used = max(0, int(value))
+
+    def snapshot(self) -> MetricsSnapshot:
+        """현재 메트릭 값을 복사해 반환한다."""
+        with self._lock:
+            return MetricsSnapshot(
+                soffice_rss_bytes=self._soffice_rss_bytes,
+                soffice_conversion_duration_seconds=tuple(self._soffice_conversion_durations),
+                soffice_conversion_failures_total=dict(self._soffice_conversion_failures),
+                worker_oom_kill_total=self._worker_oom_kill_total,
+                tmp_disk_bytes_used=self._tmp_disk_bytes_used,
+                font_fallback_warnings_total=self._font_fallback_warnings_total,
+            )
+
+    def render_prometheus(
+        self,
+        *,
+        worker_jobs_processed_total: int,
+        worker_ready_for_recycle: bool,
+        worker_concurrent_active: int,
+    ) -> str:
+        """Prometheus text exposition 포맷으로 메트릭을 렌더링한다."""
+        snapshot = self.snapshot()
+        lines = [
+            "# HELP soffice_rss_bytes Last observed LibreOffice child peak RSS in bytes.",
+            "# TYPE soffice_rss_bytes gauge",
+            f"soffice_rss_bytes {snapshot.soffice_rss_bytes}",
+            "# HELP soffice_conversion_duration_seconds LibreOffice conversion duration summary.",
+            "# TYPE soffice_conversion_duration_seconds summary",
+        ]
+        for quantile in (0.5, 0.95, 0.99):
+            lines.append(
+                "soffice_conversion_duration_seconds"
+                f'{{quantile="{quantile:g}"}} {snapshot.quantile(quantile):.6g}'
+            )
+        duration_sum = sum(snapshot.soffice_conversion_duration_seconds)
+        lines.extend(
+            [
+                f"soffice_conversion_duration_seconds_sum {duration_sum:.6g}",
+                "soffice_conversion_duration_seconds_count "
+                f"{len(snapshot.soffice_conversion_duration_seconds)}",
+                "# HELP soffice_conversion_failures_total LibreOffice conversion failures by reason.",
+                "# TYPE soffice_conversion_failures_total counter",
+            ]
+        )
+        for reason in FAILURE_REASONS:
+            lines.append(
+                f'soffice_conversion_failures_total{{reason="{reason}"}} '
+                f"{snapshot.soffice_conversion_failures_total[reason]}"
+            )
+        lines.extend(
+            [
+                "# HELP worker_oom_kill_total LibreOffice or worker OOM kill detections.",
+                "# TYPE worker_oom_kill_total counter",
+                f"worker_oom_kill_total {snapshot.worker_oom_kill_total}",
+                "# HELP worker_jobs_processed_total Worker lifetime processed conversion count.",
+                "# TYPE worker_jobs_processed_total counter",
+                f"worker_jobs_processed_total {max(0, int(worker_jobs_processed_total))}",
+                "# HELP worker_ready_for_recycle Worker recycle readiness signal.",
+                "# TYPE worker_ready_for_recycle gauge",
+                f"worker_ready_for_recycle {1 if worker_ready_for_recycle else 0}",
+                "# HELP worker_concurrent_active Active Cloud Tasks requests in this worker.",
+                "# TYPE worker_concurrent_active gauge",
+                f"worker_concurrent_active {max(0, int(worker_concurrent_active))}",
+                "# HELP tmp_disk_bytes_used Observed bytes used under the worker temp root.",
+                "# TYPE tmp_disk_bytes_used gauge",
+                f"tmp_disk_bytes_used {snapshot.tmp_disk_bytes_used}",
+                "# HELP font_fallback_warnings_total LibreOffice font fallback warnings.",
+                "# TYPE font_fallback_warnings_total counter",
+                f"font_fallback_warnings_total {snapshot.font_fallback_warnings_total}",
+            ]
+        )
+        return "\n".join(lines) + "\n"
+
+
+def normalize_failure_reason(reason: str) -> FailureReason:
+    """외부 예외/로그를 안정적인 실패 reason 라벨로 정규화한다."""
+    normalized = reason.lower().strip()
+    if normalized in FAILURE_REASONS:
+        return normalized  # type: ignore[return-value]
+    if "timeout" in normalized or "timed out" in normalized:
+        return "timeout"
+    if "oom" in normalized or "out of memory" in normalized or "sigkill" in normalized:
+        return "oom"
+    return "other"
+
+
+def safe_directory_size(path: Path) -> int:
+    """디렉터리 크기를 best-effort 로 계산한다."""
+    if not path.exists():
+        return 0
+    if path.is_file():
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0
+
+    total = 0
+    for root, _, filenames in os.walk(path):
+        for filename in filenames:
+            file_path = Path(root) / filename
+            try:
+                total += file_path.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+_metrics: WorkerMetricsRegistry | None = None
+
+
+def get_worker_metrics() -> WorkerMetricsRegistry:
+    """워커 메트릭 싱글톤 반환."""
+    global _metrics
+
+    if _metrics is None:
+        _metrics = WorkerMetricsRegistry()
+    return _metrics
+
+
+def set_worker_metrics(metrics: WorkerMetricsRegistry | None) -> None:
+    """테스트용 워커 메트릭 저장소 교체."""
+    global _metrics
+
+    _metrics = metrics
+
+
+__all__ = [
+    "FAILURE_REASONS",
+    "PROMETHEUS_CONTENT_TYPE",
+    "FailureReason",
+    "MetricsSnapshot",
+    "WorkerMetricsRegistry",
+    "get_worker_metrics",
+    "normalize_failure_reason",
+    "safe_directory_size",
+    "set_worker_metrics",
+]

--- a/apps/pptx-worker/pptx_worker/metrics.py
+++ b/apps/pptx-worker/pptx_worker/metrics.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import math
 import os
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from threading import RLock
+from threading import Lock, RLock
 from typing import Literal
 
 FailureReason = Literal["timeout", "oom", "other"]
 
+DEFAULT_DURATION_SAMPLE_LIMIT = 512
 FAILURE_REASONS: tuple[FailureReason, ...] = ("timeout", "oom", "other")
 PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+WORKER_TMP_ROOT = Path(os.getenv("TMPDIR", "/tmp")).resolve()
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,10 +41,12 @@ class MetricsSnapshot:
 class WorkerMetricsRegistry:
     """단일 워커 프로세스에서 쓰는 thread-safe 메트릭 저장소."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, max_duration_samples: int = DEFAULT_DURATION_SAMPLE_LIMIT) -> None:
+        if max_duration_samples <= 0:
+            raise ValueError("max_duration_samples는 1 이상이어야 합니다.")
         self._lock = RLock()
         self._soffice_rss_bytes = 0
-        self._soffice_conversion_durations: list[float] = []
+        self._soffice_conversion_durations: deque[float] = deque(maxlen=max_duration_samples)
         self._soffice_conversion_failures = dict.fromkeys(FAILURE_REASONS, 0)
         self._worker_oom_kill_total = 0
         self._tmp_disk_bytes_used = 0
@@ -109,7 +114,7 @@ class WorkerMetricsRegistry:
         """Prometheus text exposition 포맷으로 메트릭을 렌더링한다."""
         snapshot = self.snapshot()
         lines = [
-            "# HELP soffice_rss_bytes Last observed LibreOffice child peak RSS in bytes.",
+            "# HELP soffice_rss_bytes Last observed LibreOffice process peak RSS in bytes.",
             "# TYPE soffice_rss_bytes gauge",
             f"soffice_rss_bytes {snapshot.soffice_rss_bytes}",
             "# HELP soffice_conversion_duration_seconds LibreOffice conversion duration summary.",
@@ -126,7 +131,7 @@ class WorkerMetricsRegistry:
                 f"soffice_conversion_duration_seconds_sum {duration_sum:.6g}",
                 "soffice_conversion_duration_seconds_count "
                 f"{len(snapshot.soffice_conversion_duration_seconds)}",
-                "# HELP soffice_conversion_failures_total LibreOffice conversion failures by reason.",
+                "# HELP soffice_conversion_failures_total PPTX render conversion failures by reason.",
                 "# TYPE soffice_conversion_failures_total counter",
             ]
         )
@@ -194,6 +199,7 @@ def safe_directory_size(path: Path) -> int:
 
 
 _metrics: WorkerMetricsRegistry | None = None
+_metrics_lock = Lock()
 
 
 def get_worker_metrics() -> WorkerMetricsRegistry:
@@ -201,7 +207,9 @@ def get_worker_metrics() -> WorkerMetricsRegistry:
     global _metrics
 
     if _metrics is None:
-        _metrics = WorkerMetricsRegistry()
+        with _metrics_lock:
+            if _metrics is None:
+                _metrics = WorkerMetricsRegistry()
     return _metrics
 
 
@@ -209,12 +217,15 @@ def set_worker_metrics(metrics: WorkerMetricsRegistry | None) -> None:
     """테스트용 워커 메트릭 저장소 교체."""
     global _metrics
 
-    _metrics = metrics
+    with _metrics_lock:
+        _metrics = metrics
 
 
 __all__ = [
     "FAILURE_REASONS",
+    "DEFAULT_DURATION_SAMPLE_LIMIT",
     "PROMETHEUS_CONTENT_TYPE",
+    "WORKER_TMP_ROOT",
     "FailureReason",
     "MetricsSnapshot",
     "WorkerMetricsRegistry",

--- a/docs/architecture/pptx-gen-plan-v6.md
+++ b/docs/architecture/pptx-gen-plan-v6.md
@@ -2089,6 +2089,18 @@ GET    {WORKER_URL}/health
          "lifetime_processed": 42,
          "ready_for_recycle": false
        }
+
+GET    {WORKER_URL}/metrics
+       Response: Prometheus text exposition
+       주요 지표:
+         - soffice_conversion_duration_seconds{quantile="0.5|0.95|0.99"}
+         - soffice_conversion_failures_total{reason="timeout|oom|other"}
+         - soffice_rss_bytes
+         - worker_oom_kill_total
+         - worker_jobs_processed_total  # /health.lifetime_processed 와 동일 소스
+         - worker_ready_for_recycle     # /health.ready_for_recycle 과 동일 소스
+         - tmp_disk_bytes_used
+         - font_fallback_warnings_total
 ```
 
 **핸들러 위치 권고 (시각화 워커 코드베이스):**

--- a/docs/architecture/worker-runtime.md
+++ b/docs/architecture/worker-runtime.md
@@ -45,6 +45,13 @@ soffice 실행 + LLM I/O + 디스크 작업이 핵심 워크로드다.
 - 메인 백엔드의 큐 백로그 메트릭 기반 알람 (Cloud Tasks `oldest_age` > 5분 → 경고)
 - 최대 워커 인스턴스 수는 LLM API rate limit 고려해서 설정 (예: max 20)
 
+**운영 관측성:**
+- 워커는 `/metrics` 에 Prometheus text exposition 형식으로 soffice duration/RSS,
+  timeout/OOM/other 실패, tmp 디스크 사용량, 폰트 fallback, lifetime 처리 수를 노출한다.
+- `worker_jobs_processed_total` 은 `/health.lifetime_processed` 와 같은 카운터를 읽고,
+  `worker_ready_for_recycle` 은 `/health.ready_for_recycle` 과 같은 기준으로 0/1 gauge 를 노출한다.
+- 알람 기준과 PromQL 예시는 `worker-spec.md` §8.3.7 에 둔다.
+
 > **코드 실행 모델 / 강격리 샌드박스(Daytona 등)는 본 MVP 범위 밖이다 — §17 참조.**
 > 현재 설계는 LLM 이 데이터(`fills`)를 내고 결정적 코드가 적용하는 방식이라 임의 코드 실행이
 > 없으므로, Cloud Run 의 프로세스 격리 + 컨테이너 하드닝으로 충분하다. 원조 Anthropic PPTX

--- a/docs/architecture/worker-spec.md
+++ b/docs/architecture/worker-spec.md
@@ -184,10 +184,31 @@ RUN pip3 install defusedxml lxml pillow google-cloud-storage google-cloud-tasks 
 | `tmp_disk_bytes_used` | 임시 파일 누수 감지 |
 | `font_fallback_warnings_total` | 폰트 누락 감지 (새 템플릿 추가 시) |
 
+워커는 `GET /metrics` 에 Prometheus text exposition 형식으로 위 지표를 노출한다.
+서비스 전체가 Cloud Run require-auth 대상이므로, 외부 스크레이퍼는 워커 호출 권한이 있는
+서비스 계정으로 OIDC 토큰을 붙여 호출한다. `soffice_conversion_failures_total{reason}` 의
+라벨 값은 `timeout`, `oom`, `other` 로 고정한다(`other` 는 기타 실패).
+`worker_jobs_processed_total` 은 `/health.lifetime_processed` 와 같은 런타임 카운터를 읽고,
+`worker_ready_for_recycle` 은 `/health.ready_for_recycle` 과 같은 기준으로 0/1 gauge 를 노출한다.
+
 **알람 기준 예시:**
-- `P95 conversion_duration > 30s` 5분 지속 → 경고
-- `worker_oom_kill_total` 증가 → 즉시 알람 (메모리 한도 부족)
-- `font_fallback_warnings_total` 증가 → 폰트 누락 (디자이너 알림)
+- 렌더링 지연: `max_over_time(soffice_conversion_duration_seconds{quantile="0.95"}[5m]) > 30`
+  → 5분 지속 시 경고. 워커 용량 부족, 템플릿 고밀도화, LibreOffice 회귀를 확인한다.
+- OOM: `increase(worker_oom_kill_total[1m]) > 0` 또는
+  `increase(soffice_conversion_failures_total{reason="oom"}[1m]) > 0`
+  → 즉시 알람. Cloud Run 메모리 한도와 템플릿 이미지 용량을 확인한다.
+- timeout/기타 실패 증가:
+  `increase(soffice_conversion_failures_total{reason=~"timeout|other"}[5m]) > 0`
+  → 경고. 변환 timeout, 손상된 PPTX, pdftoppm 실패를 확인한다.
+- 폰트 fallback:
+  `increase(font_fallback_warnings_total[5m]) > 0`
+  → 폰트 누락 알림. 템플릿 사용 폰트와 컨테이너 설치 폰트를 대조한다.
+- 임시 디스크:
+  `tmp_disk_bytes_used > 800 * 1024 * 1024`
+  → 경고. `/tmp` cleanup 누수 또는 과도한 렌더 산출물을 확인한다.
+- 재활용 신호:
+  `worker_ready_for_recycle == 1`
+  → 정보성 지표. `worker_jobs_processed_total` 이 재활용 임계값에 도달한 정상 신호다.
 
 #### 8.3.8 MVP 추천 사양 요약
 

--- a/docs/architecture/worker-spec.md
+++ b/docs/architecture/worker-spec.md
@@ -188,6 +188,8 @@ RUN pip3 install defusedxml lxml pillow google-cloud-storage google-cloud-tasks 
 서비스 전체가 Cloud Run require-auth 대상이므로, 외부 스크레이퍼는 워커 호출 권한이 있는
 서비스 계정으로 OIDC 토큰을 붙여 호출한다. `soffice_conversion_failures_total{reason}` 의
 라벨 값은 `timeout`, `oom`, `other` 로 고정한다(`other` 는 기타 실패).
+이 failure counter 는 기존 spec 메트릭명을 유지하되, 실제 집계 범위는 soffice 래퍼의 렌더
+수명주기이므로 `pdftoppm` 실패도 `other` 로 포함될 수 있다.
 `worker_jobs_processed_total` 은 `/health.lifetime_processed` 와 같은 런타임 카운터를 읽고,
 `worker_ready_for_recycle` 은 `/health.ready_for_recycle` 과 같은 기준으로 0/1 gauge 를 노출한다.
 

--- a/specs/phase-1/09-worker-observability-metrics.md
+++ b/specs/phase-1/09-worker-observability-metrics.md
@@ -4,13 +4,13 @@
 시각화 워커의 soffice 변환 비용·메모리 누수·폰트 누락을 조기에 감지하기 위해 운영 메트릭을 계측하고 알람 기준을 정의해, 인스턴스 재활용과 용량 결정을 데이터로 뒷받침한다.
 
 ## Requirements
-- `soffice_rss_bytes`, `soffice_conversion_duration_seconds{quantile}`(P50/P95/P99), `soffice_conversion_failures_total{reason=timeout|oom|기타}`, `worker_oom_kill_total`, `worker_jobs_processed_total`, `tmp_disk_bytes_used`, `font_fallback_warnings_total` 메트릭을 노출한다.
+- `soffice_rss_bytes`, `soffice_conversion_duration_seconds{quantile}`(P50/P95/P99), `soffice_conversion_failures_total{reason=timeout|oom|other}`, `worker_oom_kill_total`, `worker_jobs_processed_total`, `tmp_disk_bytes_used`, `font_fallback_warnings_total` 메트릭을 노출한다(`other` 는 기타 실패).
 - 알람 기준을 정의한다: P95 `conversion_duration` > 30s 가 5분 지속되면 경고, `worker_oom_kill_total` 증가 시 즉시 알람, `font_fallback_warnings_total` 증가 시 폰트 누락으로 보고 디자이너에게 알린다.
 - `worker_jobs_processed_total` 은 인스턴스 재활용(누적 변환 N회 후 자체 종료) 시점 결정에 쓰이도록 spec 01 의 lifetime 카운터와 동일 소스를 공유한다.
 - 메트릭 emit 지점은 soffice 래퍼(spec 04)와 파이프라인 오케스트레이션(spec 05)의 계측 훅에 둔다.
 
 ## Approach
-spec 01 의 `GET /health`(`concurrent_active`/`lifetime_processed`/`ready_for_recycle`)·인스턴스 재활용 카운터와 연동해, 같은 카운터를 메트릭으로도 노출한다(worker-spec.md §8.3.7). soffice 변환 duration·RSS·실패 사유는 soffice 래퍼(spec 04)의 서브프로세스 수명주기에서, 폰트 fallback 경고는 변환 로그 파싱에서 emit 한다. `tmp_disk_bytes_used` 는 작업 디렉터리 정리 누수를 잡는 무상태 검증 지표로 둔다. 알람은 운영 대시보드/모니터링 백엔드 쪽에서 임계치로 구성하고, 워커는 메트릭 노출까지만 책임진다.
+spec 01 의 `GET /health`(`concurrent_active`/`lifetime_processed`/`ready_for_recycle`)·인스턴스 재활용 카운터와 연동해, 같은 카운터를 `/metrics` 에 Prometheus text exposition 메트릭으로도 노출한다(worker-spec.md §8.3.7). soffice 변환 duration·RSS·실패 사유는 soffice 래퍼(spec 04)의 서브프로세스 수명주기에서, 폰트 fallback 경고는 변환 로그 파싱에서 emit 한다. `tmp_disk_bytes_used` 는 작업 디렉터리 정리 누수를 잡는 무상태 검증 지표로 둔다. 알람은 운영 대시보드/모니터링 백엔드 쪽에서 임계치로 구성하고, 워커는 메트릭 노출까지만 책임진다.
 
 ## Verification
 - 정상 변환 시 `soffice_conversion_duration_seconds` 분위수(P50/P95/P99)와 `soffice_rss_bytes` 가 갱신되고, 타임아웃/OOM 실패가 `soffice_conversion_failures_total{reason}` 에 사유별로 카운트되는지 검증한다.

--- a/tasks/phase-1-pptx-worker/09-worker-observability-metrics.md
+++ b/tasks/phase-1-pptx-worker/09-worker-observability-metrics.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/09-worker-observability-metrics.md"
 depends_on: ["1.01", "1.04", "1.05"]
 blocks: []
 estimate: "S"
-status: "todo"
+status: "done"
+completed_at: "2026-05-28"
 owner: ""
 sprint: ""
 ---
@@ -23,21 +24,21 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 메트릭 노출 방식 결정(Prometheus exporter 등) + 모니터링 백엔드 연동 지점 확인
+- [x] 메트릭 노출 방식 결정(Prometheus exporter 등) + 모니터링 백엔드 연동 지점 확인
 
 ## 구현 체크리스트
 
-- [ ] `soffice_rss_bytes`, `soffice_conversion_duration_seconds{quantile}`(P50/P95/P99)
-- [ ] `soffice_conversion_failures_total{reason=timeout|oom|기타}`, `worker_oom_kill_total`
-- [ ] `worker_jobs_processed_total`(1.01 lifetime 카운터와 동일 소스), `tmp_disk_bytes_used`, `font_fallback_warnings_total`
-- [ ] 알람 기준: P95 duration>30s 5분 지속→경고, oom_kill 증가→즉시, font_fallback 증가→폰트 누락 알림
-- [ ] emit 지점: soffice 래퍼(04)·오케스트레이션(05)·`/health`(01) 계측 훅
+- [x] `soffice_rss_bytes`, `soffice_conversion_duration_seconds{quantile}`(P50/P95/P99)
+- [x] `soffice_conversion_failures_total{reason=timeout|oom|other}`, `worker_oom_kill_total`
+- [x] `worker_jobs_processed_total`(1.01 lifetime 카운터와 동일 소스), `tmp_disk_bytes_used`, `font_fallback_warnings_total`
+- [x] 알람 기준: P95 duration>30s 5분 지속→경고, oom_kill 증가→즉시, font_fallback 증가→폰트 누락 알림
+- [x] emit 지점: soffice 래퍼(04)·오케스트레이션(05)·`/health`(01) 계측 훅
 
 ## Definition of Done
 
-- [ ] 정상 변환 시 duration 분위수·RSS 갱신, 타임아웃/OOM 실패가 reason 별 카운트 검증
-- [ ] `worker_jobs_processed_total` 이 1.01 lifetime 카운터와 일치, N회 도달 시 ready_for_recycle 연동 검증
-- [ ] 폰트 누락 변환 시 `font_fallback_warnings_total` 증가, P95>30s 경고 임계 충족 검증
+- [x] 정상 변환 시 duration 분위수·RSS 갱신, 타임아웃/OOM 실패가 reason 별 카운트 검증
+- [x] `worker_jobs_processed_total` 이 1.01 lifetime 카운터와 일치, N회 도달 시 ready_for_recycle 연동 검증
+- [x] 폰트 누락 변환 시 `font_fallback_warnings_total` 증가, P95>30s 경고 임계 충족 검증
 
 ## 리스크 / 메모
 

--- a/tests/test_pptx_worker/test_app/test_tasks.py
+++ b/tests/test_pptx_worker/test_app/test_tasks.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pptx_worker.api import tasks as tasks_api
 from pptx_worker.main import create_app
+from pptx_worker.metrics import WorkerMetricsRegistry, set_worker_metrics
 from pptx_worker.runtime import WorkerRuntime, set_worker_runtime
 
 from features.visualization.service import (
@@ -92,6 +93,7 @@ def worker_client(monkeypatch):
         recycle_after=2,
         shutdown_callback=lambda: shutdown_calls.append("shutdown"),
     )
+    set_worker_metrics(WorkerMetricsRegistry())
     service = FakeVisualizationTaskService(runtime)
 
     tasks_api.set_main_client_factory(lambda callback_base_url: main_client)
@@ -102,6 +104,7 @@ def worker_client(monkeypatch):
         yield client, main_client, service, runtime, shutdown_calls
 
     tasks_api.reset_main_client_factory()
+    set_worker_metrics(None)
     set_worker_runtime(None)
 
 
@@ -309,6 +312,24 @@ def test_health_reports_runtime_counters_and_recycle_readiness(worker_client):
     assert after_second.json()["lifetime_processed"] == 2
     assert after_second.json()["ready_for_recycle"] is True
     assert shutdown_calls == ["shutdown"]
+
+
+def test_metrics_exposes_runtime_counter_and_recycle_signal(worker_client):
+    """메트릭의 처리 카운터와 재활용 신호는 /health 와 같은 런타임 소스를 쓴다."""
+    client, _, service, _, _ = worker_client
+    service.generate_conversion_count = 2
+
+    response = client.post("/tasks/visualizations/generate", json=generate_payload(jobId="job-1"))
+    health = client.get("/health").json()
+    metrics = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert health["lifetime_processed"] == 2
+    assert health["ready_for_recycle"] is True
+    assert metrics.status_code == 200
+    assert "worker_jobs_processed_total 2" in metrics.text
+    assert "worker_ready_for_recycle 1" in metrics.text
+    assert 'soffice_conversion_failures_total{reason="timeout"} 0' in metrics.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_pptx_worker/test_metrics.py
+++ b/tests/test_pptx_worker/test_metrics.py
@@ -1,0 +1,34 @@
+"""PPTX 워커 메트릭 저장소 테스트."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from pptx_worker.metrics import WorkerMetricsRegistry, get_worker_metrics, set_worker_metrics
+
+
+def test_metrics_registry_keeps_recent_duration_samples_only() -> None:
+    """duration 샘플은 고정 크기 버퍼에 최근 값만 유지한다."""
+    metrics = WorkerMetricsRegistry(max_duration_samples=2)
+
+    for duration in (1.0, 2.0, 3.0):
+        metrics.observe_soffice_conversion_success(
+            duration_seconds=duration,
+            rss_bytes=None,
+        )
+
+    snapshot = metrics.snapshot()
+    assert snapshot.soffice_conversion_duration_seconds == (2.0, 3.0)
+    assert snapshot.quantile(0.5) == 2.0
+    assert snapshot.quantile(0.95) == 3.0
+
+
+def test_worker_metrics_singleton_is_shared_between_threads() -> None:
+    """첫 접근이 병렬이어도 메트릭 싱글톤은 하나만 생성된다."""
+    set_worker_metrics(None)
+
+    try:
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            registries = list(executor.map(lambda _: get_worker_metrics(), range(64)))
+
+        assert len({id(registry) for registry in registries}) == 1
+    finally:
+        set_worker_metrics(None)

--- a/tests/test_pptx_worker/test_visualization/test_pptx/test_soffice_render.py
+++ b/tests/test_pptx_worker/test_visualization/test_pptx/test_soffice_render.py
@@ -35,7 +35,7 @@ class FakeProcess:
         self.timeout_once = timeout_once
         self.failure_returncode = failure_returncode
         self.killed = False
-        self.pid = 1000 + len(factory.processes)
+        self.pid = 10_000_000 + len(factory.processes)
         self.returncode = 0
 
     def communicate(self, timeout: float | None = None) -> tuple[str, str]:
@@ -348,13 +348,15 @@ def test_soffice_timeout_cleans_workdir_when_retry_fails(
     factory = FakePopenFactory(timeout_soffice_attempts=2)
 
     with patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory):
-        with pytest.raises(PptxRenderError, match="초과"):
+        with pytest.raises(PptxRenderError, match="초과") as exc_info:
             _make_renderer(tmp_root, counter, metrics).render(source_pptx, tmp_path / "out")
 
     soffice_processes = [
         process for process in factory.processes if process.command[0] == "soffice"
     ]
     assert [process.killed for process in soffice_processes] == [True, True]
+    assert exc_info.value.__cause__ is not None
+    assert exc_info.value.__cause__.args
     assert counter.value == 0
     assert metrics.snapshot().soffice_conversion_failures_total["timeout"] == 1
     _assert_tmp_root_empty(tmp_root)
@@ -373,10 +375,11 @@ def test_non_zero_exit_raises_render_error(
     factory = FakePopenFactory(failing_commands={command_name})
 
     with patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory):
-        with pytest.raises(PptxRenderError, match=f"{command_name} 명령이 실패"):
+        with pytest.raises(PptxRenderError, match=f"{command_name} 명령이 실패") as exc_info:
             _make_renderer(tmp_root, counter, metrics).render(source_pptx, tmp_path / "out")
 
     assert counter.value == 0
+    assert exc_info.value.args
     assert metrics.snapshot().soffice_conversion_failures_total["other"] == 1
     _assert_tmp_root_empty(tmp_root)
 

--- a/tests/test_pptx_worker/test_visualization/test_pptx/test_soffice_render.py
+++ b/tests/test_pptx_worker/test_visualization/test_pptx/test_soffice_render.py
@@ -8,6 +8,7 @@ from threading import Lock
 from unittest.mock import patch
 
 import pytest
+from pptx_worker.metrics import WorkerMetricsRegistry
 
 from features.visualization.pptx.soffice_render import (
     InMemoryConversionCounter,
@@ -27,12 +28,12 @@ class FakeProcess:
         factory: "FakePopenFactory",
         *,
         timeout_once: bool = False,
-        should_fail: bool = False,
+        failure_returncode: int | None = None,
     ) -> None:
         self.command = command
         self.factory = factory
         self.timeout_once = timeout_once
-        self.should_fail = should_fail
+        self.failure_returncode = failure_returncode
         self.killed = False
         self.pid = 1000 + len(factory.processes)
         self.returncode = 0
@@ -43,11 +44,12 @@ class FakeProcess:
         if self.killed:
             self.returncode = -9
             return "", "timeout"
-        if self.should_fail:
-            self.returncode = 1
-            return "", f"{self.command[0]} failed"
+        if self.failure_returncode is not None:
+            self.returncode = self.failure_returncode
+            stdout, stderr = self.factory.output_for(self.command[0])
+            return stdout, stderr or f"{self.command[0]} failed"
         self.factory.complete_command(self.command)
-        return "", ""
+        return self.factory.output_for(self.command[0])
 
     def kill(self) -> None:
         self.killed = True
@@ -61,11 +63,13 @@ class FakePopenFactory:
         *,
         full_pages: list[int] | None = None,
         timeout_soffice_attempts: int = 0,
-        failing_commands: set[str] | None = None,
+        failing_commands: set[str] | dict[str, int] | None = None,
+        command_outputs: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         self.full_pages = [1, 2, 3] if full_pages is None else full_pages
         self.timeout_soffice_attempts = timeout_soffice_attempts
-        self.failing_commands = failing_commands or set()
+        self.failing_commands = self._normalize_failing_commands(failing_commands)
+        self.command_outputs = command_outputs or {}
         self.commands: list[list[str]] = []
         self.popen_kwargs: list[dict] = []
         self.processes: list[FakeProcess] = []
@@ -88,7 +92,7 @@ class FakePopenFactory:
                 command,
                 self,
                 timeout_once=timeout_once,
-                should_fail=command[0] in self.failing_commands,
+                failure_returncode=self.failing_commands.get(command[0]),
             )
             self.commands.append(command)
             self.popen_kwargs.append(kwargs)
@@ -102,6 +106,19 @@ class FakePopenFactory:
             self._create_images(command)
         else:
             raise AssertionError(f"알 수 없는 명령입니다: {command}")
+
+    def output_for(self, command_name: str) -> tuple[str, str]:
+        return self.command_outputs.get(command_name, ("", ""))
+
+    @staticmethod
+    def _normalize_failing_commands(
+        failing_commands: set[str] | dict[str, int] | None,
+    ) -> dict[str, int]:
+        if failing_commands is None:
+            return {}
+        if isinstance(failing_commands, dict):
+            return dict(failing_commands)
+        return {command: 1 for command in failing_commands}
 
     @staticmethod
     def _create_pdf(command: list[str]) -> None:
@@ -143,12 +160,15 @@ def tmp_root(tmp_path: Path) -> Path:
 
 
 def _make_renderer(
-    tmp_root: Path, counter: InMemoryConversionCounter | None = None
+    tmp_root: Path,
+    counter: InMemoryConversionCounter | None = None,
+    metrics: WorkerMetricsRegistry | None = None,
 ) -> PptxRenderer:
     """테스트용 렌더러를 만든다."""
     return PptxRenderer(
         options=RenderOptions(timeout_seconds=0.1, tmp_root=tmp_root),
         counter=counter,
+        metrics=metrics or WorkerMetricsRegistry(),
     )
 
 
@@ -186,6 +206,37 @@ def test_full_render_outputs_all_pages_and_omits_page_flags(
     assert "-l" not in pdftoppm_command
     assert result.conversion_count == 1
     assert factory.popen_kwargs[0]["start_new_session"] is True
+    _assert_tmp_root_empty(tmp_root)
+
+
+def test_successful_render_updates_duration_rss_and_tmp_metrics(
+    source_pptx: Path,
+    tmp_root: Path,
+    tmp_path: Path,
+) -> None:
+    """정상 변환은 duration 분위수, RSS, tmp 사용량 gauge 를 갱신한다."""
+    metrics = WorkerMetricsRegistry()
+    factory = FakePopenFactory(full_pages=[1])
+    leftover = tmp_root / "leftover.bin"
+    leftover.write_bytes(b"tmp")
+
+    with (
+        patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory),
+        patch(
+            "features.visualization.pptx.soffice_render.time.perf_counter",
+            side_effect=[10.0, 12.5],
+        ),
+        patch("features.visualization.pptx.soffice_render._max_child_rss_bytes", return_value=512),
+    ):
+        _make_renderer(tmp_root, metrics=metrics).render(source_pptx, tmp_path / "out")
+
+    snapshot = metrics.snapshot()
+    assert snapshot.quantile(0.5) == 2.5
+    assert snapshot.quantile(0.95) == 2.5
+    assert snapshot.quantile(0.99) == 2.5
+    assert snapshot.soffice_rss_bytes == 512
+    assert snapshot.tmp_disk_bytes_used == 3
+    leftover.unlink()
     _assert_tmp_root_empty(tmp_root)
 
 
@@ -293,17 +344,19 @@ def test_soffice_timeout_cleans_workdir_when_retry_fails(
 ) -> None:
     """재시도까지 timeout 이면 예외를 내고 내부 /tmp 작업 디렉터리를 제거한다."""
     counter = InMemoryConversionCounter()
+    metrics = WorkerMetricsRegistry()
     factory = FakePopenFactory(timeout_soffice_attempts=2)
 
     with patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory):
         with pytest.raises(PptxRenderError, match="초과"):
-            _make_renderer(tmp_root, counter).render(source_pptx, tmp_path / "out")
+            _make_renderer(tmp_root, counter, metrics).render(source_pptx, tmp_path / "out")
 
     soffice_processes = [
         process for process in factory.processes if process.command[0] == "soffice"
     ]
     assert [process.killed for process in soffice_processes] == [True, True]
     assert counter.value == 0
+    assert metrics.snapshot().soffice_conversion_failures_total["timeout"] == 1
     _assert_tmp_root_empty(tmp_root)
 
 
@@ -316,13 +369,58 @@ def test_non_zero_exit_raises_render_error(
 ) -> None:
     """외부 명령이 non-zero exit 이면 렌더 실패로 처리한다."""
     counter = InMemoryConversionCounter()
+    metrics = WorkerMetricsRegistry()
     factory = FakePopenFactory(failing_commands={command_name})
 
     with patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory):
         with pytest.raises(PptxRenderError, match=f"{command_name} 명령이 실패"):
-            _make_renderer(tmp_root, counter).render(source_pptx, tmp_path / "out")
+            _make_renderer(tmp_root, counter, metrics).render(source_pptx, tmp_path / "out")
 
     assert counter.value == 0
+    assert metrics.snapshot().soffice_conversion_failures_total["other"] == 1
+    _assert_tmp_root_empty(tmp_root)
+
+
+def test_soffice_sigkill_failure_is_counted_as_oom(
+    source_pptx: Path,
+    tmp_root: Path,
+    tmp_path: Path,
+) -> None:
+    """timeout 없이 SIGKILL 된 soffice 실패는 OOM reason 으로 분류한다."""
+    metrics = WorkerMetricsRegistry()
+    factory = FakePopenFactory(failing_commands={"soffice": -signal.SIGKILL})
+
+    with patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory):
+        with pytest.raises(PptxRenderError, match="soffice 명령이 실패"):
+            _make_renderer(tmp_root, metrics=metrics).render(source_pptx, tmp_path / "out")
+
+    snapshot = metrics.snapshot()
+    assert snapshot.soffice_conversion_failures_total["oom"] == 1
+    assert snapshot.worker_oom_kill_total == 1
+    _assert_tmp_root_empty(tmp_root)
+
+
+def test_font_fallback_warning_in_soffice_logs_increments_counter(
+    source_pptx: Path,
+    tmp_root: Path,
+    tmp_path: Path,
+) -> None:
+    """soffice 로그의 font fallback 경고는 별도 카운터로 집계한다."""
+    metrics = WorkerMetricsRegistry()
+    factory = FakePopenFactory(
+        full_pages=[1],
+        command_outputs={
+            "soffice": (
+                "",
+                "warn: font fallback requested for MissingDisplay\ninfo: font substitution applied",
+            )
+        },
+    )
+
+    with patch("features.visualization.pptx.soffice_render.subprocess.Popen", factory):
+        _make_renderer(tmp_root, metrics=metrics).render(source_pptx, tmp_path / "out")
+
+    assert metrics.snapshot().font_fallback_warnings_total == 2
     _assert_tmp_root_empty(tmp_root)
 
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #226

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PPTX 워커에 Prometheus text exposition 형식의 `GET /metrics` 엔드포인트를 추가했습니다.
- `soffice_rss_bytes`, `soffice_conversion_duration_seconds{quantile="0.5|0.95|0.99"}`, `soffice_conversion_failures_total{reason="timeout|oom|other"}` 메트릭을 노출했습니다.
- `worker_oom_kill_total`, `tmp_disk_bytes_used`, `font_fallback_warnings_total` 계측을 soffice 렌더 수명주기에 연결했습니다.
- 기본 렌더러가 워커 런타임의 `processed_counter`를 공유하도록 연결해 `worker_jobs_processed_total`과 `/health.lifetime_processed` 소스를 일치시켰습니다.
- `worker_ready_for_recycle`을 `/health.ready_for_recycle`과 같은 기준의 0/1 gauge로 노출했습니다.
- 운영자가 바로 옮겨 쓸 수 있도록 worker-spec에 PromQL 알람 기준을 문서화했습니다.
- Task 1.09 문서를 완료 상태로 갱신했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`186 files already formatted`)
  - `uv run pytest` 통과 (`728 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 워커는 메트릭 노출까지만 책임지고, 알람 실행 및 대시보드 구성은 운영 모니터링 백엔드 책임으로 남겼습니다.
- 외부 스크레이퍼는 Cloud Run require-auth 정책에 맞춰 워커 호출 권한이 있는 서비스 계정 OIDC 토큰을 붙여 `/metrics`를 호출해야 합니다.
