### PR TITLE
[Fix] 생성 품질 계약 가드레일 보강 [1.24]

### DIFF
--- a/features/visualization/agents/generation.py
+++ b/features/visualization/agents/generation.py
@@ -28,10 +28,12 @@ _FILL_SYSTEM_PROMPT = """PPTX 슬라이드 Slot 을 채우는 편집 데이터 �
 스키마: {"fills": {"shape_id": {"action": "text"|"remove"|"chart", "text": string, "font_size_override": number|null, "is_title": boolean|null, "data": object|null}}}
 지침:
 - 임의 코드나 XML 을 만들지 말고 fills 데이터만 산출하세요.
-- 제공된 shape_id 만 key 로 사용하세요.
+- provided slots 중 editable=true 이고 required=true 인 shape_id 만 필수로 채우세요.
+- required=false, editable=false, kind=decorative/background/layout slot 은 필수 채움 대상이 아닙니다.
+- 제공된 shape_id 만 key 로 사용하고, 각 slot 의 allowed_actions 범위 안에서만 action 을 선택하세요.
+- chart slot 은 action=chart 와 data.categories, data.series[].values 를 함께 제공하세요.
 - 텍스트가 길면 먼저 폰트를 줄이되 원본의 60% 미만이나 10pt 미만으로 내리지 마세요.
-- 텍스트 요약이 필요하면 고유명사, 수치, 기술 스택을 보존하세요.
-- 제공된 모든 shape_id 에 대해 text/remove/chart 중 하나를 반환하세요.
+- 텍스트 요약이 필요하면 고유명사, 수치, 기술 스택, 성과 지표를 보존하세요.
 """
 
 _REGENERATE_SYSTEM_PROMPT = """PPTX 단일 슬라이드 수정 요청을 fill 변경 지시로 해석하는 편집자입니다.
@@ -40,13 +42,15 @@ _REGENERATE_SYSTEM_PROMPT = """PPTX 단일 슬라이드 수정 요청을 fill �
 지침:
 - 사용자가 지정한 도형만 fills 에 포함하세요. 지정되지 않은 도형은 절대 포함하지 마세요.
 - 제공된 shape_id 만 key 로 사용하세요.
+- 현재 구현은 텍스트 도형의 text/font_size_override/is_title 변경만 지원합니다.
 - 폰트 크기는 10pt 이상 48pt 이하로만 조정하세요.
 - 사용자가 텍스트/문구/표현 변경을 명시한 경우만 text 를 변경하세요.
 - 스타일 요청만 있으면 text 는 null 로 두고 font_size_override 같은 스타일 필드만 반환하세요.
-- 슬라이드 추가/삭제, 도형 이동, 슬라이드 밖 배치, 임의 shape 생성은 허용되지 않습니다.
+- 색상, 도형 크기, 위치, 레이아웃, 차트 데이터, 슬라이드 추가/삭제, 도형 이동,
+  슬라이드 밖 배치, 임의 shape 생성은 허용되지 않습니다.
 """
 
-_TEXT_CHANGE_HINTS = (
+_TEXT_FIELD_HINTS = (
     "텍스트",
     "문구",
     "표현",
@@ -54,21 +58,39 @@ _TEXT_CHANGE_HINTS = (
     "오타",
     "카피",
     "워딩",
+    "text",
+    "copy",
+    "wording",
+    "typo",
+)
+_TEXT_TRANSFORM_HINTS = (
     "바꿔",
     "바꾸",
-    "변경",
-    "수정",
     "고쳐",
     "임팩트",
     "짧게",
     "요약",
-    "text",
-    "copy",
-    "wording",
     "rename",
     "rephrase",
     "rewrite",
-    "typo",
+)
+_UNSUPPORTED_REGENERATE_PATTERNS = (
+    ("색상/채우기 변경", re.compile(r"색|색상|컬러|채우기|배경색|테두리|선색|color", re.I)),
+    ("위치/배치 변경", re.compile(r"위치|이동|옮겨|배치|정렬|밖으로|position|move|align", re.I)),
+    ("레이아웃 변경", re.compile(r"레이아웃|템플릿|layout|template", re.I)),
+    (
+        "도형 크기 변경",
+        re.compile(r"(도형|박스|상자|shape|box).{0,8}(크기|확대|축소|size|resize)", re.I),
+    ),
+    ("차트 데이터 변경", re.compile(r"차트|그래프|chart|graph", re.I)),
+    (
+        "슬라이드/도형 생성",
+        re.compile(r"슬라이드\s*(추가|삭제)|도형\s*(추가|삭제)|shape\s*(add|delete)", re.I),
+    ),
+)
+_METRIC_SLIDE_PATTERN = re.compile(
+    r"chart|graph|metric|metrics|kpi|차트|그래프|지표|성과\s*지표|수치|통계|전환율|증감|비율",
+    re.I,
 )
 
 
@@ -276,6 +298,7 @@ class LLMSlideChangeGenerator:
         """사용자 요청과 현재 slot/fill 을 기반으로 수정 대상만 산출한다."""
         if not user_request.strip():
             raise ValueError("재생성 요청이 비어 있습니다.")
+        _reject_unsupported_regenerate_request(user_request)
         if not slots:
             return {}
 
@@ -371,6 +394,14 @@ def prefilter_source_slides(
 def _build_plan_prompt(*, portfolio_text: str, source_slides: Sequence[SourceSlide]) -> str:
     payload = {
         "portfolio_text": portfolio_text,
+        "selection_signals": {
+            "has_numeric_data": _has_numeric_signal(portfolio_text),
+            "has_visual_asset": _has_visual_signal(portfolio_text),
+        },
+        "selection_guidance": (
+            "has_numeric_data=true 이면 chart 또는 metric-oriented Source Slide 를 "
+            "후보로 고려하고, 선택 시 reason 에 수치/성과 지표 근거를 남기세요."
+        ),
         "source_slides": [
             {
                 "id": slide.source_slide_id,
@@ -462,18 +493,34 @@ def _parse_fills_payload(
         shape_key = str(shape_id)
         if shape_key not in slots_by_id:
             raise ValueError(f"제공되지 않은 shape_id 입니다: {shape_key}")
+        slot = slots_by_id[shape_key]
+        if not _slot_is_editable(slot):
+            raise ValueError(f"비편집 slot 은 fills 대상이 아닙니다: {shape_key}")
+
         fill = raw_fill.model_dump(exclude_none=True)
         action = raw_fill.action
+        allowed_actions = _allowed_actions_for_slot(slot)
+        if action not in allowed_actions:
+            allowed_text = ", ".join(sorted(allowed_actions))
+            raise ValueError(
+                f"slot {shape_key} 은 action={action!r} 을 지원하지 않습니다. 허용: {allowed_text}"
+            )
         if action == "text":
             fill["text"] = str(raw_fill.text or "")
+        elif action == "chart":
+            _validate_chart_fill_data(fill, shape_key)
         if fill.get("font_size_override") is not None:
             fill["font_size_override"] = _guard_font_size(
                 fill["font_size_override"],
-                slots_by_id[shape_key].get("font_size_pt"),
+                slot.get("font_size_pt"),
             )
         normalized[shape_key] = fill
 
-    missing_shape_ids = sorted(set(slots_by_id) - set(normalized))
+    missing_shape_ids = sorted(
+        shape_id
+        for shape_id, slot in slots_by_id.items()
+        if _slot_requires_fill(slot) and shape_id not in normalized
+    )
     if missing_shape_ids:
         raise ValueError(f"fills 에 누락된 shape_id 가 있습니다: {', '.join(missing_shape_ids)}")
 
@@ -501,7 +548,7 @@ def _parse_regenerate_changes_payload(
             raise ValueError(f"fill 은 객체여야 합니다: {shape_key}")
 
         slot = slots_by_id[shape_key]
-        if slot.get("kind") not in {None, "text"}:
+        if not _slot_is_editable(slot) or "text" not in _allowed_actions_for_slot(slot):
             raise ValueError(f"재생성 변경은 텍스트 도형만 지원합니다: {shape_key}")
 
         action = str(raw_fill.get("action") or "text")
@@ -549,7 +596,21 @@ def _guard_regenerate_font_size(value: Any) -> float:
 
 def _text_change_requested(user_request: str) -> bool:
     lowered = user_request.casefold()
-    return any(hint in lowered for hint in _TEXT_CHANGE_HINTS)
+    if any(hint in lowered for hint in _TEXT_FIELD_HINTS):
+        return True
+    if any(hint in lowered for hint in _TEXT_TRANSFORM_HINTS):
+        return True
+    return bool(re.search(r"[\"'“”‘’][^\"'“”‘’]+[\"'“”‘’]\s*(로|으로)", user_request))
+
+
+def _reject_unsupported_regenerate_request(user_request: str) -> None:
+    for label, pattern in _UNSUPPORTED_REGENERATE_PATTERNS:
+        if pattern.search(user_request):
+            raise ValueError(
+                "지원하지 않는 수정 범위입니다: "
+                f"{label}. 현재 Phase 2 는 지정한 텍스트 도형의 문구, 폰트 크기, "
+                "제목 강조만 지원합니다."
+            )
 
 
 def _keep_source_slide(
@@ -560,11 +621,65 @@ def _keep_source_slide(
 ) -> bool:
     if slide.category in {"cover", "closing"}:
         return True
-    if slide.category == "chart" and not has_numeric_data:
+    if _is_metric_or_chart_slide(slide) and not has_numeric_data:
         return False
     if slide.category == "visual" and not has_visual_asset:
         return False
     return True
+
+
+def _slot_is_editable(slot: Mapping[str, Any]) -> bool:
+    if slot.get("editable") is False:
+        return False
+    kind = str(slot.get("kind") or "").casefold()
+    return kind not in {"decorative", "background", "layout", "non_editable"}
+
+
+def _slot_requires_fill(slot: Mapping[str, Any]) -> bool:
+    return _slot_is_editable(slot) and slot.get("required") is not False
+
+
+def _allowed_actions_for_slot(slot: Mapping[str, Any]) -> set[str]:
+    raw_actions = slot.get("allowed_actions")
+    if isinstance(raw_actions, Sequence) and not isinstance(raw_actions, str):
+        actions = {str(action) for action in raw_actions}
+        if actions:
+            return actions
+
+    kind = str(slot.get("kind") or "text").casefold()
+    if kind == "chart":
+        return {"chart"}
+    return {"text", "remove"}
+
+
+def _validate_chart_fill_data(fill: Mapping[str, Any], shape_id: str) -> None:
+    data = fill.get("data")
+    if not isinstance(data, Mapping):
+        raise ValueError(f"chart fill 에는 data 객체가 필요합니다: {shape_id}")
+
+    categories = data.get("categories")
+    if not isinstance(categories, list) or not categories:
+        raise ValueError(f"chart fill 에는 data.categories 배열이 필요합니다: {shape_id}")
+
+    series_list = data.get("series")
+    if not isinstance(series_list, list) or not series_list:
+        raise ValueError(f"chart fill 에는 data.series 배열이 필요합니다: {shape_id}")
+
+    for index, series in enumerate(series_list):
+        if not isinstance(series, Mapping):
+            raise ValueError(f"chart data.series[{index}] 는 객체여야 합니다: {shape_id}")
+        values = series.get("values")
+        if not isinstance(values, list) or not values:
+            raise ValueError(f"chart data.series[{index}].values 배열이 필요합니다: {shape_id}")
+        if len(values) != len(categories):
+            raise ValueError(
+                f"chart categories 와 series[{index}].values 길이가 일치해야 합니다: {shape_id}"
+            )
+
+
+def _is_metric_or_chart_slide(slide: SourceSlide) -> bool:
+    text = f"{slide.category} {slide.description} {slide.best_for}"
+    return bool(_METRIC_SLIDE_PATTERN.search(text))
 
 
 def _has_numeric_signal(text: str) -> bool:

--- a/features/visualization/agents/generation.py
+++ b/features/visualization/agents/generation.py
@@ -74,6 +74,21 @@ _TEXT_TRANSFORM_HINTS = (
     "rephrase",
     "rewrite",
 )
+_GENERIC_TEXT_CHANGE_HINTS = (
+    "수정",
+    "변경",
+    "업데이트",
+    "update",
+)
+_STYLE_ONLY_TEXT_CHANGE_PATTERN = re.compile(
+    r"크기|폰트|font|pt|사이즈|size|키워\s*(줘|주세요)|키우|크게|작게|줄여|줄이|확대|축소|굵게|볼드|bold",
+    re.I,
+)
+_CHART_DATA_CHANGE_PATTERN = re.compile(
+    r"(차트|그래프|chart|graph).{0,16}(데이터|수치|값|series|categories|values|data)"
+    r"|(데이터|수치|값|series|categories|values|data).{0,16}(차트|그래프|chart|graph)",
+    re.I,
+)
 _UNSUPPORTED_REGENERATE_PATTERNS = (
     ("색상/채우기 변경", re.compile(r"색|색상|컬러|채우기|배경색|테두리|선색|color", re.I)),
     ("위치/배치 변경", re.compile(r"위치|이동|옮겨|배치|정렬|밖으로|position|move|align", re.I)),
@@ -82,7 +97,7 @@ _UNSUPPORTED_REGENERATE_PATTERNS = (
         "도형 크기 변경",
         re.compile(r"(도형|박스|상자|shape|box).{0,8}(크기|확대|축소|size|resize)", re.I),
     ),
-    ("차트 데이터 변경", re.compile(r"차트|그래프|chart|graph", re.I)),
+    ("차트 데이터 변경", _CHART_DATA_CHANGE_PATTERN),
     (
         "슬라이드/도형 생성",
         re.compile(r"슬라이드\s*(추가|삭제)|도형\s*(추가|삭제)|shape\s*(add|delete)", re.I),
@@ -596,9 +611,13 @@ def _guard_regenerate_font_size(value: Any) -> float:
 
 def _text_change_requested(user_request: str) -> bool:
     lowered = user_request.casefold()
+    if _STYLE_ONLY_TEXT_CHANGE_PATTERN.search(user_request):
+        return False
     if any(hint in lowered for hint in _TEXT_FIELD_HINTS):
         return True
     if any(hint in lowered for hint in _TEXT_TRANSFORM_HINTS):
+        return True
+    if any(hint in lowered for hint in _GENERIC_TEXT_CHANGE_HINTS):
         return True
     return bool(re.search(r"[\"'“”‘’][^\"'“”‘’]+[\"'“”‘’]\s*(로|으로)", user_request))
 

--- a/features/visualization/pptx/slide_editor.py
+++ b/features/visualization/pptx/slide_editor.py
@@ -29,6 +29,8 @@ class SlideEditor:
     PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 
     _TITLE_PLACEHOLDER_TYPES = frozenset({"title", "ctrTitle", "subTitle"})
+    _TEXT_ALLOWED_ACTIONS = ("text", "remove")
+    _CHART_ALLOWED_ACTIONS = ("chart",)
 
     def extract_slots(self, slide_xml_path: str) -> list[dict[str, Any]]:
         """
@@ -40,7 +42,9 @@ class SlideEditor:
         Returns:
             list[dict[str, Any]]: Slot 디스크립터 목록. 각 항목은 `shape_id`,
             `shape_name`, `x_emu`, `y_emu`, `w_emu`, `h_emu`, `current_text`,
-            `is_title_placeholder`, `font_size_pt`, `kind` 를 포함한다.
+            `is_title_placeholder`, `font_size_pt`, `kind`, `editable`, `required`,
+            `allowed_actions` 를 포함한다. 텍스트가 없는 장식 도형은 LLM fill
+            대상에서 제외한다.
         """
         doc = parse(slide_xml_path)
         sp_tree = self._first_descendant(doc, self.PML_NS, "spTree")
@@ -142,16 +146,28 @@ class SlideEditor:
 
         cnv_pr = self._get_cnv_pr(sp_element)
         tx_body = self._first_descendant(sp_element, self.PML_NS, "txBody")
+        is_title_placeholder = self._is_title_placeholder(sp_element)
+        if tx_body is None and not is_title_placeholder:
+            return None
+
+        current_text = self._text_body_content(tx_body) if tx_body is not None else ""
+        if not current_text.strip() and not is_title_placeholder:
+            return None
+
         kind = "image" if self._has_image_fill(sp_element) else "text"
 
         return {
             "shape_id": shape_id,
             "shape_name": cnv_pr.getAttribute("name") if cnv_pr is not None else "",
             **self._coordinates(sp_element),
-            "current_text": self._text_body_content(tx_body) if tx_body is not None else "",
-            "is_title_placeholder": self._is_title_placeholder(sp_element),
+            "current_text": current_text,
+            "is_title_placeholder": is_title_placeholder,
             "font_size_pt": self._first_font_size_pt(tx_body) if tx_body is not None else None,
             "kind": kind,
+            "role": "title" if is_title_placeholder else "body",
+            "editable": True,
+            "required": True,
+            "allowed_actions": list(self._TEXT_ALLOWED_ACTIONS),
         }
 
     def _describe_graphic_frame(
@@ -180,6 +196,10 @@ class SlideEditor:
             "is_title_placeholder": False,
             "font_size_pt": None,
             "kind": "chart",
+            "role": "chart",
+            "editable": True,
+            "required": True,
+            "allowed_actions": list(self._CHART_ALLOWED_ACTIONS),
             "chart_rel_id": self._chart_rel_id(chart),
             "chart_type": chart_summary.get("chart_type"),
             "categories": chart_summary.get("categories", []),

--- a/tasks/phase-1-pptx-worker/24-generation-quality-contract-guardrails.md
+++ b/tasks/phase-1-pptx-worker/24-generation-quality-contract-guardrails.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/05-phase1-generation-pipeline.md"
 depends_on: ["1.03", "1.05", "1.06", "1.07"]
 blocks: ["1.26"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-05-28"
 owner: ""
 sprint: ""
 ---
@@ -25,34 +26,34 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #239 본문과 현재 `extract_slots()` / fill 생성 prompt / Phase 2 parser 동작 확인
-- [ ] 스펙상 허용된 수정 범위와 현재 구현 가능 범위 비교
-- [ ] chart/numeric slide selection 회귀를 재현할 수 있는 fixture 확인
+- [x] GitHub Issue #239 본문과 현재 `extract_slots()` / fill 생성 prompt / Phase 2 parser 동작 확인
+- [x] 스펙상 허용된 수정 범위와 현재 구현 가능 범위 비교
+- [x] chart/numeric slide selection 회귀를 재현할 수 있는 fixture 확인
 
 ## 구현 체크리스트
 
-- [ ] 텍스트가 없는 장식 도형, 배경/레이아웃 보조 도형, 실제 편집 가능한 텍스트 도형 구분 기준 확인
-- [ ] `extract_slots()`가 LLM에 전달할 slot descriptor에서 비편집 도형을 제외하거나 optional/decorative로 표시하도록 개선
-- [ ] chart slot과 text slot의 필수/선택 채움 규칙 분리
-- [ ] fill 생성 단계가 장식 도형을 채우지 않았다는 이유로 실패하지 않도록 계약 정리
-- [ ] 숫자/성과 지표가 있는 포트폴리오에서 chart 또는 metric-oriented slide 후보가 포함되는지 테스트
-- [ ] template category/description/best_for 기반 filtering이 의도대로 작동하는지 테스트
-- [ ] 선택된 slide의 `reason` 또는 선택 근거 필드가 pipeline 후속 단계까지 보존되는지 테스트
-- [ ] cover/closing 포함, 7~12장, 연속 카테고리 회피 기존 규칙과 새 테스트의 충돌 확인
-- [ ] LLM Call #2 입력에서 slot별 역할, 제한, optional 여부가 명확히 표현되는지 확인
-- [ ] chart fill이 필요한 slide에서 chart data 구조가 누락되지 않도록 테스트 추가
-- [ ] 숫자, 고유명사, 성과 지표 보존 지침이 fill 생성과 QA fix 양쪽에서 일관되는지 확인
-- [ ] 지원하지 않는 shape size/color/position/layout 전환 요청이 조용히 잘못 적용되지 않도록 제한 또는 명시적 실패 처리
-- [ ] "제목만 키워줘" 요청에서 지정 대상 외 텍스트/차트/도형 보존 테스트 추가
+- [x] 텍스트가 없는 장식 도형, 배경/레이아웃 보조 도형, 실제 편집 가능한 텍스트 도형 구분 기준 확인
+- [x] `extract_slots()`가 LLM에 전달할 slot descriptor에서 비편집 도형을 제외하거나 optional/decorative로 표시하도록 개선
+- [x] chart slot과 text slot의 필수/선택 채움 규칙 분리
+- [x] fill 생성 단계가 장식 도형을 채우지 않았다는 이유로 실패하지 않도록 계약 정리
+- [x] 숫자/성과 지표가 있는 포트폴리오에서 chart 또는 metric-oriented slide 후보가 포함되는지 테스트
+- [x] template category/description/best_for 기반 filtering이 의도대로 작동하는지 테스트
+- [x] 선택된 slide의 `reason` 또는 선택 근거 필드가 pipeline 후속 단계까지 보존되는지 테스트
+- [x] cover/closing 포함, 7~12장, 연속 카테고리 회피 기존 규칙과 새 테스트의 충돌 확인
+- [x] LLM Call #2 입력에서 slot별 역할, 제한, optional 여부가 명확히 표현되는지 확인
+- [x] chart fill이 필요한 slide에서 chart data 구조가 누락되지 않도록 테스트 추가
+- [x] 숫자, 고유명사, 성과 지표 보존 지침이 fill 생성과 QA fix 양쪽에서 일관되는지 확인
+- [x] 지원하지 않는 shape size/color/position/layout 전환 요청이 조용히 잘못 적용되지 않도록 제한 또는 명시적 실패 처리
+- [x] "제목만 키워줘" 요청에서 지정 대상 외 텍스트/차트/도형 보존 테스트 추가
 
 ## Definition of Done
 
-- [ ] decorative/non-editable slot 제외 또는 optional 처리 테스트 통과
-- [ ] numeric/chart slide selection 테스트 통과
-- [ ] slide selection reason 보존 테스트 통과
-- [ ] chart fill 누락 방지 테스트 통과
-- [ ] Phase 2 지정 대상 외 불변 가드레일 테스트 통과
-- [ ] `uv run ruff check .` 및 관련 visualization 테스트 통과
+- [x] decorative/non-editable slot 제외 또는 optional 처리 테스트 통과
+- [x] numeric/chart slide selection 테스트 통과
+- [x] slide selection reason 보존 테스트 통과
+- [x] chart fill 누락 방지 테스트 통과
+- [x] Phase 2 지정 대상 외 불변 가드레일 테스트 통과
+- [x] `uv run ruff check .` 및 관련 visualization 테스트 통과
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -1,5 +1,6 @@
 """시각화 생성 LLM 어댑터 테스트."""
 
+import json
 from dataclasses import dataclass
 
 import pytest
@@ -66,6 +67,11 @@ def test_slide_plan_generator_validates_required_rules() -> None:
     assert plan.selected_slides[0].source_slide_id == "cover_A"
     assert plan.selected_slides[-1].category == "closing"
     assert plan.selected_slides[-1].slide_filename == "slide7.xml"
+    assert plan.to_blob()["selected_slides"][4]["reason"] == "chart_A 선택"
+
+    prompt_payload = json.loads(llm.messages[0][1].content)
+    assert prompt_payload["selection_signals"]["has_numeric_data"] is True
+    assert any(slide["id"] == "chart_A" for slide in prompt_payload["source_slides"])
 
 
 def test_slide_plan_generator_rejects_consecutive_categories() -> None:
@@ -218,6 +224,107 @@ def test_content_fill_generator_rejects_missing_slot_fill() -> None:
         )
 
 
+def test_content_fill_generator_does_not_require_optional_decorative_slot() -> None:
+    """optional/decorative slot 은 누락되어도 fill 생성 실패로 보지 않는다."""
+    llm = FakeLLM([{"fills": {"2": {"action": "text", "text": "핵심 요약"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.create_fills(
+        content_brief="요약",
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 20,
+                "kind": "text",
+                "editable": True,
+                "required": True,
+                "allowed_actions": ["text", "remove"],
+            },
+            {
+                "shape_id": "9",
+                "kind": "decorative",
+                "editable": False,
+                "required": False,
+                "allowed_actions": [],
+            },
+        ],
+    )
+
+    assert fills == {"2": {"action": "text", "text": "핵심 요약"}}
+    system_prompt = llm.messages[0][0].content
+    prompt_payload = json.loads(llm.messages[0][1].content.rsplit("\n", maxsplit=1)[1])
+    assert "required=false" in system_prompt
+    assert "성과 지표" in system_prompt
+    assert prompt_payload["slots"][1]["editable"] is False
+
+
+def test_content_fill_generator_rejects_fill_for_non_editable_slot() -> None:
+    """LLM 이 비편집 slot 을 채우려 하면 적용 전에 거부한다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "2": {"action": "text", "text": "핵심 요약"},
+                    "9": {"action": "text", "text": "장식 오염"},
+                }
+            }
+        ]
+    )
+    generator = LLMContentFillGenerator(llm=llm)
+
+    with pytest.raises(ValueError, match="비편집"):
+        generator.create_fills(
+            content_brief="요약",
+            slots=[
+                {"shape_id": "2", "font_size_pt": 20, "kind": "text"},
+                {"shape_id": "9", "kind": "decorative", "editable": False, "required": False},
+            ],
+        )
+
+
+def test_content_fill_generator_requires_chart_data_for_chart_slot() -> None:
+    """chart slot 은 chart action 과 data 구조가 함께 있어야 한다."""
+    llm = FakeLLM([{"fills": {"8": {"action": "chart"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    with pytest.raises(ValueError, match="data 객체"):
+        generator.create_fills(
+            content_brief="성과 지표 차트",
+            slots=[
+                {
+                    "shape_id": "8",
+                    "kind": "chart",
+                    "required": True,
+                    "allowed_actions": ["chart"],
+                }
+            ],
+        )
+
+
+def test_content_fill_generator_accepts_valid_chart_fill() -> None:
+    """chart fill 은 categories 와 series values 길이를 검증한 뒤 보존한다."""
+    chart_data = {
+        "categories": ["전", "후"],
+        "series": [{"name": "전환율", "values": [12, 42]}],
+    }
+    llm = FakeLLM([{"fills": {"8": {"action": "chart", "data": chart_data}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.create_fills(
+        content_brief="성과 지표 차트",
+        slots=[
+            {
+                "shape_id": "8",
+                "kind": "chart",
+                "required": True,
+                "allowed_actions": ["chart"],
+            }
+        ],
+    )
+
+    assert fills == {"8": {"action": "chart", "data": chart_data}}
+
+
 def test_content_fill_generator_rejects_invalid_action_with_pydantic_schema() -> None:
     """Fill action 은 Pydantic schema 단계에서 허용값으로 제한된다."""
     llm = FakeLLM([{"fills": {"2": {"action": "script", "text": "오류"}}}])
@@ -256,6 +363,33 @@ def test_slide_change_generator_preserves_text_for_style_only_request() -> None:
     assert changes == {"2": {"action": "text", "text": "현재 제목", "font_size_override": 48.0}}
 
 
+def test_slide_change_generator_does_not_treat_size_change_as_text_change() -> None:
+    """크기 변경 같은 스타일 요청은 '변경' 표현이 있어도 기존 텍스트를 보존한다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "2": {
+                        "action": "text",
+                        "text": "임의로 바뀐 제목",
+                        "font_size_override": 24,
+                    }
+                }
+            }
+        ]
+    )
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    changes = generator.create_changes(
+        user_request="제목 크기를 24pt로 변경해줘",
+        slots=[{"shape_id": "2", "current_text": "기존 제목", "font_size_pt": 20, "kind": "text"}],
+        current_fills={"2": {"action": "text", "text": "현재 제목"}},
+    )
+
+    assert changes["2"]["text"] == "현재 제목"
+    assert changes["2"]["font_size_override"] == 24.0
+
+
 def test_slide_change_generator_allows_explicit_text_request() -> None:
     """표현 변경 요청처럼 명시적인 텍스트 수정은 요청 도형에 한해 허용한다."""
     llm = FakeLLM(
@@ -281,6 +415,34 @@ def test_slide_change_generator_allows_explicit_text_request() -> None:
 
     assert changes["2"]["text"] == "핵심 성과 요약"
     assert changes["2"]["font_size_override"] == 18.0
+
+
+def test_slide_change_generator_rejects_unsupported_color_request_before_llm() -> None:
+    """현재 구현 범위 밖인 색상 변경 요청은 LLM 호출 전에 명시적으로 거부한다."""
+    llm = FakeLLM([])
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    with pytest.raises(ValueError, match="지원하지 않는 수정 범위"):
+        generator.create_changes(
+            user_request="제목 색을 빨간색으로 바꿔줘",
+            slots=[{"shape_id": "2", "current_text": "기존 제목", "kind": "text"}],
+            current_fills={"2": {"action": "text", "text": "기존 제목"}},
+        )
+
+    assert llm.messages == []
+
+
+def test_slide_change_generator_rejects_chart_shape_changes() -> None:
+    """Phase 2 일반 재생성은 chart slot 변경을 지원하지 않는다."""
+    llm = FakeLLM([{"fills": {"8": {"action": "chart", "data": {"series": []}}}}])
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    with pytest.raises(ValueError, match="텍스트 도형만"):
+        generator.create_changes(
+            user_request="이 영역 수치를 업데이트해줘",
+            slots=[{"shape_id": "8", "kind": "chart", "current_text": "기존 차트"}],
+            current_fills={"8": {"action": "chart", "data": {"series": []}}},
+        )
 
 
 def test_rule_prefilter_excludes_chart_and_visual_without_signals() -> None:
@@ -317,6 +479,23 @@ def test_rule_prefilter_keeps_chart_and_visual_with_signals() -> None:
     assert "visual" in {slide.category for slide in filtered}
 
 
+def test_rule_prefilter_uses_description_and_best_for_metric_signals() -> None:
+    """category 뿐 아니라 description/best_for 의 metric 신호도 필터링 기준으로 사용한다."""
+    slides = parse_template_metadata(_template_meta(include_visual=True, include_metric=True))
+
+    without_numbers = prefilter_source_slides(
+        portfolio_text="사용자 리서치와 문제 정의를 중심으로 진행했습니다.",
+        source_slides=slides,
+    )
+    with_numbers = prefilter_source_slides(
+        portfolio_text="전환율 42% 개선과 KPI 추적 결과를 정리했습니다.",
+        source_slides=slides,
+    )
+
+    assert "metric_A" not in {slide.source_slide_id for slide in without_numbers}
+    assert {"chart_A", "metric_A"} <= {slide.source_slide_id for slide in with_numbers}
+
+
 def test_slide_plan_output_error_message_lists_supported_keys() -> None:
     """slide_plan/selected_slides 둘 다 없을 때 허용 입력을 안내한다."""
     with pytest.raises(ValueError, match="selected_slides"):
@@ -344,6 +523,7 @@ def _template_meta(
     *,
     include_overview_b: bool = False,
     include_visual: bool = False,
+    include_metric: bool = False,
 ) -> dict[str, object]:
     slides = [
         _meta_slide(0, "cover_A", "cover"),
@@ -367,6 +547,19 @@ def _template_meta(
         slides.insert(2 + offset, _meta_slide(len(slides), "toc_A", "toc"))
         slides.insert(3 + offset, _meta_slide(len(slides), "problem_A", "problem"))
         slides.insert(-1, _meta_slide(len(slides), "visual_A", "visual"))
+        for index, slide in enumerate(slides):
+            slide["slide_index"] = index
+    if include_metric:
+        slides.insert(
+            -1,
+            {
+                "slide_index": len(slides),
+                "id": "metric_A",
+                "category": "text",
+                "description": "KPI metric dashboard 설명",
+                "best_for": "전환율, 매출, 성과 지표 비교에 적합",
+            },
+        )
         for index, slide in enumerate(slides):
             slide["slide_index"] = index
     return {

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -390,6 +390,32 @@ def test_slide_change_generator_does_not_treat_size_change_as_text_change() -> N
     assert changes["2"]["font_size_override"] == 24.0
 
 
+@pytest.mark.parametrize("user_request", ["제목을 수정해줘", "내용 변경해줘"])
+def test_slide_change_generator_allows_generic_text_change_request(user_request: str) -> None:
+    """수정/변경 요청은 스타일 맥락이 없으면 텍스트 변경으로 처리한다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "2": {
+                        "action": "text",
+                        "text": "핵심 성과 요약",
+                    }
+                }
+            }
+        ]
+    )
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    changes = generator.create_changes(
+        user_request=user_request,
+        slots=[{"shape_id": "2", "current_text": "기존 제목", "font_size_pt": 20, "kind": "text"}],
+        current_fills={"2": {"action": "text", "text": "기존 제목"}},
+    )
+
+    assert changes["2"]["text"] == "핵심 성과 요약"
+
+
 def test_slide_change_generator_allows_explicit_text_request() -> None:
     """표현 변경 요청처럼 명시적인 텍스트 수정은 요청 도형에 한해 허용한다."""
     llm = FakeLLM(
@@ -415,6 +441,75 @@ def test_slide_change_generator_allows_explicit_text_request() -> None:
 
     assert changes["2"]["text"] == "핵심 성과 요약"
     assert changes["2"]["font_size_override"] == 18.0
+
+
+def test_slide_change_generator_allows_chart_adjacent_text_style_request() -> None:
+    """차트 주변 텍스트 스타일 요청은 chart 데이터 변경으로 오인해 사전 거부하지 않는다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "2": {
+                        "action": "text",
+                        "text": "임의로 바뀐 차트 제목",
+                        "font_size_override": 28,
+                    }
+                }
+            }
+        ]
+    )
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    changes = generator.create_changes(
+        user_request="차트 제목 크기 키워줘",
+        slots=[
+            {"shape_id": "2", "current_text": "기존 차트 제목", "font_size_pt": 20, "kind": "text"}
+        ],
+        current_fills={"2": {"action": "text", "text": "현재 차트 제목"}},
+    )
+
+    assert changes["2"]["text"] == "현재 차트 제목"
+    assert changes["2"]["font_size_override"] == 28.0
+
+
+def test_slide_change_generator_allows_graph_caption_text_request() -> None:
+    """그래프 설명 문구 요청은 인접 텍스트 slot 변경으로 허용한다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "2": {
+                        "action": "text",
+                        "text": "전환율 개선 설명",
+                    }
+                }
+            }
+        ]
+    )
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    changes = generator.create_changes(
+        user_request="그래프 설명 문구를 바꿔줘",
+        slots=[{"shape_id": "2", "current_text": "기존 설명", "font_size_pt": 14, "kind": "text"}],
+        current_fills={"2": {"action": "text", "text": "기존 설명"}},
+    )
+
+    assert changes["2"]["text"] == "전환율 개선 설명"
+
+
+def test_slide_change_generator_rejects_chart_data_request_before_llm() -> None:
+    """차트 데이터 변경 요청은 현재 Phase 2 지원 범위 밖이므로 LLM 호출 전에 거부한다."""
+    llm = FakeLLM([])
+    generator = LLMSlideChangeGenerator(llm=llm)
+
+    with pytest.raises(ValueError, match="차트 데이터 변경"):
+        generator.create_changes(
+            user_request="차트 수치를 변경해줘",
+            slots=[{"shape_id": "2", "current_text": "기존 차트 제목", "kind": "text"}],
+            current_fills={"2": {"action": "text", "text": "기존 차트 제목"}},
+        )
+
+    assert llm.messages == []
 
 
 def test_slide_change_generator_rejects_unsupported_color_request_before_llm() -> None:

--- a/tests/test_features/test_visualization/test_slide_editor.py
+++ b/tests/test_features/test_visualization/test_slide_editor.py
@@ -212,8 +212,16 @@ def test_extract_slots_reads_text_and_chart_metadata(tmp_path: Path) -> None:
     assert slots["2"]["is_title_placeholder"] is True
     assert slots["2"]["font_size_pt"] == 40.0
     assert slots["2"]["kind"] == "text"
+    assert slots["2"]["editable"] is True
+    assert slots["2"]["required"] is True
+    assert slots["2"]["allowed_actions"] == ["text", "remove"]
+    assert slots["2"]["role"] == "title"
 
     assert slots["8"]["kind"] == "chart"
+    assert slots["8"]["editable"] is True
+    assert slots["8"]["required"] is True
+    assert slots["8"]["allowed_actions"] == ["chart"]
+    assert slots["8"]["role"] == "chart"
     assert slots["8"]["chart_rel_id"] == "rId7"
     assert slots["8"]["chart_type"] == "bar"
     assert slots["8"]["current_text"] == "기존 차트"
@@ -239,6 +247,48 @@ def test_extract_slots_preserves_soft_line_breaks(tmp_path: Path) -> None:
     slots = {slot["shape_id"]: slot for slot in SlideEditor().extract_slots(str(slide_path))}
 
     assert slots["2"]["current_text"] == "첫 줄\n둘째 줄"
+
+
+def test_extract_slots_excludes_decorative_empty_shapes(tmp_path: Path) -> None:
+    """텍스트가 없는 장식/레이아웃 도형은 LLM fill 대상 slot 으로 노출하지 않는다."""
+    slide_path, _ = _make_sample_package(tmp_path)
+    slide_xml = slide_path.read_text(encoding="utf-8").replace(
+        "      <p:graphicFrame>",
+        """      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="4" name="Decorative Circle"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="100" y="100"/>
+            <a:ext cx="200" cy="200"/>
+          </a:xfrm>
+          <a:solidFill><a:srgbClr val="FFCC00"/></a:solidFill>
+        </p:spPr>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="5" name="Empty Helper Label"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr/>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t></a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+      <p:graphicFrame>""",
+    )
+    slide_path.write_text(slide_xml, encoding="utf-8")
+
+    slots = {slot["shape_id"]: slot for slot in SlideEditor().extract_slots(str(slide_path))}
+
+    assert set(slots) == {"2", "3", "8"}
+    assert "Decorative Circle" not in {slot["shape_name"] for slot in slots.values()}
 
 
 def test_extract_slots_rejects_external_chart_relationship(tmp_path: Path) -> None:

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -229,12 +229,15 @@ class FakeToolchain:
 class FakeEditor:
     """SlideEditor 대역."""
 
-    def __init__(self) -> None:
+    def __init__(self, slots: list[dict[str, Any]] | None = None) -> None:
+        self.slots = slots or [
+            {"shape_id": "2", "font_size_pt": 20, "kind": "text"},
+        ]
         self.applied: list[tuple[str, dict[str, dict[str, Any]]]] = []
         self.cleared: list[str] = []
 
     def extract_slots(self, slide_xml_path: str) -> list[dict[str, Any]]:
-        return [{"shape_id": "2", "font_size_pt": 20, "kind": "text", "path": slide_xml_path}]
+        return [dict(slot, path=slide_xml_path) for slot in self.slots]
 
     def apply_fills(self, slide_xml_path: str, fills: dict[str, dict[str, Any]]) -> None:
         self.applied.append((slide_xml_path, fills))
@@ -414,6 +417,10 @@ async def test_generate_pipeline_success_sends_callbacks_and_uploads_outputs() -
 
     assert context.main_client.closed is True
     assert context.main_client.slide_plan_requests[0]["idempotency_key"] == "job-1:job:slide_plan"
+    assert (
+        context.main_client.slide_plan_requests[0]["slide_plan"]["selected_slides"][0]["reason"]
+        == "테스트"
+    )
     content_events = _events(context.main_client, "slide_content_ready")
     assert len(content_events) == 7
     assert content_events[0]["idempotency_key"] == "job-1:slide:slide-1:slide_content_ready"
@@ -564,6 +571,37 @@ async def test_regenerate_user_request_changes_only_requested_shape() -> None:
 
 
 @pytest.mark.asyncio
+async def test_regenerate_preserves_unrequested_text_and_chart_fills() -> None:
+    """제목만 키우는 요청은 본문과 차트 current_fills 를 그대로 유지한다."""
+    main_client = FakeMainClient()
+    main_client.slide_context["current_fills"]["8"] = {
+        "action": "chart",
+        "data": {
+            "categories": ["전", "후"],
+            "series": [{"name": "전환율", "values": [12, 42]}],
+        },
+    }
+    editor = FakeEditor(
+        slots=[
+            {"shape_id": "2", "font_size_pt": 20, "kind": "text", "current_text": "기존 제목"},
+            {"shape_id": "3", "font_size_pt": 14, "kind": "text", "current_text": "본문 유지"},
+            {"shape_id": "8", "kind": "chart", "current_text": "전환율 차트"},
+        ]
+    )
+    context = PipelineContext(main_client=main_client, editor=editor)
+
+    await context.service.regenerate(_regenerate_task(user_request="제목만 키워줘"))
+
+    _, applied_fills = context.editor.applied[0]
+    assert set(applied_fills) == {"2"}
+
+    event = _events(context.main_client, "slide_regenerated")[0]
+    assert event["current_fills"]["2"]["font_size_override"] == 28
+    assert event["current_fills"]["3"]["text"] == "본문 유지"
+    assert event["current_fills"]["8"]["data"]["series"][0]["values"] == [12, 42]
+
+
+@pytest.mark.asyncio
 async def test_retry_regenerate_uses_content_brief_without_user_request() -> None:
     """retry 는 userRequest 없이 저장된 content_brief 로 Step 3 fill 생성을 재사용한다."""
     context = PipelineContext()
@@ -694,12 +732,13 @@ class PipelineContext:
         filler: FakeFillGenerator | None = None,
         change_generator: FakeChangeGenerator | None = None,
         qa_step: FakeQAStep | None = None,
+        editor: FakeEditor | None = None,
         max_content_concurrency: int = 4,
     ) -> None:
         self.main_client = main_client or FakeMainClient()
         self.storage = FakeStorage()
         self.toolchain = FakeToolchain()
-        self.editor = FakeEditor()
+        self.editor = editor or FakeEditor()
         self.renderer = FakeRenderer()
         self.filler = filler or FakeFillGenerator()
         self.change_generator = change_generator or FakeChangeGenerator()


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #239

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 텍스트가 없는 장식/레이아웃 도형을 LLM fill 대상 slot 에서 제외하고, 편집 가능한 slot descriptor 에 `editable`, `required`, `allowed_actions`, `role` 계약을 추가했습니다.
- fill 생성 프롬프트와 파서를 보강해 optional/non-editable slot 누락을 허용하고, chart slot 에는 `data.categories` 와 `data.series[].values` 구조를 요구하도록 했습니다.
- 숫자/성과 지표가 있는 포트폴리오에서 chart 또는 metric-oriented Source Slide 후보가 유지되도록 filtering/prompt 신호를 보강했습니다.
- slide selection `reason` 이 저장용 slide plan blob 과 pipeline 후속 단계까지 보존되는지 회귀 테스트로 고정했습니다.
- Phase 2 수정 요청은 현재 구현 범위인 텍스트 도형의 문구/폰트/제목 강조 변경으로 제한하고, 색상·위치·레이아웃·차트 데이터 변경 요청은 명시적으로 거부하도록 했습니다.
- Task 1.24 문서를 완료 상태로 갱신했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`189 files already formatted`)
  - `uv run pytest` 통과 (`791 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 렌더 후 이미지 기반 QA 안정화는 기존 계획대로 Task 1.23 범위이며, 이번 PR은 LLM 계약과 OOXML 편집 대상 품질 가드레일에 집중했습니다.
- 별도 배포 전 수동 작업은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **품질 개선**
  * 콘텐츠 생성 시 더욱 엄격한 유효성 검사 적용으로 생성 품질 향상
  * 고유명사, 수치, 성과 지표 등 중요 정보 보존 강화
  * 편집 가능 슬롯과 지원되는 작업 범위를 명확히 하여 불필요한 수정 요청 사전 차단

* **테스트 및 문서**
  * 생성 품질 검증 테스트 케이스 확대
  * 작업 완료 문서 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->