### PR TITLE
[Fix] 정규 인터뷰 완료 직후 추가 대화 자동 시작

### DIFF
--- a/features/interview/agents/nodes/analyst.py
+++ b/features/interview/agents/nodes/analyst.py
@@ -194,6 +194,20 @@ def run(state: InterviewState) -> InterviewState:
                 f"{llm_error} | {completion_llm_error}" if llm_error else completion_llm_error
             )
 
+        if _has_extension_capacity(state, global_config.max_extensions):
+            return {
+                **state,
+                **_build_regular_completion_extension_state(
+                    state,
+                    global_config.extension_turns_per_session,
+                ),
+                "stage_progress": updated_progress,
+                "collected_data": updated_collected_data,
+                "overall_completion_percentage": overall_completion_percentage,
+                "next_node": "question_generator",
+                "llm_error": merged_llm_error,
+            }
+
         return {
             **state,
             "stage_progress": updated_progress,
@@ -211,6 +225,31 @@ def run(state: InterviewState) -> InterviewState:
         "collected_data": updated_collected_data,
         "next_node": "question_generator",
         "llm_error": llm_error,
+    }
+
+
+def _has_extension_capacity(state: InterviewState, max_extensions: int) -> bool:
+    """추가 대화를 새로 시작할 수 있는지 판단한다."""
+    extension_count = int(state.get("extension_count") or 0)
+    return extension_count < max_extensions
+
+
+def _build_regular_completion_extension_state(
+    state: InterviewState,
+    extension_turns_max: int,
+) -> dict:
+    """정규 인터뷰 완료 직후 같은 턴에서 연장 모드로 전환할 state를 구성한다."""
+    extension_count = int(state.get("extension_count") or 0)
+    return {
+        "all_stages_complete": False,
+        "is_extended_mode": True,
+        "extension_count": extension_count + 1,
+        "extension_turns_used": 0,
+        "extension_turns_max": extension_turns_max,
+        "additional_question_target_statuses": {},
+        "additional_question_pre_evaluated": False,
+        "current_additional_question_target_id": None,
+        "pending_extended_end_guide": False,
     }
 
 

--- a/features/interview/agents/nodes/analyst.py
+++ b/features/interview/agents/nodes/analyst.py
@@ -238,7 +238,10 @@ def _build_regular_completion_extension_state(
     state: InterviewState,
     extension_turns_max: int,
 ) -> dict:
-    """정규 인터뷰 완료 직후 같은 턴에서 연장 모드로 전환할 state를 구성한다."""
+    """정규 인터뷰 완료 직후 같은 턴에서 연장 모드로 전환할 state를 구성한다.
+
+    같은 그래프 실행에서 첫 연장 질문을 생성하므로 file_contexts와 mentioned_insight는 유지한다.
+    """
     extension_count = int(state.get("extension_count") or 0)
     return {
         "all_stages_complete": False,

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -67,6 +67,15 @@ class InterviewService:
                 return str(content)
         return None
 
+    @classmethod
+    def _get_latest_new_ai_response(
+        cls, previous_messages: list, current_messages: list
+    ) -> str | None:
+        """이번 그래프 실행에서 새로 추가된 AI 응답 텍스트를 반환한다."""
+        if len(current_messages) < len(previous_messages):
+            return cls._get_latest_ai_response(current_messages)
+        return cls._get_latest_ai_response(current_messages[len(previous_messages) :])
+
     @staticmethod
     def _build_extension_meta(state: dict | None) -> dict:
         """응답 페이로드용 연장 메타데이터 구성"""
@@ -81,6 +90,35 @@ class InterviewService:
     def _get_thread_config(session_id: str) -> dict[str, dict[str, str]]:
         """세션별 LangGraph thread config를 반환"""
         return {"configurable": {"thread_id": session_id}}
+
+    @staticmethod
+    def _build_extension_start_state(current_state: dict, extension_turns_max: int) -> dict:
+        """완료 세션을 연장 모드로 전환하기 위한 공통 state update를 구성한다."""
+        extension_count = int(current_state.get("extension_count") or 0)
+        return {
+            "is_extended_mode": True,
+            "all_stages_complete": False,
+            "extension_count": extension_count + 1,
+            "extension_turns_used": 0,
+            "extension_turns_max": extension_turns_max,
+            "additional_question_target_statuses": {},
+            "additional_question_pre_evaluated": False,
+            "current_additional_question_target_id": None,
+            "pending_extended_end_guide": False,
+            "current_turn_files": [],
+            "file_contexts": [],
+            "mentioned_insight": None,
+        }
+
+    @staticmethod
+    def _should_auto_start_extension(current_state: dict, max_extensions: int) -> bool:
+        """완료된 일반 세션의 후속 채팅을 연장 모드 첫 입력으로 처리할지 판단한다."""
+        extension_count = int(current_state.get("extension_count") or 0)
+        return (
+            bool(current_state.get("all_stages_complete"))
+            and not bool(current_state.get("is_extended_mode", False))
+            and extension_count < max_extensions
+        )
 
     async def _set_session_status(
         self,
@@ -335,23 +373,13 @@ class InterviewService:
         if not current_state["all_stages_complete"]:
             raise ValueError("연장은 모든 단계 완료 후에만 시작할 수 있습니다.")
 
-        if current_state["extension_count"] >= global_config.max_extensions:
+        if int(current_state.get("extension_count") or 0) >= global_config.max_extensions:
             raise ValueError("최대 연장 횟수에 도달하여 더 이상 연장할 수 없습니다.")
 
-        input_state = {
-            "is_extended_mode": True,
-            "all_stages_complete": False,
-            "extension_count": current_state["extension_count"] + 1,
-            "extension_turns_used": 0,
-            "extension_turns_max": global_config.extension_turns_per_session,
-            "additional_question_target_statuses": {},
-            "additional_question_pre_evaluated": False,
-            "current_additional_question_target_id": None,
-            "pending_extended_end_guide": False,
-            "current_turn_files": [],
-            "file_contexts": [],
-            "mentioned_insight": None,
-        }
+        input_state = self._build_extension_start_state(
+            current_state,
+            global_config.extension_turns_per_session,
+        )
 
         result = await self._graph.ainvoke(
             input_state,
@@ -407,7 +435,7 @@ class InterviewService:
             }
             return
 
-        if current_state["extension_count"] >= global_config.max_extensions:
+        if int(current_state.get("extension_count") or 0) >= global_config.max_extensions:
             yield {
                 "event": SSEEventType.ERROR,
                 "data": json.dumps(
@@ -423,20 +451,10 @@ class InterviewService:
             }
             return
 
-        input_state = {
-            "is_extended_mode": True,
-            "all_stages_complete": False,
-            "extension_count": current_state["extension_count"] + 1,
-            "extension_turns_used": 0,
-            "extension_turns_max": global_config.extension_turns_per_session,
-            "additional_question_target_statuses": {},
-            "additional_question_pre_evaluated": False,
-            "current_additional_question_target_id": None,
-            "pending_extended_end_guide": False,
-            "current_turn_files": [],
-            "file_contexts": [],
-            "mentioned_insight": None,
-        }
+        input_state = self._build_extension_start_state(
+            current_state,
+            global_config.extension_turns_per_session,
+        )
         config = self._get_thread_config(session_id)
         accumulated_text = ""
 
@@ -597,14 +615,24 @@ class InterviewService:
             raise ValueError(f"세션을 찾을 수 없습니다: {session_id}")
 
         normalized_message = _normalize_user_message(message)
+        global_config = get_global_config()
 
         # 입력 상태 구성
-        input_state: dict = {
+        turn_input_state: dict = {
             "messages": [HumanMessage(content=normalized_message)],
             "current_turn_files": files or [],
             "file_contexts": [],
             "mentioned_insight": mentioned_insight,
         }
+        input_state: dict = turn_input_state
+        if self._should_auto_start_extension(current_state, global_config.max_extensions):
+            input_state = {
+                **self._build_extension_start_state(
+                    current_state,
+                    global_config.extension_turns_per_session,
+                ),
+                **turn_input_state,
+            }
 
         # 그래프 비동기 실행 (Checkpointer가 이전 상태 자동 로드)
         result = await self._graph.ainvoke(
@@ -612,9 +640,10 @@ class InterviewService:
             config=self._get_thread_config(session_id),
         )
 
-        ai_response = None
-        if not result["all_stages_complete"]:
-            ai_response = self._get_latest_ai_response(result.get("messages", []))
+        ai_response = self._get_latest_new_ai_response(
+            current_state.get("messages", []),
+            result.get("messages", []),
+        )
 
         return {
             "ai_response": ai_response,
@@ -725,14 +754,24 @@ class InterviewService:
             return
 
         normalized_message = _normalize_user_message(message)
+        global_config = get_global_config()
 
         # 2. 입력 상태 구성
-        input_state: dict = {
+        turn_input_state: dict = {
             "messages": [HumanMessage(content=normalized_message)],
             "current_turn_files": files or [],
             "file_contexts": [],
             "mentioned_insight": mentioned_insight,
         }
+        input_state: dict = turn_input_state
+        if self._should_auto_start_extension(current_state, global_config.max_extensions):
+            input_state = {
+                **self._build_extension_start_state(
+                    current_state,
+                    global_config.extension_turns_per_session,
+                ),
+                **turn_input_state,
+            }
 
         config = self._get_thread_config(session_id)
         accumulated_text = ""
@@ -795,11 +834,10 @@ class InterviewService:
             if final_state:
                 await self._set_session_status(session_id, "completed")
                 final_state = {**final_state, "status": "completed"}
-                ai_response: str | None = None
-                if not final_state["all_stages_complete"]:
-                    ai_response = accumulated_text or self._get_latest_ai_response(
-                        final_state.get("messages", [])
-                    )
+                ai_response = accumulated_text or self._get_latest_new_ai_response(
+                    current_state.get("messages", []),
+                    final_state.get("messages", []),
+                )
 
                 yield {
                     "event": SSEEventType.MESSAGE_COMPLETE,

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -386,7 +386,10 @@ class InterviewService:
             config={"configurable": {"thread_id": session_id}},
         )
 
-        ai_response = self._get_latest_ai_response(result.get("messages", []))
+        ai_response = self._get_latest_new_ai_response(
+            current_state.get("messages", []),
+            result.get("messages", []),
+        )
         if ai_response is None:
             raise ValueError("연장 질문을 생성하지 못했습니다.")
 
@@ -492,8 +495,9 @@ class InterviewService:
             if final_state:
                 await self._set_session_status(session_id, "completed")
                 final_state = {**final_state, "status": "completed"}
-                ai_response = accumulated_text or self._get_latest_ai_response(
-                    final_state.get("messages", [])
+                ai_response = accumulated_text or self._get_latest_new_ai_response(
+                    current_state.get("messages", []),
+                    final_state.get("messages", []),
                 )
 
                 yield {

--- a/tests/test_features/test_interview/test_analyst.py
+++ b/tests/test_features/test_interview/test_analyst.py
@@ -211,8 +211,8 @@ def test_run_keeps_stage_when_fixed_questions_remain_even_if_required_fields_com
     assert result["stage_progress"]["is_complete"] is False
 
 
-def test_run_marks_all_complete_at_stage_4(monkeypatch):
-    """4단계 완료 시 all_stages_complete와 overall_completion_percentage를 설정한다."""
+def test_run_starts_extended_mode_at_stage_4_completion(monkeypatch):
+    """4단계 완료 시 같은 요청에서 연장 모드 첫 질문 생성으로 라우팅한다."""
     response = AnalystResponse(
         fields=[
             AnalystFieldResult(
@@ -248,10 +248,49 @@ def test_run_marks_all_complete_at_stage_4(monkeypatch):
 
     assert result["current_stage"] == 4
     assert result["stage_progress"]["is_complete"] is True
+    assert result["all_stages_complete"] is False
+    assert result["is_extended_mode"] is True
+    assert result["extension_count"] == 1
+    assert result["extension_turns_used"] == 0
+    assert result["extension_turns_max"] == 18
+    assert result["additional_question_target_statuses"] == {}
+    assert result["additional_question_pre_evaluated"] is False
+    assert result["current_additional_question_target_id"] is None
+    assert result["overall_completion_percentage"] == 88.5
+    assert result["next_node"] == "question_generator"
+    assert result["collected_data"]["stage_4"]["final_deliverable"]["value"] == "서비스 런칭 완료"
+
+
+def test_run_marks_all_complete_at_stage_4_when_extension_limit_reached(monkeypatch):
+    """연장 가능 횟수가 없으면 4단계 완료 시 기존처럼 종료한다."""
+    response = AnalystResponse(fields=[])
+    monkeypatch.setattr(
+        analyst, "get_analyst_llm", lambda temperature=0.3: _mock_analyst_llm(response)
+    )
+    monkeypatch.setattr(
+        analyst,
+        "_calculate_overall_completion_percentage",
+        lambda experience_name, collected_data: (88.5, None),
+    )
+
+    state = get_initial_interview_state(
+        user_id="test_user",
+        session_id="test_session",
+        experience_name="테스트 경험",
+    )
+    state["current_stage"] = 4
+    state["extension_count"] = 1
+    stage_4_config = load_stage_config(4)
+    state["stage_progress"]["fixed_q_total"] = len(stage_4_config.fixed_questions)
+    state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
+
+    result = analyst.run(state)
+
+    assert result["stage_progress"]["is_complete"] is True
     assert result["all_stages_complete"] is True
+    assert result["is_extended_mode"] is False
     assert result["overall_completion_percentage"] == 88.5
     assert result["next_node"] == "end"
-    assert result["collected_data"]["stage_4"]["final_deliverable"]["value"] == "서비스 런칭 완료"
 
 
 def test_run_extended_mode_routes_to_question_generator(monkeypatch):

--- a/tests/test_features/test_interview/test_analyst.py
+++ b/tests/test_features/test_interview/test_analyst.py
@@ -25,9 +25,17 @@ class _DummyLLM:
 
 
 class _DummyGlobalConfig:
-    def __init__(self, *, enable_dynamic_followup: bool = True):
+    def __init__(
+        self,
+        *,
+        enable_dynamic_followup: bool = True,
+        max_extensions: int = 1,
+        extension_turns_per_session: int = 18,
+    ):
         self.enable_dynamic_followup = enable_dynamic_followup
         self.context_window_size = 5
+        self.max_extensions = max_extensions
+        self.extension_turns_per_session = extension_turns_per_session
 
 
 def _mock_analyst_llm(response: AnalystResponse):
@@ -230,6 +238,11 @@ def test_run_starts_extended_mode_at_stage_4_completion(monkeypatch):
         "_calculate_overall_completion_percentage",
         lambda experience_name, collected_data: (88.5, None),
     )
+    monkeypatch.setattr(
+        analyst,
+        "get_global_config",
+        lambda: _DummyGlobalConfig(max_extensions=1, extension_turns_per_session=18),
+    )
 
     state = get_initial_interview_state(
         user_id="test_user",
@@ -271,6 +284,11 @@ def test_run_marks_all_complete_at_stage_4_when_extension_limit_reached(monkeypa
         analyst,
         "_calculate_overall_completion_percentage",
         lambda experience_name, collected_data: (88.5, None),
+    )
+    monkeypatch.setattr(
+        analyst,
+        "get_global_config",
+        lambda: _DummyGlobalConfig(max_extensions=1, extension_turns_per_session=18),
     )
 
     state = get_initial_interview_state(

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -500,15 +500,17 @@ async def test_process_message_resets_current_turn_files_when_no_files(monkeypat
 async def test_extend_session_success(monkeypatch):
     """완료된 세션은 연장 모드로 전환되고 첫 연장 질문을 반환한다."""
     dummy_graph = DummyGraph()
+    previous_messages = [AIMessage(content="정규 마지막 질문")]
     dummy_graph.state_snapshot = DummyStateSnapshot(
         values={
             "session_id": "session_1",
+            "messages": previous_messages,
             "all_stages_complete": True,
             "extension_count": 0,
         }
     )
     dummy_graph.invoke_result = {
-        "messages": [AIMessage(content="연장 첫 질문")],
+        "messages": [*previous_messages, AIMessage(content="연장 첫 질문")],
         "extension_count": 1,
         "extension_turns_max": 18,
     }
@@ -544,6 +546,42 @@ async def test_extend_session_success(monkeypatch):
     assert invocation["state"]["current_turn_files"] == []
     assert invocation["state"]["file_contexts"] == []
     assert invocation["state"]["mentioned_insight"] is None
+
+
+@pytest.mark.asyncio
+async def test_extend_session_raises_when_no_new_ai_response(monkeypatch):
+    """연장 실행 결과에 새 AI 메시지가 없으면 과거 질문을 재사용하지 않고 실패한다."""
+    dummy_graph = DummyGraph()
+    previous_messages = [AIMessage(content="정규 마지막 질문")]
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "messages": previous_messages,
+            "all_stages_complete": True,
+            "extension_count": 0,
+        }
+    )
+    dummy_graph.invoke_result = {
+        "messages": previous_messages,
+        "extension_count": 1,
+        "extension_turns_max": 18,
+    }
+    monkeypatch.setattr(
+        interview_service,
+        "get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = _build_service(monkeypatch, dummy_graph)
+
+    with pytest.raises(ValueError, match="연장 질문을 생성하지 못했습니다"):
+        await service.extend_session("session_1")
 
 
 @pytest.mark.asyncio

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -314,9 +314,18 @@ async def test_process_message_accepts_file_only_request(monkeypatch):
 async def test_process_message_returns_none_when_all_complete(monkeypatch):
     """모든 단계 완료 상태면 ai_response를 None으로 반환한다."""
     dummy_graph = DummyGraph()
-    dummy_graph.state_snapshot = DummyStateSnapshot(values={"session_id": "session_1"})
+    previous_messages = [AIMessage(content="직전 질문")]
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "messages": previous_messages,
+            "all_stages_complete": False,
+            "is_extended_mode": False,
+            "extension_count": 0,
+        }
+    )
     dummy_graph.invoke_result = {
-        "messages": [HumanMessage(content="사용자 최종 답변")],
+        "messages": [*previous_messages, HumanMessage(content="사용자 최종 답변")],
         "current_stage": 4,
         "stage_progress": {"fixed_q_used": 3},
         "overall_completion_percentage": 100.0,
@@ -336,6 +345,128 @@ async def test_process_message_returns_none_when_all_complete(monkeypatch):
     invocation = dummy_graph.invocations[0]
     assert invocation["state"]["current_turn_files"] == []
     assert invocation["state"]["file_contexts"] == []
+
+
+@pytest.mark.asyncio
+async def test_process_message_returns_immediate_extension_question_after_stage_four_completion(
+    monkeypatch,
+):
+    """정규 마지막 답변 처리 결과로 생성된 첫 연장 질문을 반환한다."""
+    dummy_graph = DummyGraph()
+    previous_messages = [
+        AIMessage(content="정규 마지막 질문"),
+    ]
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "messages": previous_messages,
+            "all_stages_complete": False,
+            "is_extended_mode": False,
+            "extension_count": 0,
+        }
+    )
+    dummy_graph.invoke_result = {
+        "messages": [
+            *previous_messages,
+            HumanMessage(content="정규 마지막 답변입니다."),
+            AIMessage(content="연장 첫 질문"),
+        ],
+        "current_stage": 4,
+        "stage_progress": {"fixed_q_used": 3},
+        "overall_completion_percentage": 100.0,
+        "all_stages_complete": False,
+        "is_extended_mode": True,
+        "extension_count": 1,
+        "extension_turns_used": 1,
+        "extension_turns_max": 18,
+    }
+    service = _build_service(monkeypatch, dummy_graph)
+
+    result = await service.process_message(
+        session_id="session_1",
+        message="정규 마지막 답변입니다.",
+    )
+
+    assert result["ai_response"] == "연장 첫 질문"
+    assert result["all_complete"] is False
+    assert result["is_extended_mode"] is True
+    assert result["extension_turns_used"] == 1
+    assert result["extension_turns_max"] == 18
+
+    invocation = dummy_graph.invocations[0]
+    assert "is_extended_mode" not in invocation["state"]
+    assert invocation["state"]["messages"] == [HumanMessage(content="정규 마지막 답변입니다.")]
+
+
+@pytest.mark.asyncio
+async def test_process_message_auto_starts_extension_for_completed_legacy_session(monkeypatch):
+    """이미 완료 상태로 저장된 기존 세션도 후속 채팅으로 연장 모드에 진입한다."""
+    dummy_graph = DummyGraph()
+    previous_messages = [
+        AIMessage(content="정규 마지막 질문"),
+        HumanMessage(content="정규 마지막 답변"),
+    ]
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "messages": previous_messages,
+            "all_stages_complete": True,
+            "is_extended_mode": False,
+            "extension_count": 0,
+        }
+    )
+    dummy_graph.invoke_result = {
+        "messages": [
+            *previous_messages,
+            HumanMessage(content="추가로 정리하고 싶은 내용입니다."),
+            AIMessage(content="연장 질문"),
+        ],
+        "current_stage": 4,
+        "stage_progress": {"fixed_q_used": 3},
+        "overall_completion_percentage": 100.0,
+        "all_stages_complete": False,
+        "is_extended_mode": True,
+        "extension_count": 1,
+        "extension_turns_used": 1,
+        "extension_turns_max": 18,
+    }
+    monkeypatch.setattr(
+        interview_service,
+        "get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = _build_service(monkeypatch, dummy_graph)
+
+    result = await service.process_message(
+        session_id="session_1",
+        message="추가로 정리하고 싶은 내용입니다.",
+    )
+
+    assert result["ai_response"] == "연장 질문"
+    assert result["all_complete"] is False
+    assert result["is_extended_mode"] is True
+    assert result["extension_turns_used"] == 1
+    assert result["extension_turns_max"] == 18
+
+    invocation = dummy_graph.invocations[0]
+    assert invocation["state"]["is_extended_mode"] is True
+    assert invocation["state"]["all_stages_complete"] is False
+    assert invocation["state"]["extension_count"] == 1
+    assert invocation["state"]["extension_turns_used"] == 0
+    assert invocation["state"]["extension_turns_max"] == 18
+    assert invocation["state"]["additional_question_target_statuses"] == {}
+    assert invocation["state"]["additional_question_pre_evaluated"] is False
+    assert invocation["state"]["current_additional_question_target_id"] is None
+    assert invocation["state"]["messages"] == [
+        HumanMessage(content="추가로 정리하고 싶은 내용입니다.")
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -322,9 +322,10 @@ async def test_process_message_stream_accepts_file_only_request(monkeypatch):
 async def test_process_message_stream_returns_none_when_all_complete(monkeypatch):
     """모든 단계 완료 상태면 message_complete의 ai_response는 null이다."""
     dummy_graph = DummyGraph()
+    previous_messages = [AIMessage(content="직전 질문")]
     dummy_graph.state_snapshot = DummyStateSnapshot(
         values={
-            "messages": [HumanMessage(content="사용자 최종 답변")],
+            "messages": [*previous_messages, HumanMessage(content="사용자 최종 답변")],
             "current_stage": 4,
             "stage_progress": {
                 "fixed_q_used": 3,
@@ -336,6 +337,8 @@ async def test_process_message_stream_returns_none_when_all_complete(monkeypatch
             },
             "overall_completion_percentage": 100.0,
             "all_stages_complete": True,
+            "is_extended_mode": False,
+            "extension_count": 1,
         }
     )
     dummy_graph.stream_events = []
@@ -361,6 +364,104 @@ async def test_process_message_stream_returns_none_when_all_complete(monkeypatch
     assert complete_payload["message"]["ai_response"] is None
     assert complete_payload["message"]["status"] == "completed"
     assert complete_payload["message"]["is_extended_mode"] is False
+
+
+@pytest.mark.anyio
+async def test_process_message_stream_auto_starts_extension_after_regular_completion(monkeypatch):
+    """완료 세션의 채팅 스트림은 별도 /extend 없이 연장 모드 상태로 실행된다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.stream_events = [
+        {
+            "event": LangGraphEventType.ON_CHAT_MODEL_STREAM,
+            "metadata": {"langgraph_node": "question_generator"},
+            "data": {"chunk": DummyChunk("연장 질문")},
+        }
+    ]
+
+    monkeypatch.setattr(
+        "features.interview.service.build_graph", lambda checkpointer=None: dummy_graph
+    )
+    monkeypatch.setattr("features.interview.service.get_checkpointer", lambda: object())
+    monkeypatch.setattr(
+        "features.interview.service.get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = InterviewService()
+
+    previous_messages = [
+        AIMessage(content="정규 마지막 질문"),
+        HumanMessage(content="정규 마지막 답변"),
+    ]
+    initial_state = {
+        "session_id": "session-1",
+        "messages": previous_messages,
+        "all_stages_complete": True,
+        "is_extended_mode": False,
+        "extension_count": 0,
+    }
+    final_state = {
+        "messages": [
+            *previous_messages,
+            HumanMessage(content="추가로 정리하고 싶은 내용입니다."),
+            AIMessage(content="연장 질문"),
+        ],
+        "current_stage": 4,
+        "stage_progress": {
+            "fixed_q_used": 3,
+            "fixed_q_total": 3,
+            "generated_q_used": 2,
+            "generated_q_max": 2,
+            "force_all_generated_q": False,
+            "is_complete": True,
+        },
+        "overall_completion_percentage": 100.0,
+        "all_stages_complete": False,
+        "is_extended_mode": True,
+        "extension_count": 1,
+        "extension_turns_used": 1,
+        "extension_turns_max": 18,
+    }
+    states = [initial_state, final_state]
+
+    async def _get_session_state(_session_id: str):
+        if states:
+            return states.pop(0)
+        return final_state
+
+    monkeypatch.setattr(service, "get_session_state", _get_session_state)
+
+    events = [
+        event
+        async for event in service.process_message_stream(
+            session_id="session-1",
+            message="추가로 정리하고 싶은 내용입니다.",
+        )
+    ]
+
+    invocation = dummy_graph.astream_calls[0]["state"]
+    assert invocation["is_extended_mode"] is True
+    assert invocation["all_stages_complete"] is False
+    assert invocation["extension_count"] == 1
+    assert invocation["extension_turns_used"] == 0
+    assert invocation["extension_turns_max"] == 18
+    assert invocation["messages"] == [HumanMessage(content="추가로 정리하고 싶은 내용입니다.")]
+
+    complete_event = next(
+        event for event in events if event["event"] == SSEEventType.MESSAGE_COMPLETE
+    )
+    complete_payload = json.loads(complete_event["data"])
+    assert complete_payload["message"]["ai_response"] == "연장 질문"
+    assert complete_payload["message"]["all_complete"] is False
+    assert complete_payload["message"]["is_extended_mode"] is True
+    assert complete_payload["message"]["extension_turns_used"] == 1
+    assert complete_payload["message"]["extension_turns_max"] == 18
 
 
 @pytest.mark.anyio

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -550,6 +550,72 @@ async def test_extend_session_stream_yields_delta_and_complete(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_extend_session_stream_uses_new_ai_response_when_no_tokens(monkeypatch):
+    """연장 시작 스트림 토큰이 없으면 최종 상태의 새 AI 메시지만 응답으로 사용한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.stream_events = []
+
+    monkeypatch.setattr(
+        "features.interview.service.build_graph", lambda checkpointer=None: dummy_graph
+    )
+    monkeypatch.setattr("features.interview.service.get_checkpointer", lambda: object())
+    monkeypatch.setattr(
+        "features.interview.service.get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = InterviewService()
+
+    previous_messages = [AIMessage(content="정규 마지막 질문")]
+    initial_state = {
+        "session_id": "session-1",
+        "messages": previous_messages,
+        "all_stages_complete": True,
+        "extension_count": 0,
+    }
+    final_state = {
+        "messages": [*previous_messages, AIMessage(content="연장 질문")],
+        "current_stage": 4,
+        "stage_progress": {
+            "fixed_q_used": 3,
+            "fixed_q_total": 3,
+            "generated_q_used": 2,
+            "generated_q_max": 2,
+            "force_all_generated_q": False,
+            "is_complete": True,
+        },
+        "overall_completion_percentage": 100.0,
+        "all_stages_complete": False,
+        "is_extended_mode": True,
+        "extension_turns_used": 1,
+        "extension_turns_max": 18,
+        "extension_count": 1,
+    }
+    states = [initial_state, final_state]
+
+    async def _get_session_state(_session_id: str):
+        if states:
+            return states.pop(0)
+        return final_state
+
+    monkeypatch.setattr(service, "get_session_state", _get_session_state)
+
+    events = [event async for event in service.extend_session_stream(session_id="session-1")]
+
+    complete_event = next(
+        event for event in events if event["event"] == SSEEventType.MESSAGE_COMPLETE
+    )
+    complete_payload = json.loads(complete_event["data"])
+    assert complete_payload["message"]["ai_response"] == "연장 질문"
+
+
+@pytest.mark.anyio
 async def test_process_message_stream_sets_failed_status_on_exception(monkeypatch):
     """스트리밍 예외 발생 시 세션 status를 failed로 기록한다."""
     dummy_graph = DummyGraph()


### PR DESCRIPTION
## 📌 관련 이슈

- 없음 (프론트 문의 대응, 별도 이슈 미작성)

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 정규 인터뷰 4단계 마지막 답변 처리 중 완료가 감지되면 같은 그래프 실행에서 바로 연장 모드로 전환하도록 수정했습니다.
- 연장 가능 횟수가 남아 있으면 `question_generator`가 첫 추가 질문을 즉시 생성하고, `/chat`·`/chat/stream` 응답에 해당 질문이 내려가도록 했습니다.
- 이미 완료 상태로 저장된 기존 세션도 후속 채팅이 들어오면 자동으로 연장 모드에 진입하는 호환 fallback을 유지했습니다.
- 응답 추출은 이번 실행에서 새로 생성된 AI 메시지만 보도록 보강해, 과거 질문이 `ai_response`로 재전송되는 문제를 방지했습니다.
- 일반/스트리밍 서비스 경로와 Analyst 라우팅 회귀 테스트를 추가했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`188 files already formatted`)
  - `uv run pytest -q` 통과 (`741 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- `/extend` 및 `/extend/stream` 엔드포인트는 기존 클라이언트 호환을 위해 유지했습니다.
- 프론트는 정규 마지막 답변 이후 별도 `/extend` 호출 없이 기존 `/chat` 또는 `/chat/stream` 응답에서 첫 추가 질문을 받을 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 인터뷰 완료 후 설정된 횟수 내에서 자동으로 연장 모드로 전환되어 추가 질문을 진행할 수 있습니다.

* **Improvements**
  * AI 응답 처리 로직을 개선하여 메시지 처리의 일관성을 강화했습니다.

* **Tests**
  * 연장 모드 기능 및 자동 전환 시나리오에 대한 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->