### PR TITLE
[Fix] PPTX Worker 런타임 부팅 smoke 보강 [1.20]

### DIFF
--- a/apps/pptx-worker/Dockerfile
+++ b/apps/pptx-worker/Dockerfile
@@ -6,6 +6,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV UV_LINK_MODE=copy
 ENV UV_PYTHON=3.12
 ENV UV_PYTHON_DOWNLOADS=automatic
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
 ENV PORT=8080
 ENV JAVA_TOOL_OPTIONS=-Xmx512m
 ENV PPTX_WORKER_RECYCLE_AFTER=20
@@ -43,7 +44,7 @@ RUN mkdir -p /tmp \
     && bash apps/pptx-worker/scripts/verify_runtime_image.sh
 
 RUN useradd --create-home --uid 10001 appuser \
-    && chown -R appuser:appuser /app
+    && chown -R appuser:appuser /app /opt/uv-python
 
 USER appuser
 

--- a/apps/pptx-worker/pptx_worker/__init__.py
+++ b/apps/pptx-worker/pptx_worker/__init__.py
@@ -6,7 +6,7 @@ from importlib import import_module
 def __getattr__(name: str):
     """앱 진입점은 명시적으로 요청될 때만 로드한다."""
     if name != "create_app":
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        raise AttributeError(f"{__name__!r} 모듈에 {name!r} 속성이 없습니다.")
     module = import_module("pptx_worker.main")
     value = getattr(module, name)
     globals()[name] = value

--- a/apps/pptx-worker/pptx_worker/__init__.py
+++ b/apps/pptx-worker/pptx_worker/__init__.py
@@ -1,5 +1,16 @@
 """PPTX 시각화 워커 애플리케이션."""
 
-from .main import create_app
+from importlib import import_module
+
+
+def __getattr__(name: str):
+    """앱 진입점은 명시적으로 요청될 때만 로드한다."""
+    if name != "create_app":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module("pptx_worker.main")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
 
 __all__ = ["create_app"]

--- a/apps/pptx-worker/scripts/verify_runtime_image.sh
+++ b/apps/pptx-worker/scripts/verify_runtime_image.sh
@@ -6,16 +6,116 @@ command -v pdftoppm >/dev/null
 soffice --headless --version >/dev/null
 fc-match "Noto Sans CJK KR" | grep -qi "Noto"
 
-python - <<'PY'
+PYTHON_BIN=""
+for candidate in "${PYTHON:-}" /app/.venv/bin/python /app/.venv/bin/python3 python python3; do
+    if [[ -z "$candidate" ]]; then
+        continue
+    fi
+    if [[ "$candidate" == */* ]]; then
+        if [[ -x "$candidate" ]]; then
+            PYTHON_BIN="$candidate"
+            break
+        fi
+        continue
+    fi
+    if command -v "$candidate" >/dev/null; then
+        PYTHON_BIN="$(command -v "$candidate")"
+        break
+    fi
+done
+
+if [[ -z "$PYTHON_BIN" ]]; then
+    echo "python 실행 파일을 찾을 수 없습니다." >&2
+    exit 127
+fi
+
+"$PYTHON_BIN" - <<'PY'
+import importlib
+import os
+import subprocess
+import sys
+import textwrap
+
 import defusedxml  # noqa: F401
 import fastapi  # noqa: F401
+import langchain_openai  # noqa: F401
 import lxml.etree  # noqa: F401
 import markitdown  # noqa: F401
 import PIL  # noqa: F401
 import uvicorn  # noqa: F401
+from dotenv import load_dotenv  # noqa: F401
+from fastapi import FastAPI
 from google.cloud import storage, tasks_v2  # noqa: F401
+from langchain_core.messages import HumanMessage, SystemMessage  # noqa: F401
 
 import common  # noqa: F401
 import features.visualization.pptx.soffice_render  # noqa: F401
 import pptx_worker  # noqa: F401
+from features.visualization.pptx import (
+    ANTHROPIC_PPTX_SKILL_ENV,
+    PptxToolchain,
+    PptxToolchainError,
+)
+
+if "pptx_worker.main" in sys.modules:
+    raise RuntimeError("pptx_worker package import loaded pptx_worker.main eagerly")
+
+try:
+    PptxToolchain.from_env(env_var="FOLIOO_MISSING_PPTX_SKILL_DIR_SMOKE")
+except PptxToolchainError as exc:
+    if "환경변수가 설정되지 않았습니다" not in str(exc):
+        raise
+else:
+    raise RuntimeError("missing PPTX skill env smoke did not fail")
+
+if os.getenv(ANTHROPIC_PPTX_SKILL_ENV):
+    PptxToolchain.from_env().ensure_available()
+
+
+def run_import_order(module_names: tuple[str, ...]) -> None:
+    source = textwrap.dedent(
+        f"""
+        import importlib
+
+        from fastapi import FastAPI
+
+        for module_name in {module_names!r}:
+            importlib.import_module(module_name)
+
+        main = importlib.import_module("pptx_worker.main")
+        app = main.create_app()
+        if not isinstance(app, FastAPI):
+            raise TypeError(f"create_app returned {{type(app).__name__}}, expected FastAPI")
+
+        routes = {{route.path for route in app.routes}}
+        required = {{
+            "/health",
+            "/metrics",
+            "/tasks/visualizations/generate",
+            "/tasks/visualizations/regenerate",
+        }}
+        missing = sorted(required - routes)
+        if missing:
+            raise RuntimeError(f"worker app routes missing: {{missing}}")
+        """
+    )
+    subprocess.run(
+        [sys.executable, "-c", source],
+        check=True,
+        cwd=os.getcwd(),
+        env=os.environ.copy(),
+    )
+
+
+for import_order in (
+    ("features.visualization.service", "features.visualization.qa", "pptx_worker.main"),
+    ("features.visualization.qa", "features.visualization.service", "pptx_worker.main"),
+    ("pptx_worker.main", "features.visualization.service", "features.visualization.qa"),
+):
+    run_import_order(import_order)
+
+main = importlib.import_module("pptx_worker.main")
+app = main.create_app()
+if not isinstance(app, FastAPI):
+    raise TypeError(f"create_app returned {type(app).__name__}, expected FastAPI")
 PY

--- a/apps/pptx-worker/scripts/verify_runtime_image.sh
+++ b/apps/pptx-worker/scripts/verify_runtime_image.sh
@@ -62,9 +62,8 @@ if "pptx_worker.main" in sys.modules:
 
 try:
     PptxToolchain.from_env(env_var="FOLIOO_MISSING_PPTX_SKILL_DIR_SMOKE")
-except PptxToolchainError as exc:
-    if "환경변수가 설정되지 않았습니다" not in str(exc):
-        raise
+except PptxToolchainError:
+    pass
 else:
     raise RuntimeError("missing PPTX skill env smoke did not fail")
 

--- a/deploy/pptx-worker/README.md
+++ b/deploy/pptx-worker/README.md
@@ -34,6 +34,11 @@ docker run --rm \
   apps/pptx-worker/scripts/verify_runtime_image.sh
 ```
 
+이미지 build smoke는 `ANTHROPIC_PPTX_SKILL_DIR` 미설정 시 빠르게 실패하는 경로만
+검증한다. 실제 skill directory를 Secret/volume/env로 runtime에 주입하는 배포에서는
+동일한 스크립트를 runtime 환경에서 실행해 `PptxToolchain.ensure_available()`까지
+확인한다.
+
 ## Deploy
 
 Cloud Run 서비스는 `concurrency=1`, `timeout=1800s`, max instances 20, 2 vCPU,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,12 @@ pptx-worker = [
     "google-cloud-storage>=3.10.1",
     "google-cloud-tasks>=2.18.0",
     "httpx>=0.28.1",
+    "langchain-core>=1.2.3",
+    "langchain-openai>=1.1.7",
     "lxml>=6.0.0",
     "markitdown[pptx]>=0.1.3",
     "pillow>=11.0.0",
+    "python-dotenv>=1.2.1",
     "uvicorn[standard]>=0.40.0",
 ]
 

--- a/tasks/phase-1-pptx-worker/20-pptx-worker-runtime-boot-image-packaging.md
+++ b/tasks/phase-1-pptx-worker/20-pptx-worker-runtime-boot-image-packaging.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/10-cloud-run-deployment-config.md"
 depends_on: ["1.01", "1.05", "1.06", "1.07", "1.10"]
 blocks: ["1.26"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-05-28"
 owner: ""
 sprint: ""
 ---
@@ -26,29 +27,29 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #235 본문과 감사 로그의 circular import 재현 조건 확인
-- [ ] 전체 테스트 통과와 worker visualization 단독 테스트 실패가 다른 원인인지 재확인
-- [ ] 컨테이너 smoke 검증이 실행되는 위치와 배포 파이프라인 연결 지점 확인
+- [x] GitHub Issue #235 본문과 감사 로그의 circular import 재현 조건 확인
+- [x] 전체 테스트 통과와 worker visualization 단독 테스트 실패가 다른 원인인지 재확인
+- [x] 컨테이너 smoke 검증이 실행되는 위치와 배포 파이프라인 연결 지점 확인
 
 ## 구현 체크리스트
 
-- [ ] `features.visualization.service` 단독 import 실패 경로를 재현하는 테스트 또는 smoke 체크 추가
-- [ ] `pptx_worker.__init__`, 앱 진입점, router import 구조에서 불필요한 eager import 제거
-- [ ] `features.visualization.qa` 단독 import가 `pptx_worker.main` 순환 로딩을 유발하지 않도록 의존 방향 정리
-- [ ] `pptx_worker.main`, `features.visualization.service`, `features.visualization.qa` import 순서별 smoke 검증 추가
-- [ ] `pyproject.toml`의 `pptx-worker` dependency group과 실제 worker runtime import 목록 비교
-- [ ] worker runtime에 필요한 LangChain/OpenRouter/dotenv 계열 dependency를 컨테이너 설치 그룹에 반영
-- [ ] dev/test dependency에 기대어 컨테이너에서만 실패하는 import가 없는지 확인
-- [ ] `apps/pptx-worker/scripts/verify_runtime_image.sh`가 실제 worker app 생성 또는 FastAPI 진입점 import까지 확인하도록 보강
-- [ ] Anthropic PPTX toolchain 경로처럼 컨테이너 런타임 필수 환경이 누락되면 빠르게 실패하도록 smoke 체크 추가
+- [x] `features.visualization.service` 단독 import 실패 경로를 재현하는 테스트 또는 smoke 체크 추가
+- [x] `pptx_worker.__init__`, 앱 진입점, router import 구조에서 불필요한 eager import 제거
+- [x] `features.visualization.qa` 단독 import가 `pptx_worker.main` 순환 로딩을 유발하지 않도록 의존 방향 정리
+- [x] `pptx_worker.main`, `features.visualization.service`, `features.visualization.qa` import 순서별 smoke 검증 추가
+- [x] `pyproject.toml`의 `pptx-worker` dependency group과 실제 worker runtime import 목록 비교
+- [x] worker runtime에 필요한 LangChain/OpenRouter/dotenv 계열 dependency를 컨테이너 설치 그룹에 반영
+- [x] dev/test dependency에 기대어 컨테이너에서만 실패하는 import가 없는지 확인
+- [x] `apps/pptx-worker/scripts/verify_runtime_image.sh`가 실제 worker app 생성 또는 FastAPI 진입점 import까지 확인하도록 보강
+- [x] Anthropic PPTX toolchain 경로처럼 컨테이너 런타임 필수 환경이 누락되면 빠르게 실패하도록 smoke 체크 추가
 
 ## Definition of Done
 
-- [ ] `uv run ruff check .` 통과
-- [ ] `uv run pytest` 통과
-- [ ] `uv run pytest tests/test_pptx_worker/test_visualization -q` 단독 실행 통과
-- [ ] `features.visualization.service`, `features.visualization.qa`, `pptx_worker.main` 단독 import smoke 통과
-- [ ] Docker 이미지 smoke 검증에서 실제 worker 앱 부팅 경로와 필수 런타임 의존성 확인
+- [x] `uv run ruff check .` 통과
+- [x] `uv run pytest` 통과
+- [x] `uv run pytest tests/test_pptx_worker/test_visualization -q` 단독 실행 통과
+- [x] `features.visualization.service`, `features.visualization.qa`, `pptx_worker.main` 단독 import smoke 통과
+- [x] Docker 이미지 smoke 검증에서 실제 worker 앱 부팅 경로와 필수 런타임 의존성 확인
 
 ## 리스크 / 메모
 

--- a/tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
+++ b/tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
@@ -208,3 +208,18 @@ def test_deployment_readme_documents_required_auth_checks(expected: str) -> None
     readme = README.read_text()
 
     assert expected in readme
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        "이미지 build smoke는 `ANTHROPIC_PPTX_SKILL_DIR` 미설정 시 빠르게 실패하는 경로만",
+        "Secret/volume/env로 runtime에 주입",
+        "`PptxToolchain.ensure_available()`까지",
+    ],
+)
+def test_deployment_readme_documents_runtime_skill_smoke_scope(expected: str) -> None:
+    """PPTX skill directory smoke 범위가 build/runtime 경계를 설명한다."""
+    readme = README.read_text()
+
+    assert expected in readme

--- a/tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
+++ b/tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
@@ -1,5 +1,6 @@
 """PPTX 워커 Cloud Run 배포 설정 테스트."""
 
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ SERVICE_YAML = ROOT / "deploy" / "pptx-worker" / "cloud-run-service.yaml"
 CLOUDBUILD_YAML = ROOT / "deploy" / "pptx-worker" / "cloudbuild.yaml"
 README = ROOT / "deploy" / "pptx-worker" / "README.md"
 VERIFY_SCRIPT = ROOT / "apps" / "pptx-worker" / "scripts" / "verify_runtime_image.sh"
+PYPROJECT = ROOT / "pyproject.toml"
 
 
 def _load_service() -> dict:
@@ -74,9 +76,11 @@ def test_cloud_run_service_caps_java_heap_and_tmp_volume() -> None:
         "COPY common/ ./common/",
         "COPY features/visualization/ ./features/visualization/",
         "COPY apps/pptx-worker/ ./apps/pptx-worker/",
+        "UV_PYTHON_INSTALL_DIR=/opt/uv-python",
         "PYTHONPATH=/app:/app/apps/pptx-worker",
         "JAVA_TOOL_OPTIONS=-Xmx512m",
         "useradd --create-home --uid 10001 appuser",
+        "chown -R appuser:appuser /app /opt/uv-python",
         "USER appuser",
         "PORT:-8080",
         "pptx_worker.main:app",
@@ -102,18 +106,57 @@ def test_worker_dockerfile_excludes_unrelated_application_units() -> None:
 @pytest.mark.parametrize(
     "expected",
     [
+        "defusedxml>=0.7.1",
+        "fastapi>=0.128.0",
+        "google-cloud-storage>=3.10.1",
+        "google-cloud-tasks>=2.18.0",
+        "httpx>=0.28.1",
+        "langchain-core>=1.2.3",
+        "langchain-openai>=1.1.7",
+        "lxml>=6.0.0",
+        "markitdown[pptx]>=0.1.3",
+        "pillow>=11.0.0",
+        "python-dotenv>=1.2.1",
+        "uvicorn[standard]>=0.40.0",
+    ],
+)
+def test_pptx_worker_dependency_group_includes_runtime_imports(expected: str) -> None:
+    """워커 전용 dependency group 이 실제 앱 import 의존성을 포함한다."""
+    pyproject = tomllib.loads(PYPROJECT.read_text())
+
+    assert expected in pyproject["dependency-groups"]["pptx-worker"]
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
         "command -v soffice",
         "command -v pdftoppm",
         'fc-match "Noto Sans CJK KR"',
+        "PYTHON_BIN",
+        "/app/.venv/bin/python",
+        "python3",
         "import defusedxml",
         "import fastapi",
+        "import langchain_openai",
         "import lxml.etree",
         "import markitdown",
         "import PIL",
         "import uvicorn",
+        "from dotenv import load_dotenv",
         "from google.cloud import storage, tasks_v2",
+        "from langchain_core.messages import HumanMessage, SystemMessage",
         "import common",
         "import pptx_worker",
+        "ANTHROPIC_PPTX_SKILL_ENV",
+        "PptxToolchain.from_env",
+        "PptxToolchainError",
+        "ensure_available()",
+        "pptx_worker.main",
+        "main.create_app()",
+        "/tasks/visualizations/generate",
+        "/tasks/visualizations/regenerate",
+        "subprocess.run",
     ],
 )
 def test_runtime_image_smoke_script_checks_required_binaries_and_imports(

--- a/tests/test_pptx_worker/test_runtime_imports.py
+++ b/tests/test_pptx_worker/test_runtime_imports.py
@@ -1,0 +1,104 @@
+"""PPTX 워커 런타임 import smoke 테스트."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKER_PATH = ROOT / "apps" / "pptx-worker"
+
+
+def _worker_pythonpath() -> str:
+    paths = [str(ROOT), str(WORKER_PATH)]
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        paths.append(existing)
+    return os.pathsep.join(paths)
+
+
+def _run_python(source: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = _worker_pythonpath()
+    return subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_pptx_worker_package_import_does_not_eager_load_app() -> None:
+    """패키지 import 만으로 FastAPI 앱과 라우터를 로드하지 않는다."""
+    source = """
+import sys
+
+import pptx_worker  # noqa: F401
+
+eager_modules = {
+    "pptx_worker.main",
+    "pptx_worker.api",
+    "pptx_worker.api.tasks",
+} & set(sys.modules)
+if eager_modules:
+    raise RuntimeError(f"eager worker imports detected: {sorted(eager_modules)}")
+"""
+
+    _run_python(textwrap.dedent(source))
+
+
+def test_visualization_service_import_does_not_eager_load_worker_app() -> None:
+    """service 단독 import 가 pptx_worker.main 순환 로딩을 유발하지 않는다."""
+    source = """
+import sys
+
+import features.visualization.service  # noqa: F401
+
+if "pptx_worker.main" in sys.modules:
+    raise RuntimeError("features.visualization.service imported pptx_worker.main")
+"""
+
+    _run_python(textwrap.dedent(source))
+
+
+@pytest.mark.parametrize(
+    "module_names",
+    [
+        ("features.visualization.service", "features.visualization.qa", "pptx_worker.main"),
+        ("features.visualization.qa", "features.visualization.service", "pptx_worker.main"),
+        ("pptx_worker.main", "features.visualization.service", "features.visualization.qa"),
+    ],
+)
+def test_worker_runtime_import_order_boots_fastapi_app(module_names: tuple[str, ...]) -> None:
+    """주요 worker runtime 모듈은 import 순서와 무관하게 앱을 생성한다."""
+    source = f"""
+import importlib
+
+from fastapi import FastAPI
+
+for module_name in {module_names!r}:
+    importlib.import_module(module_name)
+
+main = importlib.import_module("pptx_worker.main")
+app = main.create_app()
+if not isinstance(app, FastAPI):
+    raise TypeError(f"create_app returned {{type(app).__name__}}, expected FastAPI")
+
+routes = {{route.path for route in app.routes}}
+required = {{
+    "/health",
+    "/metrics",
+    "/tasks/visualizations/generate",
+    "/tasks/visualizations/regenerate",
+}}
+missing = sorted(required - routes)
+if missing:
+    raise RuntimeError(f"worker app routes missing: {{missing}}")
+"""
+
+    _run_python(textwrap.dedent(source))

--- a/tests/test_pptx_worker/test_runtime_imports.py
+++ b/tests/test_pptx_worker/test_runtime_imports.py
@@ -13,6 +13,7 @@ WORKER_PATH = ROOT / "apps" / "pptx-worker"
 
 
 def _worker_pythonpath() -> str:
+    """fresh subprocess 가 worker package를 찾도록 PYTHONPATH를 만든다."""
     paths = [str(ROOT), str(WORKER_PATH)]
     existing = os.environ.get("PYTHONPATH")
     if existing:
@@ -21,16 +22,23 @@ def _worker_pythonpath() -> str:
 
 
 def _run_python(source: str) -> subprocess.CompletedProcess[str]:
+    """격리 Python 프로세스를 실행하고 실패 출력을 pytest 메시지에 포함한다."""
     env = os.environ.copy()
     env["PYTHONPATH"] = _worker_pythonpath()
-    return subprocess.run(
+    result = subprocess.run(
         [sys.executable, "-c", source],
         cwd=ROOT,
         env=env,
-        check=True,
         text=True,
         capture_output=True,
     )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"worker import smoke 실패 (exit={result.returncode}):\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result
 
 
 def test_pptx_worker_package_import_does_not_eager_load_app() -> None:
@@ -61,6 +69,20 @@ import features.visualization.service  # noqa: F401
 
 if "pptx_worker.main" in sys.modules:
     raise RuntimeError("features.visualization.service imported pptx_worker.main")
+"""
+
+    _run_python(textwrap.dedent(source))
+
+
+def test_visualization_qa_import_does_not_eager_load_worker_app() -> None:
+    """qa 단독 import 가 pptx_worker.main 순환 로딩을 유발하지 않는다."""
+    source = """
+import sys
+
+import features.visualization.qa  # noqa: F401
+
+if "pptx_worker.main" in sys.modules:
+    raise RuntimeError("features.visualization.qa imported pptx_worker.main")
 """
 
     _run_python(textwrap.dedent(source))

--- a/uv.lock
+++ b/uv.lock
@@ -433,9 +433,12 @@ pptx-worker = [
     { name = "google-cloud-storage" },
     { name = "google-cloud-tasks" },
     { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-openai" },
     { name = "lxml" },
     { name = "markitdown", extra = ["pptx"] },
     { name = "pillow" },
+    { name = "python-dotenv" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 template-tools = [
@@ -481,9 +484,12 @@ pptx-worker = [
     { name = "google-cloud-storage", specifier = ">=3.10.1" },
     { name = "google-cloud-tasks", specifier = ">=2.18.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "langchain-core", specifier = ">=1.2.3" },
+    { name = "langchain-openai", specifier = ">=1.1.7" },
     { name = "lxml", specifier = ">=6.0.0" },
     { name = "markitdown", extras = ["pptx"], specifier = ">=0.1.3" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.40.0" },
 ]
 template-tools = [


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #235

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `pptx_worker` 패키지 import 시 FastAPI 앱을 eager load하지 않도록 `create_app` export를 lazy import로 변경했습니다.
- `features.visualization.service`, `features.visualization.qa`, `pptx_worker.main` import 순서와 무관하게 worker 앱이 생성되는 subprocess smoke 테스트를 추가했습니다.
- Docker `pptx-worker` dependency group에 실제 worker runtime import에 필요한 LangChain/OpenRouter/dotenv 계열 패키지를 반영했습니다.
- `uv` managed Python을 `/opt/uv-python`에 설치하도록 Dockerfile을 보강해 runtime `appuser`가 venv Python과 site-packages를 안정적으로 사용할 수 있게 했습니다.
- 이미지 smoke 스크립트가 필수 binary/import, FastAPI app 생성, worker route 존재, Anthropic PPTX toolchain env fail-fast 경로를 검증하도록 확장했습니다.
- Task 1.20 문서를 완료 상태로 갱신했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`189 files already formatted`)
  - `uv run pytest` 통과 (`777 passed`)
  - `uv run pytest tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py tests/test_pptx_worker/test_runtime_imports.py -q` 통과 (`78 passed`)
  - `sudo docker build --no-cache -f apps/pptx-worker/Dockerfile -t folioo-pptx-worker-smoke:task-20 .` 통과
  - `sudo docker run --rm --entrypoint bash folioo-pptx-worker-smoke:task-20 apps/pptx-worker/scripts/verify_runtime_image.sh` 통과

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 배포 IAM, Secret Manager, GCS 권한 검증은 Task 1.21 범위로 남겼습니다.
- smoke 스크립트는 성공 시 출력 없이 종료하며, 실패 시 traceback 또는 shell error로 즉시 실패합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * PPTX 워커 런타임 안정성 및 권한 관리 개선
  * 모듈 초기화 방식 최적화로 성능 향상

* **Chores**
  * 런타임 의존성 업데이트 (langchain-core 추가)
  * 배포 환경 검증 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->