### PR TITLE
[Fix] Visual QA 안정화: 병렬 처리와 검증 강화 [1.23]

### DIFF
--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -19,7 +19,12 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from common.llm.client import get_file_processor_llm
 from features.visualization.fills import merge_current_fills
 from features.visualization.main_client import VisualizationMainClient
-from features.visualization.pptx import PptxRenderer, PptxToolchain, SlideEditor
+from features.visualization.pptx import (
+    PptxRenderer,
+    PptxToolchain,
+    PptxToolchainError,
+    SlideEditor,
+)
 from features.visualization.storage.gcs_client import GcsClient
 
 logger = logging.getLogger(__name__)
@@ -170,6 +175,15 @@ class _PendingSlide:
     last_result: VisualQAResult | None = None
 
 
+@dataclass(frozen=True)
+class _SlideCheckResult:
+    """비동기 QA 호출 하나의 결과."""
+
+    slide_order: int
+    qa_result: VisualQAResult
+    had_exception: bool = False
+
+
 class VisualQA:
     """렌더된 슬라이드 이미지를 비전 LLM으로 검사한다."""
 
@@ -265,10 +279,13 @@ class VisualQAFixVerifyStep:
         renderer: PptxRenderer,
         fixer: FixInstructionBuilder | None = None,
         max_fix_attempts: int = 2,
+        max_qa_concurrency: int = 4,
         clock: Any | None = None,
     ) -> None:
         if max_fix_attempts < 0:
             raise ValueError("max_fix_attempts는 0 이상이어야 합니다.")
+        if max_qa_concurrency <= 0:
+            raise ValueError("max_qa_concurrency는 1 이상이어야 합니다.")
         self._qa = qa
         self._storage = storage
         self._main_client = main_client
@@ -277,6 +294,7 @@ class VisualQAFixVerifyStep:
         self._renderer = renderer
         self._fixer = fixer or LLMVisualFixer(editor=editor)
         self._max_fix_attempts = max_fix_attempts
+        self._max_qa_concurrency = max_qa_concurrency
         self._clock = clock or (lambda: datetime.now(UTC))
 
     async def process(
@@ -332,31 +350,86 @@ class VisualQAFixVerifyStep:
             recheck_failed_orders: list[int] = []
 
             if fixed_orders:
-                fixed_pptx.parent.mkdir(parents=True, exist_ok=True)
-                self._toolchain.pack(unpacked_root, fixed_pptx, original_pptx=working_pptx)
-                pack_count += 1
+                try:
+                    self._pack_and_validate_fixed_pptx(
+                        unpacked_root=unpacked_root,
+                        fixed_pptx=fixed_pptx,
+                        working_pptx=working_pptx,
+                        attempt=fix_attempts,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "visual QA fixed PPTX validation failed: orders=%s attempt=%s error=%s",
+                        fixed_orders,
+                        fix_attempts,
+                        exc,
+                    )
+                    self._mark_orders_failed(
+                        pending,
+                        fixed_orders,
+                        code="pptx_validation_failed",
+                        message=f"자동 수정 산출물 검증에 실패했습니다: {exc}",
+                        retryable=True,
+                    )
+                    failed_orders = [*unfixed_orders, *fixed_orders]
+                    continue
 
-                render_page = fixed_orders[0] if len(fixed_orders) == 1 else None
-                render_result = self._renderer.render(fixed_pptx, render_dir, page=render_page)
-                render_count += 1
+                pack_count += 1
+                try:
+                    render_page = fixed_orders[0] if len(fixed_orders) == 1 else None
+                    render_result = self._renderer.render(fixed_pptx, render_dir, page=render_page)
+                    render_count += 1
+                except Exception as exc:
+                    logger.warning(
+                        "visual QA fixed PPTX render failed: orders=%s attempt=%s error=%s",
+                        fixed_orders,
+                        fix_attempts,
+                        exc,
+                    )
+                    self._mark_orders_failed(
+                        pending,
+                        fixed_orders,
+                        code="pptx_render_failed",
+                        message=f"자동 수정 산출물 렌더링에 실패했습니다: {exc}",
+                        retryable=True,
+                    )
+                    failed_orders = [*unfixed_orders, *fixed_orders]
+                    continue
+
                 rendered_by_page = {
                     rendered.page: rendered.image_path for rendered in render_result.slides
                 }
+                rendered_orders: list[int] = []
+                missing_orders: list[int] = []
                 for slide_order in fixed_orders:
-                    if slide_order not in rendered_by_page:
-                        raise RuntimeError(
-                            f"재렌더 결과에 slide_order={slide_order} 이미지가 없습니다."
-                        )
-                    pending[slide_order].image_path = rendered_by_page[slide_order]
+                    rendered_image = rendered_by_page.get(slide_order)
+                    if rendered_image is None:
+                        missing_orders.append(slide_order)
+                        continue
+                    pending[slide_order].image_path = rendered_image
+                    rendered_orders.append(slide_order)
 
-                recheck_failed_orders = await self._check_and_publish_passes(
-                    job_id=job_id,
-                    pending=pending,
-                    candidate_orders=fixed_orders,
-                    outcomes=outcomes,
-                    checked_orders=checked_orders,
-                    ready_event=ready_event,
-                )
+                if missing_orders:
+                    self._mark_orders_failed(
+                        pending,
+                        tuple(missing_orders),
+                        code="pptx_render_missing_slide",
+                        message="재렌더 결과에 슬라이드 이미지가 없습니다.",
+                        retryable=True,
+                    )
+
+                if rendered_orders:
+                    recheck_failed_orders = await self._check_and_publish_passes(
+                        job_id=job_id,
+                        pending=pending,
+                        candidate_orders=tuple(rendered_orders),
+                        outcomes=outcomes,
+                        checked_orders=checked_orders,
+                        ready_event=ready_event,
+                    )
+                else:
+                    recheck_failed_orders = []
+                recheck_failed_orders = [*missing_orders, *recheck_failed_orders]
 
             failed_orders = [*unfixed_orders, *recheck_failed_orders]
 
@@ -401,36 +474,138 @@ class VisualQAFixVerifyStep:
         checked_orders: list[int],
         ready_event: str | None,
     ) -> list[int]:
-        failed_orders: list[int] = []
-        for slide_order in candidate_orders:
-            if slide_order in outcomes:
-                continue
-            pending_slide = pending[slide_order]
-            qa_result = await asyncio.to_thread(
-                self._qa.check_slide,
-                pending_slide.image_path,
-                _expected_content(pending_slide.slide),
+        check_orders = tuple(
+            slide_order for slide_order in candidate_orders if slide_order not in outcomes
+        )
+        if not check_orders:
+            return []
+
+        failed_order_set: set[int] = set()
+        semaphore = asyncio.Semaphore(self._max_qa_concurrency)
+        tasks = [
+            asyncio.create_task(
+                self._check_one_slide(
+                    pending_slide=pending[slide_order],
+                    semaphore=semaphore,
+                )
             )
-            pending_slide.qa_attempts += 1
-            pending_slide.last_result = qa_result
-            checked_orders.append(slide_order)
-            if qa_result.passed:
-                gcs_key = await self._upload_and_send_ready(
-                    job_id,
-                    pending_slide,
-                    ready_event=ready_event,
+            for slide_order in check_orders
+        ]
+        try:
+            for future in asyncio.as_completed(tasks):
+                check_result = await future
+                slide_order = check_result.slide_order
+                pending_slide = pending[slide_order]
+                qa_result = check_result.qa_result
+
+                pending_slide.qa_attempts += 1
+                pending_slide.last_result = qa_result
+                checked_orders.append(slide_order)
+
+                if check_result.had_exception:
+                    await self._send_preview_error(
+                        job_id,
+                        pending_slide.slide,
+                        message=_format_issue_message(qa_result.issues),
+                        retryable=_issues_retryable(qa_result.issues),
+                    )
+                    outcomes[slide_order] = self._error_outcome(pending_slide, qa_result.issues)
+                    continue
+
+                if qa_result.passed:
+                    outcomes[slide_order] = await self._publish_ready_or_error(
+                        job_id,
+                        pending_slide,
+                        ready_event=ready_event,
+                    )
+                    continue
+
+                failed_order_set.add(slide_order)
+        except Exception:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
+        return [slide_order for slide_order in check_orders if slide_order in failed_order_set]
+
+    async def _check_one_slide(
+        self,
+        *,
+        pending_slide: _PendingSlide,
+        semaphore: asyncio.Semaphore,
+    ) -> _SlideCheckResult:
+        slide = pending_slide.slide
+        async with semaphore:
+            try:
+                qa_result = await asyncio.to_thread(
+                    self._qa.check_slide,
+                    pending_slide.image_path,
+                    _expected_content(slide),
                 )
-                outcomes[slide_order] = SlidePreviewOutcome(
-                    slide_id=pending_slide.slide.slide_id,
-                    slide_order=slide_order,
-                    status="ready",
-                    qa_attempts=pending_slide.qa_attempts,
-                    gcs_preview_key=gcs_key,
-                    current_fills=pending_slide.slide.current_fills,
+            except Exception as exc:
+                logger.warning(
+                    "visual QA check failed: slide_order=%s error=%s",
+                    slide.slide_order,
+                    exc,
                 )
-                continue
-            failed_orders.append(slide_order)
-        return failed_orders
+                return _SlideCheckResult(
+                    slide_order=slide.slide_order,
+                    qa_result=VisualQAResult(
+                        passed=False,
+                        issues=(
+                            VisualQAIssue(
+                                code="visual_qa_exception",
+                                message=f"시각 QA 호출에 실패했습니다: {exc}",
+                                retryable=True,
+                            ),
+                        ),
+                    ),
+                    had_exception=True,
+                )
+        return _SlideCheckResult(slide_order=slide.slide_order, qa_result=qa_result)
+
+    async def _publish_ready_or_error(
+        self,
+        job_id: str,
+        pending_slide: _PendingSlide,
+        *,
+        ready_event: str | None,
+    ) -> SlidePreviewOutcome:
+        try:
+            gcs_key = await self._upload_and_send_ready(
+                job_id,
+                pending_slide,
+                ready_event=ready_event,
+            )
+        except Exception as exc:
+            logger.warning(
+                "visual QA preview publish failed: slide_order=%s error=%s",
+                pending_slide.slide.slide_order,
+                exc,
+            )
+            issue = VisualQAIssue(
+                code="preview_publish_failed",
+                message=f"프리뷰 업로드 또는 콜백에 실패했습니다: {exc}",
+                retryable=True,
+            )
+            pending_slide.last_result = VisualQAResult(passed=False, issues=(issue,))
+            await self._send_preview_error(
+                job_id,
+                pending_slide.slide,
+                message=_format_issue_message((issue,)),
+                retryable=issue.retryable,
+            )
+            return self._error_outcome(pending_slide, (issue,))
+
+        return SlidePreviewOutcome(
+            slide_id=pending_slide.slide.slide_id,
+            slide_order=pending_slide.slide.slide_order,
+            status="ready",
+            qa_attempts=pending_slide.qa_attempts,
+            gcs_preview_key=gcs_key,
+            current_fills=pending_slide.slide.current_fills,
+        )
 
     async def _apply_fixes(
         self,
@@ -485,6 +660,63 @@ class VisualQAFixVerifyStep:
                 continue
             fixed_orders.append(slide_order)
         return tuple(fixed_orders)
+
+    def _pack_and_validate_fixed_pptx(
+        self,
+        *,
+        unpacked_root: Path,
+        fixed_pptx: Path,
+        working_pptx: Path,
+        attempt: int,
+    ) -> None:
+        candidate_pptx = _candidate_fixed_pptx_path(fixed_pptx, attempt)
+        candidate_pptx.parent.mkdir(parents=True, exist_ok=True)
+        candidate_pptx.unlink(missing_ok=True)
+
+        self._toolchain.pack(unpacked_root, candidate_pptx, original_pptx=working_pptx)
+        validation = self._toolchain.validate(unpacked_root, original_pptx=working_pptx)
+        if not validation.success:
+            repair_result = self._toolchain.repair(unpacked_root, original_pptx=working_pptx)
+            if not repair_result.success:
+                candidate_pptx.unlink(missing_ok=True)
+                raise PptxToolchainError(
+                    _validation_error_message("PPTX auto-repair 실패", repair_result)
+                )
+            self._toolchain.pack(unpacked_root, candidate_pptx, original_pptx=working_pptx)
+            validation = self._toolchain.validate(unpacked_root, original_pptx=working_pptx)
+            if not validation.success:
+                candidate_pptx.unlink(missing_ok=True)
+                raise PptxToolchainError(
+                    _validation_error_message("PPTX 검증이 repair 이후에도 실패", validation)
+                )
+
+        candidate_pptx.replace(fixed_pptx)
+
+    def _mark_orders_failed(
+        self,
+        pending: dict[int, _PendingSlide],
+        slide_orders: tuple[int, ...],
+        *,
+        code: str,
+        message: str,
+        retryable: bool,
+    ) -> None:
+        issue = VisualQAIssue(code=code, message=message, retryable=retryable)
+        for slide_order in slide_orders:
+            pending[slide_order].last_result = VisualQAResult(passed=False, issues=(issue,))
+
+    def _error_outcome(
+        self,
+        pending_slide: _PendingSlide,
+        issues: tuple[VisualQAIssue, ...],
+    ) -> SlidePreviewOutcome:
+        return SlidePreviewOutcome(
+            slide_id=pending_slide.slide.slide_id,
+            slide_order=pending_slide.slide.slide_order,
+            status="error",
+            qa_attempts=pending_slide.qa_attempts,
+            issues=issues,
+        )
 
     async def _upload_and_send_ready(
         self,
@@ -728,6 +960,16 @@ def _slide_xml_path(unpacked_root: Path, slide_filename: str) -> Path:
     if not path.is_file():
         raise FileNotFoundError(f"슬라이드 XML을 찾을 수 없습니다: {path}")
     return path
+
+
+def _candidate_fixed_pptx_path(fixed_pptx: Path, attempt: int) -> Path:
+    return fixed_pptx.with_name(f"{fixed_pptx.stem}.attempt-{attempt}{fixed_pptx.suffix}")
+
+
+def _validation_error_message(reason: str, validation: object) -> str:
+    stdout = getattr(validation, "stdout", "")
+    stderr = getattr(validation, "stderr", "")
+    return f"{reason}.\nstdout:\n{stdout}\nstderr:\n{stderr}"
 
 
 def _idempotency_key(job_id: str, slide: SlidePreview, event: str) -> str:

--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -8,7 +8,7 @@ import json
 import logging
 import mimetypes
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -16,7 +16,7 @@ from typing import Any, Literal, Protocol
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from common.llm.client import get_file_processor_llm
+from common.llm.client import get_file_processor_llm, get_file_processor_llm_uncached
 from features.visualization.fills import merge_current_fills
 from features.visualization.main_client import VisualizationMainClient
 from features.visualization.pptx import (
@@ -187,8 +187,16 @@ class _SlideCheckResult:
 class VisualQA:
     """렌더된 슬라이드 이미지를 비전 LLM으로 검사한다."""
 
-    def __init__(self, llm: VisionLLM | None = None) -> None:
+    def __init__(
+        self,
+        llm: VisionLLM | None = None,
+        *,
+        llm_factory: Callable[[], VisionLLM] | None = None,
+    ) -> None:
+        if llm is not None and llm_factory is not None:
+            raise ValueError("llm과 llm_factory는 동시에 설정할 수 없습니다.")
         self._llm = llm
+        self._llm_factory = llm_factory
 
     def check_slide(
         self,
@@ -200,7 +208,7 @@ class VisualQA:
         if not image_path.is_file():
             raise FileNotFoundError(f"슬라이드 프리뷰 이미지를 찾을 수 없습니다: {image_path}")
 
-        llm = self._llm or get_file_processor_llm()
+        llm = self._get_llm()
         messages = [
             SystemMessage(content=_QA_SYSTEM_PROMPT),
             HumanMessage(
@@ -219,6 +227,13 @@ class VisualQA:
         response = llm.invoke(messages)
         response_text = _normalize_response_text(getattr(response, "content", response))
         return _parse_qa_response(response_text)
+
+    def _get_llm(self) -> VisionLLM:
+        if self._llm is not None:
+            return self._llm
+        if self._llm_factory is not None:
+            return self._llm_factory()
+        return get_file_processor_llm_uncached()
 
 
 class LLMVisualFixer:
@@ -364,14 +379,16 @@ class VisualQAFixVerifyStep:
                         fix_attempts,
                         exc,
                     )
-                    self._mark_orders_failed(
-                        pending,
-                        fixed_orders,
+                    await self._finalize_slide_errors(
+                        job_id=job_id,
+                        pending=pending,
+                        outcomes=outcomes,
+                        slide_orders=fixed_orders,
                         code="pptx_validation_failed",
                         message=f"자동 수정 산출물 검증에 실패했습니다: {exc}",
                         retryable=True,
                     )
-                    failed_orders = [*unfixed_orders, *fixed_orders]
+                    failed_orders = unfixed_orders
                     continue
 
                 pack_count += 1
@@ -386,14 +403,16 @@ class VisualQAFixVerifyStep:
                         fix_attempts,
                         exc,
                     )
-                    self._mark_orders_failed(
-                        pending,
-                        fixed_orders,
+                    await self._finalize_slide_errors(
+                        job_id=job_id,
+                        pending=pending,
+                        outcomes=outcomes,
+                        slide_orders=fixed_orders,
                         code="pptx_render_failed",
                         message=f"자동 수정 산출물 렌더링에 실패했습니다: {exc}",
                         retryable=True,
                     )
-                    failed_orders = [*unfixed_orders, *fixed_orders]
+                    failed_orders = unfixed_orders
                     continue
 
                 rendered_by_page = {
@@ -410,9 +429,11 @@ class VisualQAFixVerifyStep:
                     rendered_orders.append(slide_order)
 
                 if missing_orders:
-                    self._mark_orders_failed(
-                        pending,
-                        tuple(missing_orders),
+                    await self._finalize_slide_errors(
+                        job_id=job_id,
+                        pending=pending,
+                        outcomes=outcomes,
+                        slide_orders=tuple(missing_orders),
                         code="pptx_render_missing_slide",
                         message="재렌더 결과에 슬라이드 이미지가 없습니다.",
                         retryable=True,
@@ -429,7 +450,6 @@ class VisualQAFixVerifyStep:
                     )
                 else:
                     recheck_failed_orders = []
-                recheck_failed_orders = [*missing_orders, *recheck_failed_orders]
 
             failed_orders = [*unfixed_orders, *recheck_failed_orders]
 
@@ -456,7 +476,7 @@ class VisualQAFixVerifyStep:
 
         result = VisualQAPipelineResult(
             outcomes=tuple(outcomes[key] for key in sorted(outcomes)),
-            qa_checked_slide_orders=tuple(checked_orders),
+            qa_checked_slide_orders=tuple(sorted(checked_orders)),
             fix_attempts=fix_attempts,
             pack_count=pack_count,
             render_count=render_count,
@@ -692,18 +712,28 @@ class VisualQAFixVerifyStep:
 
         candidate_pptx.replace(fixed_pptx)
 
-    def _mark_orders_failed(
+    async def _finalize_slide_errors(
         self,
-        pending: dict[int, _PendingSlide],
-        slide_orders: tuple[int, ...],
         *,
+        job_id: str,
+        pending: dict[int, _PendingSlide],
+        outcomes: dict[int, SlidePreviewOutcome],
+        slide_orders: tuple[int, ...],
         code: str,
         message: str,
         retryable: bool,
     ) -> None:
         issue = VisualQAIssue(code=code, message=message, retryable=retryable)
         for slide_order in slide_orders:
-            pending[slide_order].last_result = VisualQAResult(passed=False, issues=(issue,))
+            pending_slide = pending[slide_order]
+            pending_slide.last_result = VisualQAResult(passed=False, issues=(issue,))
+            await self._send_preview_error(
+                job_id,
+                pending_slide.slide,
+                message=_format_issue_message((issue,)),
+                retryable=retryable,
+            )
+            outcomes[slide_order] = self._error_outcome(pending_slide, (issue,))
 
     def _error_outcome(
         self,

--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -8,7 +8,7 @@ import json
 import logging
 import mimetypes
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -193,6 +193,11 @@ class VisualQA:
         *,
         llm_factory: Callable[[], VisionLLM] | None = None,
     ) -> None:
+        """QA 클라이언트를 초기화한다.
+
+        llm_factory 는 병렬 QA worker thread 에서 호출되므로 thread-safe 하거나
+        호출마다 독립적인 LLM 클라이언트를 반환해야 한다.
+        """
         if llm is not None and llm_factory is not None:
             raise ValueError("llm과 llm_factory는 동시에 설정할 수 없습니다.")
         self._llm = llm
@@ -366,7 +371,7 @@ class VisualQAFixVerifyStep:
 
             if fixed_orders:
                 try:
-                    self._pack_and_validate_fixed_pptx(
+                    pack_count += self._pack_and_validate_fixed_pptx(
                         unpacked_root=unpacked_root,
                         fixed_pptx=fixed_pptx,
                         working_pptx=working_pptx,
@@ -391,7 +396,6 @@ class VisualQAFixVerifyStep:
                     failed_orders = unfixed_orders
                     continue
 
-                pack_count += 1
                 try:
                     render_page = fixed_orders[0] if len(fixed_orders) == 1 else None
                     render_result = self._renderer.render(fixed_pptx, render_dir, page=render_page)
@@ -688,11 +692,12 @@ class VisualQAFixVerifyStep:
         fixed_pptx: Path,
         working_pptx: Path,
         attempt: int,
-    ) -> None:
+    ) -> int:
         candidate_pptx = _candidate_fixed_pptx_path(fixed_pptx, attempt)
         candidate_pptx.parent.mkdir(parents=True, exist_ok=True)
         candidate_pptx.unlink(missing_ok=True)
 
+        pack_count = 1
         self._toolchain.pack(unpacked_root, candidate_pptx, original_pptx=working_pptx)
         validation = self._toolchain.validate(unpacked_root, original_pptx=working_pptx)
         if not validation.success:
@@ -702,6 +707,7 @@ class VisualQAFixVerifyStep:
                 raise PptxToolchainError(
                     _validation_error_message("PPTX auto-repair 실패", repair_result)
                 )
+            pack_count += 1
             self._toolchain.pack(unpacked_root, candidate_pptx, original_pptx=working_pptx)
             validation = self._toolchain.validate(unpacked_root, original_pptx=working_pptx)
             if not validation.success:
@@ -711,6 +717,7 @@ class VisualQAFixVerifyStep:
                 )
 
         candidate_pptx.replace(fixed_pptx)
+        return pack_count
 
     async def _finalize_slide_errors(
         self,
@@ -718,7 +725,7 @@ class VisualQAFixVerifyStep:
         job_id: str,
         pending: dict[int, _PendingSlide],
         outcomes: dict[int, SlidePreviewOutcome],
-        slide_orders: tuple[int, ...],
+        slide_orders: Sequence[int],
         code: str,
         message: str,
         retryable: bool,

--- a/common/llm/client.py
+++ b/common/llm/client.py
@@ -83,12 +83,23 @@ def get_file_processor_llm(
 ) -> ChatOpenAI:
     """FileProcessor 노드 전용 Vision LLM 클라이언트 반환"""
 
-    file_processor_model = model or os.getenv(
-        "FILE_PROCESSOR_MODEL_NAME", "google/gemini-3.1-pro-preview"
+    return _build_llm(
+        model=_file_processor_model(model),
+        temperature=temperature,
+        timeout=120,
+        disable_streaming=True,
+        max_retries=0,
     )
 
+
+def get_file_processor_llm_uncached(
+    model: str | None = None,
+    temperature: float = 0.0,
+) -> ChatOpenAI:
+    """FileProcessor 노드 전용 Vision LLM 클라이언트를 캐시 없이 반환"""
+
     return _build_llm(
-        model=file_processor_model,
+        model=_file_processor_model(model),
         temperature=temperature,
         timeout=120,
         disable_streaming=True,
@@ -104,3 +115,7 @@ def get_llm_uncached(
     """캐싱 없이 새 LLM 인스턴스 반환 (테스트/특수 케이스용)"""
 
     return _build_llm(model=model, temperature=temperature, timeout=timeout)
+
+
+def _file_processor_model(model: str | None) -> str:
+    return model or os.getenv("FILE_PROCESSOR_MODEL_NAME", "google/gemini-3.1-pro-preview")

--- a/tests/test_features/test_interview/test_file_processor.py
+++ b/tests/test_features/test_interview/test_file_processor.py
@@ -316,3 +316,26 @@ def test_get_file_processor_llm_uses_dedicated_configuration(monkeypatch):
     assert captured["disable_streaming"] is True
     assert captured["max_retries"] == 0
     llm_client.get_file_processor_llm.cache_clear()
+
+
+def test_get_file_processor_llm_uncached_returns_new_instances(monkeypatch):
+    """캐시 없는 FileProcessor LLM helper는 호출마다 새 클라이언트를 만든다."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://example.test")
+    monkeypatch.setenv("FILE_PROCESSOR_MODEL_NAME", "google/gemini-test")
+
+    captured: list[dict[str, object]] = []
+
+    class _FakeChatOpenAI:
+        def __init__(self, **kwargs):
+            captured.append(kwargs)
+
+    monkeypatch.setattr(llm_client, "ChatOpenAI", _FakeChatOpenAI)
+
+    first = llm_client.get_file_processor_llm_uncached()
+    second = llm_client.get_file_processor_llm_uncached()
+
+    assert isinstance(first, _FakeChatOpenAI)
+    assert isinstance(second, _FakeChatOpenAI)
+    assert first is not second
+    assert [item["model"] for item in captured] == ["google/gemini-test", "google/gemini-test"]

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -254,6 +254,20 @@ class FakeRenderer:
         return FakeRenderResult(slides=tuple(rendered))
 
 
+class FailingRenderer(FakeRenderer):
+    """렌더 단계 실패 대역."""
+
+    def render(
+        self,
+        pptx_path: Path,
+        output_dir: Path,
+        *,
+        page: int | None = None,
+    ) -> FakeRenderResult:
+        self.calls.append((pptx_path, output_dir, page))
+        raise RuntimeError("render failed")
+
+
 def test_visual_qa_classifies_passed_and_issue_slides(tmp_path: Path) -> None:
     """LLM JSON 응답을 통과/이슈 결과로 파싱한다."""
     image_path = tmp_path / "slide-01.jpg"
@@ -295,6 +309,38 @@ def test_visual_qa_parses_first_json_object_from_wrapped_response(tmp_path: Path
 
     assert result.passed is True
     assert result.issues == ()
+
+
+def test_visual_qa_factory_creates_llm_per_check(tmp_path: Path) -> None:
+    """기본 병렬 QA 경로에서 호출별 LLM 분리가 가능하도록 factory 를 사용한다."""
+    image_path = tmp_path / "slide-01.jpg"
+    _write_jpeg(image_path, width=800, height=450)
+    llms = [
+        FakeLLM(['{"passed": true, "issues": []}']),
+        FakeLLM(['{"passed": true, "issues": []}']),
+    ]
+    created: list[FakeLLM] = []
+
+    def llm_factory() -> FakeLLM:
+        llm = llms.pop(0)
+        created.append(llm)
+        return llm
+
+    qa = VisualQA(llm_factory=llm_factory)
+
+    qa.check_slide(image_path, {"brief": "표지"})
+    qa.check_slide(image_path, {"brief": "본문"})
+
+    assert len(created) == 2
+    assert created[0] is not created[1]
+    assert len(created[0].messages) == 1
+    assert len(created[1].messages) == 1
+
+
+def test_visual_qa_rejects_llm_and_factory_together() -> None:
+    """LLM 공유 객체와 factory 를 동시에 주입하는 잘못된 설정을 막는다."""
+    with pytest.raises(ValueError, match="동시에 설정"):
+        VisualQA(llm=FakeLLM([]), llm_factory=lambda: FakeLLM([]))
 
 
 def test_llm_visual_fixer_preserves_guardrails_in_prompt(tmp_path: Path) -> None:
@@ -532,7 +578,7 @@ async def test_fix_validation_failure_blocks_preview_ready_and_reports_slide_err
     context.toolchain.repair_results = [FakeValidation(success=False, stderr="repair failed")]
     qa = FakeQA({1: [_failed("overflow")]})
     renderer = FakeRenderer(pages=[1])
-    step = context.make_step(qa=qa, renderer=renderer, max_fix_attempts=1)
+    step = context.make_step(qa=qa, renderer=renderer)
 
     result = await step.process(
         job_id="job-1",
@@ -543,6 +589,7 @@ async def test_fix_validation_failure_blocks_preview_ready_and_reports_slide_err
         render_output_dir=context.render_dir,
     )
 
+    assert [call[0] for call in context.fixer.calls] == [1]
     assert len(context.toolchain.pack_calls) == 1
     assert len(context.toolchain.validate_calls) == 1
     assert len(context.toolchain.repair_calls) == 1
@@ -557,6 +604,36 @@ async def test_fix_validation_failure_blocks_preview_ready_and_reports_slide_err
     assert event["retryable"] is True
     assert "pptx_validation_failed" in event["message"]
     assert "repair failed" in event["message"]
+
+
+@pytest.mark.asyncio
+async def test_fix_render_failure_is_not_retried_as_fix_input(tmp_path: Path) -> None:
+    """자동 수정 후 렌더 실패는 즉시 slide error 로 확정하고 fix 루프에 재진입하지 않는다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    qa = FakeQA({1: [_failed("overflow")]})
+    renderer = FailingRenderer(pages=[1])
+    step = context.make_step(qa=qa, renderer=renderer)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert [call[0] for call in context.fixer.calls] == [1]
+    assert len(context.toolchain.pack_calls) == 1
+    assert len(context.toolchain.validate_calls) == 1
+    assert len(renderer.calls) == 1
+    assert context.storage.uploads == []
+    assert result.pack_count == 1
+    assert result.render_count == 0
+    assert result.outcomes[0].status == "error"
+    event = context.main_client.events[0]
+    assert event["event"] == "slide_preview_error"
+    assert "pptx_render_failed" in event["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -444,7 +444,8 @@ async def test_qa_checks_run_in_parallel_and_fast_pass_is_published_before_slow_
         lambda: any(
             event["event"] == "slide_preview_ready" and event["slide_order"] == 2
             for event in context.main_client.events
-        )
+        ),
+        timeout=1.5,
     )
 
     assert process_task.done() is False
@@ -604,6 +605,37 @@ async def test_fix_validation_failure_blocks_preview_ready_and_reports_slide_err
     assert event["retryable"] is True
     assert "pptx_validation_failed" in event["message"]
     assert "repair failed" in event["message"]
+
+
+@pytest.mark.asyncio
+async def test_fix_validation_repair_success_counts_both_pack_calls(tmp_path: Path) -> None:
+    """repair 성공 후 재pack 된 횟수까지 pack_count 에 반영한다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    context.toolchain.validation_results = [
+        FakeValidation(success=False, stdout="invalid"),
+        FakeValidation(success=True),
+    ]
+    context.toolchain.repair_results = [FakeValidation(success=True)]
+    qa = FakeQA({1: [_failed("overflow"), _passed()]})
+    renderer = FakeRenderer(pages=[1])
+    step = context.make_step(qa=qa, renderer=renderer)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert len(context.toolchain.pack_calls) == 2
+    assert len(context.toolchain.validate_calls) == 2
+    assert len(context.toolchain.repair_calls) == 1
+    assert result.pack_count == 2
+    assert result.render_count == 1
+    assert context.fixed_pptx.exists() is True
+    assert result.outcomes[0].status == "ready"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -1,5 +1,7 @@
 """시각 QA + fix-and-verify 단계 테스트."""
 
+import asyncio
+import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -61,7 +63,7 @@ class FakeSlotEditor:
 class FakeQA:
     """슬라이드 순서별 QA 응답 대역."""
 
-    def __init__(self, responses: dict[int, list[VisualQAResult]]) -> None:
+    def __init__(self, responses: dict[int, list[VisualQAResult | Exception]]) -> None:
         self.responses = responses
         self.calls: list[tuple[int, dict[str, str]]] = []
 
@@ -72,7 +74,29 @@ class FakeQA:
         self.calls.append((slide_order, expected_content))
         if not self.responses[slide_order]:
             raise AssertionError(f"slide_order={slide_order} QA 응답이 소진되었습니다.")
-        return self.responses[slide_order].pop(0)
+        response = self.responses[slide_order].pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class BlockingExceptionQA:
+    """느린 QA 예외와 빠른 통과를 동시에 재현하는 대역."""
+
+    def __init__(self) -> None:
+        self.release = threading.Event()
+        self.calls: list[int] = []
+
+    def check_slide(
+        self, slide_image_path: Path, expected_content: dict[str, str]
+    ) -> VisualQAResult:
+        del expected_content
+        slide_order = _slide_order_from_path(slide_image_path)
+        self.calls.append(slide_order)
+        if slide_order == 1:
+            self.release.wait(timeout=2)
+            raise TimeoutError("vision timeout")
+        return _passed()
 
 
 class FakeStorage:
@@ -80,8 +104,11 @@ class FakeStorage:
 
     def __init__(self) -> None:
         self.uploads: list[tuple[str, int, Path]] = []
+        self.fail_preview_orders: set[int] = set()
 
     def upload_preview(self, job_id: str, slide_order: int, src: Path) -> str:
+        if slide_order in self.fail_preview_orders:
+            raise OSError("preview upload failed")
         self.uploads.append((job_id, slide_order, src))
         return preview_key(job_id, slide_order)
 
@@ -151,15 +178,40 @@ class FailingFixer:
         raise ValueError("LLM JSON 파싱 실패")
 
 
+@dataclass(frozen=True)
+class FakeValidation:
+    """PPTX validate/repair 결과 대역."""
+
+    success: bool = True
+    stdout: str = ""
+    stderr: str = ""
+
+
 class FakeToolchain:
     """PPTX pack 대역."""
 
     def __init__(self) -> None:
         self.pack_calls: list[tuple[Path, Path, Path]] = []
+        self.validate_calls: list[tuple[Path, Path]] = []
+        self.repair_calls: list[tuple[Path, Path]] = []
+        self.validation_results: list[FakeValidation] = []
+        self.repair_results: list[FakeValidation] = []
 
     def pack(self, unpacked_dir: Path, output_pptx: Path, *, original_pptx: Path) -> None:
         self.pack_calls.append((unpacked_dir, output_pptx, original_pptx))
         output_pptx.write_bytes(b"pptx")
+
+    def validate(self, unpacked_dir: Path, *, original_pptx: Path) -> FakeValidation:
+        self.validate_calls.append((unpacked_dir, original_pptx))
+        if self.validation_results:
+            return self.validation_results.pop(0)
+        return FakeValidation(success=True)
+
+    def repair(self, unpacked_dir: Path, *, original_pptx: Path) -> FakeValidation:
+        self.repair_calls.append((unpacked_dir, original_pptx))
+        if self.repair_results:
+            return self.repair_results.pop(0)
+        return FakeValidation(success=True)
 
 
 @dataclass(frozen=True)
@@ -308,19 +360,85 @@ async def test_passed_slides_upload_preview_and_send_ready_callbacks(tmp_path: P
     )
 
     assert result.qa_performed is True
-    assert result.qa_checked_slide_orders == (1, 2)
+    assert sorted(result.qa_checked_slide_orders) == [1, 2]
     assert [outcome.status for outcome in result.outcomes] == ["ready", "ready"]
-    assert [upload[:2] for upload in context.storage.uploads] == [("job-1", 1), ("job-1", 2)]
-    assert [event["event"] for event in context.main_client.events] == [
-        "slide_preview_ready",
-        "slide_preview_ready",
+    assert sorted(upload[:2] for upload in context.storage.uploads) == [
+        ("job-1", 1),
+        ("job-1", 2),
     ]
-    first_event = context.main_client.events[0]
+    assert all(event["event"] == "slide_preview_ready" for event in context.main_client.events)
+    first_event = next(event for event in context.main_client.events if event["slide_order"] == 1)
     assert first_event["gcs_preview_key"] == "jobs/job-1/previews/slide-01.jpg"
     assert first_event["preview_width"] == 801
     assert first_event["preview_height"] == 451
     assert first_event["preview_byte_size"] == len(context.slides[0].image_path.read_bytes())
     assert context.toolchain.pack_calls == []
+
+
+@pytest.mark.asyncio
+async def test_qa_checks_run_in_parallel_and_fast_pass_is_published_before_slow_failure(
+    tmp_path: Path,
+) -> None:
+    """느린 QA 예외가 있어도 빠른 통과 슬라이드는 먼저 preview_ready 로 공개된다."""
+    context = _make_step_context(tmp_path, slide_orders=[1, 2])
+    qa = BlockingExceptionQA()
+    step = context.make_step(qa=qa, renderer=FakeRenderer(pages=[1, 2]))
+
+    process_task = asyncio.create_task(
+        step.process(
+            job_id="job-1",
+            slides=context.slides,
+            unpacked_dir=context.unpacked_dir,
+            working_pptx_path=context.working_pptx,
+            fixed_pptx_path=context.fixed_pptx,
+            render_output_dir=context.render_dir,
+        )
+    )
+    await _wait_until(
+        lambda: any(
+            event["event"] == "slide_preview_ready" and event["slide_order"] == 2
+            for event in context.main_client.events
+        )
+    )
+
+    assert process_task.done() is False
+    qa.release.set()
+    result = await asyncio.wait_for(process_task, timeout=2)
+
+    error_events = [
+        event for event in context.main_client.events if event["event"] == "slide_preview_error"
+    ]
+    assert sorted(qa.calls) == [1, 2]
+    assert error_events[0]["slide_order"] == 1
+    assert "visual_qa_exception" in error_events[0]["message"]
+    assert [outcome.status for outcome in result.outcomes] == ["error", "ready"]
+
+
+@pytest.mark.asyncio
+async def test_preview_upload_failure_sends_slide_error_without_aborting_job(
+    tmp_path: Path,
+) -> None:
+    """프리뷰 업로드 실패는 해당 슬라이드 error 로 수렴하고 다른 슬라이드는 ready 처리된다."""
+    context = _make_step_context(tmp_path, slide_orders=[1, 2])
+    context.storage.fail_preview_orders.add(1)
+    qa = FakeQA({1: [_passed()], 2: [_passed()]})
+    step = context.make_step(qa=qa, renderer=FakeRenderer(pages=[1, 2]))
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    events_by_order = {event["slide_order"]: event for event in context.main_client.events}
+    assert events_by_order[1]["event"] == "slide_preview_error"
+    assert "preview_publish_failed" in events_by_order[1]["message"]
+    assert events_by_order[2]["event"] == "slide_preview_ready"
+    assert [outcome.status for outcome in result.outcomes] == ["error", "ready"]
+    assert context.fixer.calls == []
 
 
 @pytest.mark.asyncio
@@ -348,16 +466,18 @@ async def test_issue_slides_are_fixed_as_batch_and_only_affected_slides_rechecke
         render_output_dir=context.render_dir,
     )
 
-    assert [call[0] for call in qa.calls] == [1, 2, 3, 1, 3]
+    assert sorted(call[0] for call in qa.calls[:3]) == [1, 2, 3]
+    assert sorted(call[0] for call in qa.calls[3:]) == [1, 3]
     assert [call[0] for call in context.fixer.calls] == [1, 3]
     assert len(context.editor.applied) == 2
     assert result.fix_attempts == 1
     assert result.pack_count == 1
     assert result.render_count == 1
     assert len(context.toolchain.pack_calls) == 1
+    assert len(context.toolchain.validate_calls) == 1
     assert len(renderer.calls) == 1
     assert renderer.calls[0][2] is None
-    assert [event["slide_order"] for event in context.main_client.events] == [2, 1, 3]
+    assert sorted(event["slide_order"] for event in context.main_client.events) == [1, 2, 3]
     assert all(event["event"] == "slide_preview_ready" for event in context.main_client.events)
     assert [outcome.status for outcome in result.outcomes] == ["ready", "ready", "ready"]
 
@@ -400,6 +520,43 @@ async def test_failed_after_max_attempts_sends_retryable_preview_error(tmp_path:
     assert result.outcomes[0].status == "error"
     assert result.outcomes[0].qa_attempts == 3
     assert result.fix_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_fix_validation_failure_blocks_preview_ready_and_reports_slide_error(
+    tmp_path: Path,
+) -> None:
+    """자동 수정 산출물 검증 실패 시 재렌더/업로드/ready 로 진행하지 않는다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    context.toolchain.validation_results = [FakeValidation(success=False, stdout="invalid")]
+    context.toolchain.repair_results = [FakeValidation(success=False, stderr="repair failed")]
+    qa = FakeQA({1: [_failed("overflow")]})
+    renderer = FakeRenderer(pages=[1])
+    step = context.make_step(qa=qa, renderer=renderer, max_fix_attempts=1)
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+    )
+
+    assert len(context.toolchain.pack_calls) == 1
+    assert len(context.toolchain.validate_calls) == 1
+    assert len(context.toolchain.repair_calls) == 1
+    assert renderer.calls == []
+    assert context.storage.uploads == []
+    assert context.fixed_pptx.exists() is False
+    assert result.pack_count == 0
+    assert result.render_count == 0
+    assert result.outcomes[0].status == "error"
+    event = context.main_client.events[0]
+    assert event["event"] == "slide_preview_error"
+    assert event["retryable"] is True
+    assert "pptx_validation_failed" in event["message"]
+    assert "repair failed" in event["message"]
 
 
 @pytest.mark.asyncio
@@ -524,9 +681,10 @@ class StepContext:
     def make_step(
         self,
         *,
-        qa: FakeQA,
+        qa: Any,
         renderer: FakeRenderer,
         max_fix_attempts: int = 2,
+        max_qa_concurrency: int = 4,
     ) -> VisualQAFixVerifyStep:
         return VisualQAFixVerifyStep(
             qa=qa,
@@ -537,6 +695,7 @@ class StepContext:
             renderer=renderer,
             fixer=self.fixer,
             max_fix_attempts=max_fix_attempts,
+            max_qa_concurrency=max_qa_concurrency,
             clock=lambda: datetime(2026, 5, 27, 3, 0, tzinfo=UTC),
         )
 
@@ -593,6 +752,16 @@ def _failed(code: str, *, retryable: bool = True) -> VisualQAResult:
 
 def _slide_order_from_path(path: Path) -> int:
     return int(path.stem.rsplit("-", maxsplit=1)[1])
+
+
+async def _wait_until(condition: Any, *, timeout: float = 1.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("조건이 시간 내에 충족되지 않았습니다.")
 
 
 def _write_jpeg(path: Path, *, width: int, height: int) -> None:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #238

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- Visual QA 초기 검사와 재검증을 슬라이드 단위 병렬 처리로 변경했습니다.
- `check_slide` 예외를 해당 슬라이드의 `slide_preview_error` 결과로 격리해 일부 실패가 전체 Cloud Tasks retry로 번지지 않도록 했습니다.
- preview 업로드 또는 ready callback 실패를 슬라이드별 preview error 로 수렴하고, 나머지 통과 슬라이드는 계속 `preview_ready`로 공개되도록 했습니다.
- fix-and-verify 이후 PPTX 산출물에 `pack -> validate -> repair -> repack -> validate` 검증을 강제했습니다.
- 검증 실패 산출물은 `fixed_pptx`로 승격하지 않고, 재렌더/업로드/성공 콜백으로 진행하지 않도록 차단했습니다.
- QA 병렬성, 슬라이드별 예외 격리, preview 업로드 실패, fix 후 검증 실패 차단 테스트를 추가했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`189 files already formatted`)
  - `uv run pytest` 통과 (`784 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 재생성 canonical 산출물 promote/rollback 설계는 Task 1.25 범위로 남겼습니다.
- 완료 전 최소 1회 시각 QA 원칙과 영향 받은 슬라이드만 재검증하는 정책은 유지했습니다.
