### PR TITLE
[Fix] Cloud Tasks In-flight 멱등 처리 강화 [1.22]

### DIFF
--- a/apps/pptx-worker/pptx_worker/api/tasks.py
+++ b/apps/pptx-worker/pptx_worker/api/tasks.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tasks/visualizations", tags=["cloud-tasks"])
 
 _GENERATE_PROCESSABLE_JOB_STATUSES = {"pending", "generating"}
+_REGENERATE_PROCESSABLE_SLIDE_STATUSES = {"regenerating", "generating"}
 
 
 class MainClient(Protocol):
@@ -261,6 +262,49 @@ def _slide_order_from_context(slide_context: dict[str, Any]) -> int:
     return 0
 
 
+def _generate_in_flight_keys(payload: GeneratePushPayload) -> tuple[str, str]:
+    """generate payload 실행 키와 job 대상 키를 만든다."""
+    execution_key = (
+        f"{payload.message_type}:job:{payload.job_id}:idempotency:{payload.idempotency_key}"
+    )
+    target_key = f"{payload.message_type}:job:{payload.job_id}"
+    return execution_key, target_key
+
+
+def _regenerate_in_flight_keys(payload: RegeneratePushPayload) -> tuple[str, str]:
+    """regenerate/retry payload 실행 키와 slide 대상 키를 만든다."""
+    execution_key = (
+        f"{payload.message_type}:job:{payload.job_id}:slide:{payload.slide_id}:"
+        f"idempotency:{payload.idempotency_key}"
+    )
+    target_key = f"{payload.message_type}:job:{payload.job_id}:slide:{payload.slide_id}"
+    return execution_key, target_key
+
+
+def _in_flight_skip_response(
+    *,
+    payload: GeneratePushPayload | RegeneratePushPayload,
+    target_key: str,
+    background_tasks: BackgroundTasks,
+) -> JSONResponse:
+    """동일 worker-local 대상이 이미 실행 중이면 Cloud Tasks 에 ACK skip 을 반환한다."""
+    logger.info(
+        "in-flight 중복 작업 skip: message_type=%s job_id=%s target_key=%s idempotency_key=%s",
+        payload.message_type,
+        payload.job_id,
+        target_key,
+        payload.idempotency_key,
+    )
+    body: dict[str, Any] = {
+        "status": "skipped",
+        "reason": "in_flight_duplicate",
+        "jobId": payload.job_id,
+    }
+    if isinstance(payload, RegeneratePushPayload):
+        body["slideId"] = payload.slide_id
+    return _json_response(body, background_tasks=background_tasks)
+
+
 async def _send_regenerate_fatal_callback(
     client: MainClient,
     payload: RegeneratePushPayload,
@@ -316,51 +360,64 @@ async def handle_generate_task(
                     background_tasks=background_tasks,
                 )
 
-            try:
-                await service.generate(payload.to_task())
-            except RetryableError as exc:
-                logger.warning(
-                    "generate 작업 재시도 가능 실패: job_id=%s idempotency_key=%s detail=%s",
-                    payload.job_id,
-                    payload.idempotency_key,
-                    exc,
-                )
-                return _json_response(
-                    {"status": "retryable_failure", "detail": str(exc)},
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    background_tasks=background_tasks,
-                )
-            except FatalError as exc:
-                logger.warning(
-                    "generate 작업 치명 실패: job_id=%s idempotency_key=%s detail=%s",
-                    payload.job_id,
-                    payload.idempotency_key,
-                    exc,
-                )
-                try:
-                    await _send_generate_fatal_callback(client, payload, exc)
-                except Exception as callback_exc:
-                    logger.exception(
-                        "generate 치명 실패 콜백 전송 실패: job_id=%s idempotency_key=%s",
-                        payload.job_id,
-                        payload.idempotency_key,
-                    )
-                    return _json_response(
-                        {"status": "retryable_failure", "detail": str(callback_exc)},
-                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                        background_tasks=background_tasks,
-                    )
-                await _schedule_recycle_if_needed(runtime, background_tasks)
-                return _json_response(
-                    {"status": "fatal_acked", "jobId": payload.job_id},
+            execution_key, target_key = _generate_in_flight_keys(payload)
+            claim = await runtime.in_flight_tasks.try_acquire(
+                execution_key=execution_key,
+                target_key=target_key,
+            )
+            if claim is None:
+                return _in_flight_skip_response(
+                    payload=payload,
+                    target_key=target_key,
                     background_tasks=background_tasks,
                 )
 
-            await _schedule_recycle_if_needed(runtime, background_tasks)
-            return _json_response(
-                {"status": "ok", "jobId": payload.job_id},
-                background_tasks=background_tasks,
-            )
+            async with claim:
+                try:
+                    await service.generate(payload.to_task())
+                except RetryableError as exc:
+                    logger.warning(
+                        "generate 작업 재시도 가능 실패: job_id=%s idempotency_key=%s detail=%s",
+                        payload.job_id,
+                        payload.idempotency_key,
+                        exc,
+                    )
+                    return _json_response(
+                        {"status": "retryable_failure", "detail": str(exc)},
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        background_tasks=background_tasks,
+                    )
+                except FatalError as exc:
+                    logger.warning(
+                        "generate 작업 치명 실패: job_id=%s idempotency_key=%s detail=%s",
+                        payload.job_id,
+                        payload.idempotency_key,
+                        exc,
+                    )
+                    try:
+                        await _send_generate_fatal_callback(client, payload, exc)
+                    except Exception as callback_exc:
+                        logger.exception(
+                            "generate 치명 실패 콜백 전송 실패: job_id=%s idempotency_key=%s",
+                            payload.job_id,
+                            payload.idempotency_key,
+                        )
+                        return _json_response(
+                            {"status": "retryable_failure", "detail": str(callback_exc)},
+                            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                            background_tasks=background_tasks,
+                        )
+                    await _schedule_recycle_if_needed(runtime, background_tasks)
+                    return _json_response(
+                        {"status": "fatal_acked", "jobId": payload.job_id},
+                        background_tasks=background_tasks,
+                    )
+
+                await _schedule_recycle_if_needed(runtime, background_tasks)
+                return _json_response(
+                    {"status": "ok", "jobId": payload.job_id},
+                    background_tasks=background_tasks,
+                )
         finally:
             await _close_client(client)
 
@@ -389,7 +446,7 @@ async def handle_regenerate_task(
                 )
 
             slide_status = slide_context.get("status")
-            if slide_status not in ("regenerating", "generating"):
+            if slide_status not in _REGENERATE_PROCESSABLE_SLIDE_STATUSES:
                 logger.info(
                     "regenerate 작업 skip: job_id=%s slide_id=%s status=%s idempotency_key=%s",
                     payload.job_id,
@@ -402,56 +459,74 @@ async def handle_regenerate_task(
                     background_tasks=background_tasks,
                 )
 
-            try:
-                await service.regenerate(payload.to_task())
-            except RetryableError as exc:
-                logger.warning(
-                    "regenerate 작업 재시도 가능 실패: job_id=%s slide_id=%s "
-                    "idempotency_key=%s detail=%s",
-                    payload.job_id,
-                    payload.slide_id,
-                    payload.idempotency_key,
-                    exc,
-                )
-                return _json_response(
-                    {"status": "retryable_failure", "detail": str(exc)},
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    background_tasks=background_tasks,
-                )
-            except FatalError as exc:
-                logger.warning(
-                    "regenerate 작업 치명 실패: job_id=%s slide_id=%s idempotency_key=%s detail=%s",
-                    payload.job_id,
-                    payload.slide_id,
-                    payload.idempotency_key,
-                    exc,
-                )
-                try:
-                    await _send_regenerate_fatal_callback(client, payload, slide_context, exc)
-                except Exception as callback_exc:
-                    logger.exception(
-                        "regenerate 치명 실패 콜백 전송 실패: job_id=%s slide_id=%s "
-                        "idempotency_key=%s",
-                        payload.job_id,
-                        payload.slide_id,
-                        payload.idempotency_key,
-                    )
-                    return _json_response(
-                        {"status": "retryable_failure", "detail": str(callback_exc)},
-                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                        background_tasks=background_tasks,
-                    )
-                await _schedule_recycle_if_needed(runtime, background_tasks)
-                return _json_response(
-                    {"status": "fatal_acked", "jobId": payload.job_id, "slideId": payload.slide_id},
+            execution_key, target_key = _regenerate_in_flight_keys(payload)
+            claim = await runtime.in_flight_tasks.try_acquire(
+                execution_key=execution_key,
+                target_key=target_key,
+            )
+            if claim is None:
+                return _in_flight_skip_response(
+                    payload=payload,
+                    target_key=target_key,
                     background_tasks=background_tasks,
                 )
 
-            await _schedule_recycle_if_needed(runtime, background_tasks)
-            return _json_response(
-                {"status": "ok", "jobId": payload.job_id, "slideId": payload.slide_id},
-                background_tasks=background_tasks,
-            )
+            async with claim:
+                try:
+                    await service.regenerate(payload.to_task())
+                except RetryableError as exc:
+                    logger.warning(
+                        "regenerate 작업 재시도 가능 실패: job_id=%s slide_id=%s "
+                        "idempotency_key=%s detail=%s",
+                        payload.job_id,
+                        payload.slide_id,
+                        payload.idempotency_key,
+                        exc,
+                    )
+                    return _json_response(
+                        {"status": "retryable_failure", "detail": str(exc)},
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        background_tasks=background_tasks,
+                    )
+                except FatalError as exc:
+                    logger.warning(
+                        "regenerate 작업 치명 실패: job_id=%s slide_id=%s "
+                        "idempotency_key=%s detail=%s",
+                        payload.job_id,
+                        payload.slide_id,
+                        payload.idempotency_key,
+                        exc,
+                    )
+                    try:
+                        await _send_regenerate_fatal_callback(client, payload, slide_context, exc)
+                    except Exception as callback_exc:
+                        logger.exception(
+                            "regenerate 치명 실패 콜백 전송 실패: job_id=%s slide_id=%s "
+                            "idempotency_key=%s",
+                            payload.job_id,
+                            payload.slide_id,
+                            payload.idempotency_key,
+                        )
+                        return _json_response(
+                            {"status": "retryable_failure", "detail": str(callback_exc)},
+                            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                            background_tasks=background_tasks,
+                        )
+                    await _schedule_recycle_if_needed(runtime, background_tasks)
+                    return _json_response(
+                        {
+                            "status": "fatal_acked",
+                            "jobId": payload.job_id,
+                            "slideId": payload.slide_id,
+                        },
+                        background_tasks=background_tasks,
+                    )
+
+                await _schedule_recycle_if_needed(runtime, background_tasks)
+                return _json_response(
+                    {"status": "ok", "jobId": payload.job_id, "slideId": payload.slide_id},
+                    background_tasks=background_tasks,
+                )
         finally:
             await _close_client(client)
 

--- a/apps/pptx-worker/pptx_worker/api/tasks.py
+++ b/apps/pptx-worker/pptx_worker/api/tasks.py
@@ -332,10 +332,21 @@ async def handle_generate_task(
     """초기 PPTX 생성 Cloud Tasks push 요청을 처리한다."""
     runtime = _get_runtime()
     service = _get_task_service()
+    execution_key, target_key = _generate_in_flight_keys(payload)
     client = _main_client_factory(payload.callback_base_url)
 
     async with runtime.track_active():
         try:
+            if await runtime.in_flight_tasks.is_in_flight(
+                execution_key=execution_key,
+                target_key=target_key,
+            ):
+                return _in_flight_skip_response(
+                    payload=payload,
+                    target_key=target_key,
+                    background_tasks=background_tasks,
+                )
+
             try:
                 job_context = await client.get_job_context(payload.job_id)
             except MainServerError as exc:
@@ -360,7 +371,6 @@ async def handle_generate_task(
                     background_tasks=background_tasks,
                 )
 
-            execution_key, target_key = _generate_in_flight_keys(payload)
             claim = await runtime.in_flight_tasks.try_acquire(
                 execution_key=execution_key,
                 target_key=target_key,
@@ -430,10 +440,21 @@ async def handle_regenerate_task(
     """단일 슬라이드 재생성 Cloud Tasks push 요청을 처리한다."""
     runtime = _get_runtime()
     service = _get_task_service()
+    execution_key, target_key = _regenerate_in_flight_keys(payload)
     client = _main_client_factory(payload.callback_base_url)
 
     async with runtime.track_active():
         try:
+            if await runtime.in_flight_tasks.is_in_flight(
+                execution_key=execution_key,
+                target_key=target_key,
+            ):
+                return _in_flight_skip_response(
+                    payload=payload,
+                    target_key=target_key,
+                    background_tasks=background_tasks,
+                )
+
             try:
                 slide_context = await client.get_slide_context(payload.job_id, payload.slide_id)
             except MainServerError as exc:
@@ -459,7 +480,6 @@ async def handle_regenerate_task(
                     background_tasks=background_tasks,
                 )
 
-            execution_key, target_key = _regenerate_in_flight_keys(payload)
             claim = await runtime.in_flight_tasks.try_acquire(
                 execution_key=execution_key,
                 target_key=target_key,

--- a/apps/pptx-worker/pptx_worker/runtime.py
+++ b/apps/pptx-worker/pptx_worker/runtime.py
@@ -192,6 +192,11 @@ class InFlightTaskRegistry:
             target_key=target_key,
         )
 
+    async def is_in_flight(self, *, execution_key: str, target_key: str) -> bool:
+        """이미 실행 중인 payload 또는 대상인지 확인한다."""
+        async with self._lock:
+            return execution_key in self._execution_keys or target_key in self._target_keys
+
     async def release(self, *, execution_key: str, target_key: str) -> None:
         """실행 완료 또는 실패 후 in-flight 키를 해제한다."""
         async with self._lock:

--- a/apps/pptx-worker/pptx_worker/runtime.py
+++ b/apps/pptx-worker/pptx_worker/runtime.py
@@ -55,12 +55,18 @@ class WorkerRuntime:
         self._active_count = 0
         self._processed_counter = processed_counter or InMemoryConversionCounter()
         self._shutdown_requested = False
+        self._in_flight_tasks = InFlightTaskRegistry()
         self._lock = asyncio.Lock()
 
     @property
     def processed_counter(self) -> ConversionCounter:
         """PPTX 렌더러와 공유할 누적 변환 카운터."""
         return self._processed_counter
+
+    @property
+    def in_flight_tasks(self) -> "InFlightTaskRegistry":
+        """현재 워커 프로세스에서 실행 중인 Cloud Tasks 작업 registry."""
+        return self._in_flight_tasks
 
     @asynccontextmanager
     async def track_active(self):
@@ -113,6 +119,86 @@ class WorkerRuntime:
         return True
 
 
+class InFlightTaskClaim:
+    """worker-local in-flight 작업 claim."""
+
+    def __init__(
+        self,
+        registry: "InFlightTaskRegistry",
+        *,
+        execution_key: str,
+        target_key: str,
+    ) -> None:
+        self._registry = registry
+        self._execution_key = execution_key
+        self._target_key = target_key
+        self._released = False
+
+    @property
+    def execution_key(self) -> str:
+        """Cloud Tasks payload 단위 실행 키."""
+        return self._execution_key
+
+    @property
+    def target_key(self) -> str:
+        """job 또는 slide 단위 대상 키."""
+        return self._target_key
+
+    async def __aenter__(self) -> "InFlightTaskClaim":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> None:
+        await self.release()
+
+    async def release(self) -> None:
+        """claim 을 해제한다."""
+        if self._released:
+            return
+        await self._registry.release(
+            execution_key=self._execution_key,
+            target_key=self._target_key,
+        )
+        self._released = True
+
+
+class InFlightTaskRegistry:
+    """동일 워커 프로세스 안의 중복 Cloud Tasks 실행을 막는다."""
+
+    def __init__(self) -> None:
+        self._execution_keys: set[str] = set()
+        self._target_keys: set[str] = set()
+        self._lock = asyncio.Lock()
+
+    async def try_acquire(
+        self,
+        *,
+        execution_key: str,
+        target_key: str,
+    ) -> InFlightTaskClaim | None:
+        """이미 실행 중인 payload 또는 대상이면 None, 아니면 claim 을 반환한다."""
+        async with self._lock:
+            if execution_key in self._execution_keys or target_key in self._target_keys:
+                return None
+            self._execution_keys.add(execution_key)
+            self._target_keys.add(target_key)
+        return InFlightTaskClaim(
+            self,
+            execution_key=execution_key,
+            target_key=target_key,
+        )
+
+    async def release(self, *, execution_key: str, target_key: str) -> None:
+        """실행 완료 또는 실패 후 in-flight 키를 해제한다."""
+        async with self._lock:
+            self._execution_keys.discard(execution_key)
+            self._target_keys.discard(target_key)
+
+
 _runtime: WorkerRuntime | None = None
 
 
@@ -134,6 +220,8 @@ def set_worker_runtime(runtime: WorkerRuntime | None) -> None:
 
 __all__ = [
     "DEFAULT_RECYCLE_AFTER",
+    "InFlightTaskClaim",
+    "InFlightTaskRegistry",
     "WorkerRuntime",
     "get_worker_runtime",
     "set_worker_runtime",

--- a/tasks/phase-1-pptx-worker/22-cloud-tasks-inflight-idempotency.md
+++ b/tasks/phase-1-pptx-worker/22-cloud-tasks-inflight-idempotency.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/01-worker-service-scaffold.md"
 depends_on: ["1.01", "1.02", "1.05", "1.07"]
 blocks: ["1.26"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-05-28"
 owner: ""
 sprint: ""
 ---
@@ -25,34 +26,36 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #237 본문과 Cloud Tasks at-least-once delivery 전제 확인
-- [ ] 현재 terminal skip과 processable status 조건을 테스트로 재현
-- [ ] Main Backend CAS가 담당해야 할 범위와 worker-local guard로 가능한 범위 구분
+- [x] GitHub Issue #237 본문과 Cloud Tasks at-least-once delivery 전제 확인
+- [x] 현재 terminal skip과 processable status 조건을 테스트로 재현
+- [x] Main Backend CAS가 담당해야 할 범위와 worker-local guard로 가능한 범위 구분
 
 ## 구현 체크리스트
 
-- [ ] generate push 처리 전 Main Backend 상태 조회 조건 확인
-- [ ] regenerate/retry push 처리 전 slide/job 상태 조회 조건 확인
-- [ ] terminal 상태 skip과 processable 상태 진입 조건을 테스트로 고정
-- [ ] `idempotencyKey`가 callback event key와 worker execution key에서 어떻게 쓰이는지 분리 확인
-- [ ] 같은 payload 동시 도착 시 worker-local guard, Main internal API claim/check, 기존 상태 조회 API 확장 중 구현 방안 결정
-- [ ] Cloud Run `concurrency=1`만으로 보장되지 않는 중복 재전송 케이스 문서화
-- [ ] skip/retry/fatal 응답 코드가 Cloud Tasks 재시도 모델과 맞는지 확인
-- [ ] 동일 job generate push가 이미 처리 중일 때 중복 파이프라인 실행 방지
-- [ ] 동일 slide regenerate push가 이미 처리 중일 때 중복 파이프라인 실행 방지
-- [ ] 처리 대상이 아닌 상태는 200 ACK skip 유지
-- [ ] retryable/fatal 실패가 기존 callback 계약을 깨지 않도록 유지
+- [x] generate push 처리 전 Main Backend 상태 조회 조건 확인
+- [x] regenerate/retry push 처리 전 slide/job 상태 조회 조건 확인
+- [x] terminal 상태 skip과 processable 상태 진입 조건을 테스트로 고정
+- [x] `idempotencyKey`가 callback event key와 worker execution key에서 어떻게 쓰이는지 분리 확인
+- [x] 같은 payload 동시 도착 시 worker-local guard, Main internal API claim/check, 기존 상태 조회 API 확장 중 구현 방안 결정
+- [x] Cloud Run `concurrency=1`만으로 보장되지 않는 중복 재전송 케이스 문서화
+- [x] skip/retry/fatal 응답 코드가 Cloud Tasks 재시도 모델과 맞는지 확인
+- [x] 동일 job generate push가 이미 처리 중일 때 중복 파이프라인 실행 방지
+- [x] 동일 slide regenerate push가 이미 처리 중일 때 중복 파이프라인 실행 방지
+- [x] 처리 대상이 아닌 상태는 200 ACK skip 유지
+- [x] retryable/fatal 실패가 기존 callback 계약을 깨지 않도록 유지
 
 ## Definition of Done
 
-- [ ] generate terminal 재전송이 재실행 없이 200 ACK 되는 테스트 통과
-- [ ] generate in-flight 중복 push가 실제 파이프라인을 중복 실행하지 않는 테스트 통과
-- [ ] regenerate terminal/비대상 상태 push가 200 skip 되는 테스트 통과
-- [ ] regenerate in-flight 중복 push가 단일 실행으로 수렴하는 테스트 통과
-- [ ] retryable/fatal/skip 응답 분류가 Cloud Tasks 재시도 정책과 문서상 일치
-- [ ] `uv run ruff check .` 및 관련 worker 테스트 통과
+- [x] generate terminal 재전송이 재실행 없이 200 ACK 되는 테스트 통과
+- [x] generate in-flight 중복 push가 실제 파이프라인을 중복 실행하지 않는 테스트 통과
+- [x] regenerate terminal/비대상 상태 push가 200 skip 되는 테스트 통과
+- [x] regenerate in-flight 중복 push가 단일 실행으로 수렴하는 테스트 통과
+- [x] retryable/fatal/skip 응답 분류가 Cloud Tasks 재시도 정책과 문서상 일치
+- [x] `uv run ruff check .` 및 관련 worker 테스트 통과
 
 ## 리스크 / 메모
 
 - Worker는 Postgres에 직접 접근하지 않는다.
 - Main Backend의 DB CAS, quota 차감, stuck recovery 구현이 필요하면 1.26 handoff에 명확히 남긴다.
+- 이번 구현은 worker-local in-flight registry로 같은 워커 프로세스 안의 동일 payload 및 동일 job/slide 대상 중복 실행을 200 ACK skip 처리한다.
+- Cloud Run `concurrency=1`은 인스턴스당 1요청만 제한하므로, 서로 다른 인스턴스로 분산된 중복 push의 원자적 차단은 Main Backend CAS/claim 계약(1.26 handoff) 범위로 남긴다.

--- a/tests/test_pptx_worker/test_app/test_tasks.py
+++ b/tests/test_pptx_worker/test_app/test_tasks.py
@@ -267,7 +267,7 @@ async def test_generate_in_flight_duplicate_push_is_acked_without_reexecution(mo
     assert duplicate.json()["status"] == "skipped"
     assert duplicate.json()["reason"] == "in_flight_duplicate"
     assert len(service.generate_calls) == 1
-    assert main_client.job_context_calls == ["job-1", "job-1"]
+    assert main_client.job_context_calls == ["job-1"]
 
 
 @pytest.mark.asyncio
@@ -306,7 +306,7 @@ async def test_regenerate_in_flight_duplicate_push_is_acked_without_reexecution(
     assert duplicate.json()["reason"] == "in_flight_duplicate"
     assert len(service.regenerate_calls) == 1
     assert service.regenerate_calls[0].user_request == "표를 더 간결하게 바꿔줘"
-    assert main_client.slide_context_calls == [("job-1", "slide-3"), ("job-1", "slide-3")]
+    assert main_client.slide_context_calls == [("job-1", "slide-3")]
 
 
 def test_retryable_error_returns_503_for_cloud_tasks_retry(worker_client):

--- a/tests/test_pptx_worker/test_app/test_tasks.py
+++ b/tests/test_pptx_worker/test_app/test_tasks.py
@@ -1,7 +1,9 @@
 """PPTX 워커 Cloud Tasks push 핸들러 테스트."""
 
+import asyncio
 from typing import Any
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 from pptx_worker.api import tasks as tasks_api
@@ -68,9 +70,17 @@ class FakeVisualizationTaskService(VisualizationTaskService):
         self.regenerate_error: Exception | None = None
         self.generate_conversion_count = 0
         self.regenerate_conversion_count = 0
+        self.generate_started: asyncio.Event | None = None
+        self.release_generate: asyncio.Event | None = None
+        self.regenerate_started: asyncio.Event | None = None
+        self.release_regenerate: asyncio.Event | None = None
 
     async def generate(self, task: GenerateVisualizationTask) -> None:
         self.generate_calls.append(task)
+        if self.generate_started is not None:
+            self.generate_started.set()
+        if self.release_generate is not None:
+            await self.release_generate.wait()
         if self.generate_error is not None:
             raise self.generate_error
         for _ in range(self.generate_conversion_count):
@@ -78,15 +88,18 @@ class FakeVisualizationTaskService(VisualizationTaskService):
 
     async def regenerate(self, task: RegenerateVisualizationTask) -> None:
         self.regenerate_calls.append(task)
+        if self.regenerate_started is not None:
+            self.regenerate_started.set()
+        if self.release_regenerate is not None:
+            await self.release_regenerate.wait()
         if self.regenerate_error is not None:
             raise self.regenerate_error
         for _ in range(self.regenerate_conversion_count):
             await self.runtime.mark_processed()
 
 
-@pytest.fixture()
-def worker_client(monkeypatch):
-    """테스트용 워커 앱과 fake 의존성을 구성한다."""
+def configure_worker_dependencies(monkeypatch):
+    """테스트용 워커 fake 의존성을 구성한다."""
     main_client = FakeMainClient()
     shutdown_calls: list[str] = []
     runtime = WorkerRuntime(
@@ -100,12 +113,25 @@ def worker_client(monkeypatch):
     monkeypatch.setattr(tasks_api, "_get_task_service", lambda: service)
     set_worker_runtime(runtime)
 
-    with TestClient(create_app()) as client:
-        yield client, main_client, service, runtime, shutdown_calls
+    return main_client, service, runtime, shutdown_calls
 
+
+def reset_worker_dependencies() -> None:
+    """테스트용 워커 fake 의존성을 정리한다."""
     tasks_api.reset_main_client_factory()
     set_worker_metrics(None)
     set_worker_runtime(None)
+
+
+@pytest.fixture()
+def worker_client(monkeypatch):
+    """테스트용 워커 앱과 fake 의존성을 구성한다."""
+    main_client, service, runtime, shutdown_calls = configure_worker_dependencies(monkeypatch)
+
+    with TestClient(create_app()) as client:
+        yield client, main_client, service, runtime, shutdown_calls
+
+    reset_worker_dependencies()
 
 
 def generate_payload(**overrides: Any) -> dict[str, Any]:
@@ -209,6 +235,80 @@ def test_terminal_regenerate_push_is_acked_without_reexecution(worker_client):
     assert client.get("/health").json()["lifetime_processed"] == 0
 
 
+@pytest.mark.asyncio
+async def test_generate_in_flight_duplicate_push_is_acked_without_reexecution(monkeypatch):
+    main_client, service, _, _ = configure_worker_dependencies(monkeypatch)
+    service.generate_started = asyncio.Event()
+    service.release_generate = asyncio.Event()
+    app = create_app()
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            first = asyncio.create_task(
+                client.post("/tasks/visualizations/generate", json=generate_payload())
+            )
+            await asyncio.wait_for(service.generate_started.wait(), timeout=1)
+
+            duplicate = await client.post(
+                "/tasks/visualizations/generate",
+                json=generate_payload(),
+            )
+            service.release_generate.set()
+            first_response = await asyncio.wait_for(first, timeout=1)
+    finally:
+        reset_worker_dependencies()
+
+    assert first_response.status_code == 200
+    assert first_response.json()["status"] == "ok"
+    assert duplicate.status_code == 200
+    assert duplicate.json()["status"] == "skipped"
+    assert duplicate.json()["reason"] == "in_flight_duplicate"
+    assert len(service.generate_calls) == 1
+    assert main_client.job_context_calls == ["job-1", "job-1"]
+
+
+@pytest.mark.asyncio
+async def test_regenerate_in_flight_duplicate_push_is_acked_without_reexecution(monkeypatch):
+    main_client, service, _, _ = configure_worker_dependencies(monkeypatch)
+    service.regenerate_started = asyncio.Event()
+    service.release_regenerate = asyncio.Event()
+    app = create_app()
+
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            first = asyncio.create_task(
+                client.post("/tasks/visualizations/regenerate", json=regenerate_payload())
+            )
+            await asyncio.wait_for(service.regenerate_started.wait(), timeout=1)
+
+            duplicate = await client.post(
+                "/tasks/visualizations/regenerate",
+                json=regenerate_payload(
+                    userRequest="같은 슬라이드를 다시 만들어줘",
+                    idempotencyKey="idem-regenerate-repeat",
+                ),
+            )
+            service.release_regenerate.set()
+            first_response = await asyncio.wait_for(first, timeout=1)
+    finally:
+        reset_worker_dependencies()
+
+    assert first_response.status_code == 200
+    assert first_response.json()["status"] == "ok"
+    assert duplicate.status_code == 200
+    assert duplicate.json()["status"] == "skipped"
+    assert duplicate.json()["reason"] == "in_flight_duplicate"
+    assert len(service.regenerate_calls) == 1
+    assert service.regenerate_calls[0].user_request == "표를 더 간결하게 바꿔줘"
+    assert main_client.slide_context_calls == [("job-1", "slide-3"), ("job-1", "slide-3")]
+
+
 def test_retryable_error_returns_503_for_cloud_tasks_retry(worker_client):
     client, _, service, _, _ = worker_client
     service.generate_error = RetryableError("LLM 일시 실패")
@@ -218,6 +318,13 @@ def test_retryable_error_returns_503_for_cloud_tasks_retry(worker_client):
     assert response.status_code == 503
     assert response.json()["status"] == "retryable_failure"
     assert client.get("/health").json()["lifetime_processed"] == 0
+
+    service.generate_error = None
+    retry_response = client.post("/tasks/visualizations/generate", json=generate_payload())
+
+    assert retry_response.status_code == 200
+    assert retry_response.json()["status"] == "ok"
+    assert len(service.generate_calls) == 2
 
 
 def test_fatal_generate_error_sends_job_callback_then_acks(worker_client):

--- a/tests/test_pptx_worker/test_runtime.py
+++ b/tests/test_pptx_worker/test_runtime.py
@@ -1,0 +1,96 @@
+"""PPTX 워커 런타임 상태 관리 테스트."""
+
+import asyncio
+
+import pytest
+from pptx_worker.runtime import InFlightTaskRegistry
+
+
+@pytest.mark.asyncio
+async def test_in_flight_registry_blocks_same_execution_key() -> None:
+    """같은 payload 실행 키는 중복 claim 할 수 없다."""
+    registry = InFlightTaskRegistry()
+
+    claim = await registry.try_acquire(
+        execution_key="viz.generate:job:job-1:idempotency:task-1",
+        target_key="viz.generate:job:job-1",
+    )
+    duplicate = await registry.try_acquire(
+        execution_key="viz.generate:job:job-1:idempotency:task-1",
+        target_key="viz.generate:job:job-2",
+    )
+
+    assert claim is not None
+    assert duplicate is None
+
+
+@pytest.mark.asyncio
+async def test_in_flight_registry_blocks_same_target_key_with_different_execution_key() -> None:
+    """다른 payload 라도 같은 job/slide 대상이면 중복 claim 할 수 없다."""
+    registry = InFlightTaskRegistry()
+
+    claim = await registry.try_acquire(
+        execution_key="viz.regenerate:job:job-1:slide:slide-1:idempotency:task-1",
+        target_key="viz.regenerate:job:job-1:slide:slide-1",
+    )
+    duplicate = await registry.try_acquire(
+        execution_key="viz.regenerate:job:job-1:slide:slide-1:idempotency:task-2",
+        target_key="viz.regenerate:job:job-1:slide:slide-1",
+    )
+
+    assert claim is not None
+    assert duplicate is None
+
+
+@pytest.mark.asyncio
+async def test_in_flight_registry_allows_only_one_concurrent_acquire() -> None:
+    """동시에 같은 대상을 claim 해도 하나만 성공한다."""
+    registry = InFlightTaskRegistry()
+
+    claims = await asyncio.gather(
+        *[
+            registry.try_acquire(
+                execution_key=f"viz.generate:job:job-1:idempotency:task-{index}",
+                target_key="viz.generate:job:job-1",
+            )
+            for index in range(10)
+        ]
+    )
+
+    assert sum(claim is not None for claim in claims) == 1
+
+
+@pytest.mark.asyncio
+async def test_in_flight_registry_releases_keys_for_reacquire() -> None:
+    """claim 해제 후 같은 실행 키와 대상 키를 다시 claim 할 수 있다."""
+    registry = InFlightTaskRegistry()
+    execution_key = "viz.generate:job:job-1:idempotency:task-1"
+    target_key = "viz.generate:job:job-1"
+
+    claim = await registry.try_acquire(execution_key=execution_key, target_key=target_key)
+    assert claim is not None
+    assert await registry.is_in_flight(execution_key=execution_key, target_key=target_key) is True
+
+    await claim.release()
+    reacquired = await registry.try_acquire(execution_key=execution_key, target_key=target_key)
+
+    assert await registry.is_in_flight(execution_key=execution_key, target_key=target_key) is True
+    assert reacquired is not None
+
+
+@pytest.mark.asyncio
+async def test_in_flight_registry_context_manager_releases_after_exception() -> None:
+    """context manager 는 처리 중 예외가 나도 claim 을 해제한다."""
+    registry = InFlightTaskRegistry()
+    execution_key = "viz.generate:job:job-1:idempotency:task-1"
+    target_key = "viz.generate:job:job-1"
+    claim = await registry.try_acquire(execution_key=execution_key, target_key=target_key)
+    assert claim is not None
+
+    with pytest.raises(RuntimeError):
+        async with claim:
+            raise RuntimeError("pipeline failed")
+
+    reacquired = await registry.try_acquire(execution_key=execution_key, target_key=target_key)
+
+    assert reacquired is not None


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #237

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PPTX Worker 런타임에 worker-local in-flight task registry를 추가했습니다.
- generate push는 동일 job 대상, regenerate/retry push는 동일 slide 대상이 이미 처리 중이면 파이프라인을 재실행하지 않고 `200 skipped`로 ACK하도록 보강했습니다.
- in-flight 중복 skip 응답에 `reason: "in_flight_duplicate"`를 포함해 terminal/non-target skip과 구분할 수 있게 했습니다.
- `RetryableError`는 503으로 Cloud Tasks 재시도를 유지하고, `FatalError`는 기존 callback 후 200 ACK 계약을 유지했습니다.
- Task 1.22 문서를 완료 상태로 갱신하고, 서로 다른 Cloud Run 인스턴스에 분산된 중복 push의 원자적 차단은 Main Backend CAS/claim handoff 범위로 명시했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`189 files already formatted`)
  - `uv run pytest` 통과 (`783 passed`)
  - `uv run pytest tests/test_pptx_worker` 통과 (`183 passed`)
  - `uv run pytest tests/test_pptx_worker/test_app/test_tasks.py` 통과 (`16 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- Worker는 Postgres에 직접 접근하지 않고 기존 Main internal API 상태 조회 계약을 유지합니다.
- 이번 guard는 같은 워커 프로세스 안의 중복 실행 방지입니다. Cloud Run `concurrency=1`만으로 보장되지 않는 cross-instance 중복 차단은 후속 Main Backend CAS/claim 계약 범위입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 중복된 작업이 워커 프로세스 내에서 재실행되지 않도록 방지하는 메커니즘을 추가했습니다. 동일한 작업에 대한 중복 요청은 이제 건너뛰고 적절히 처리됩니다.

* **Tests**
  * 중복 작업 처리 시나리오에 대한 검증 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->