### PR TITLE
[Fix] 재생성 산출물 promote 계약 정리 [1.25]

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -484,6 +484,7 @@ class VisualizationTaskService:
                         task.job_id,
                         registered_slide.slide_id,
                         "slide_regenerated",
+                        attempt_id,
                     ),
                     occurred_at=self._now_iso(),
                     schema_version=task.schema_version,
@@ -1262,8 +1263,11 @@ def _is_regenerate_retryable_error(exc: Exception) -> bool:
     return isinstance(exc, (OSError, PptxRenderError))
 
 
-def _slide_event_key(job_id: str, slide_id: str, event: str) -> str:
-    return f"{job_id}:slide:{slide_id}:{event}"
+def _slide_event_key(job_id: str, slide_id: str, event: str, *parts: str) -> str:
+    key = f"{job_id}:slide:{slide_id}:{event}"
+    if parts:
+        return f"{key}:{':'.join(parts)}"
+    return key
 
 
 def _job_event_key(job_id: str, event: str, stage: str | None = None) -> str:

--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -31,7 +33,7 @@ from features.visualization.pptx import (
     SlideEditor,
 )
 from features.visualization.qa import SlidePreview, VisualQA, VisualQAFixVerifyStep
-from features.visualization.storage.gcs_client import GcsClient, job_workdir
+from features.visualization.storage.gcs_client import GcsClient, job_workdir, preview_key
 
 logger = logging.getLogger(__name__)
 
@@ -159,12 +161,49 @@ class StorageClient(Protocol):
         """current.pptx 를 업로드하고 GCS key 를 반환한다."""
         ...
 
+    def upload_regeneration_attempt_pptx(
+        self,
+        job_id: str,
+        attempt_id: str,
+        src: Path,
+    ) -> str:
+        """재생성 PPTX 를 attempt key 로 업로드하고 GCS key 를 반환한다."""
+        ...
+
     def upload_pdf(self, job_id: str, src: Path) -> str:
         """current.pdf 를 업로드하고 GCS key 를 반환한다."""
         ...
 
+    def upload_regeneration_attempt_pdf(
+        self,
+        job_id: str,
+        attempt_id: str,
+        src: Path,
+    ) -> str:
+        """재생성 PDF 를 attempt key 로 업로드하고 GCS key 를 반환한다."""
+        ...
+
     def upload_preview(self, job_id: str, slide_order: int, src: Path) -> str:
         """슬라이드 프리뷰를 업로드하고 GCS key 를 반환한다."""
+        ...
+
+    def upload_regeneration_attempt_preview(
+        self,
+        job_id: str,
+        attempt_id: str,
+        slide_order: int,
+        src: Path,
+    ) -> str:
+        """재생성 프리뷰를 attempt key 로 업로드하고 GCS key 를 반환한다."""
+        ...
+
+    def promote_regeneration_attempt(
+        self,
+        job_id: str,
+        attempt_id: str,
+        slide_order: int,
+    ) -> Any:
+        """재생성 attempt 산출물을 canonical key 로 promote 한다."""
         ...
 
 
@@ -317,6 +356,7 @@ class VisualizationTaskService:
         main_client: MainClient,
     ) -> None:
         slide_context = await main_client.get_slide_context(task.job_id, task.slide_id)
+        attempt_id = _regeneration_attempt_id(task.idempotency_key)
         registered_slide = RegisteredSlide(
             slide_id=task.slide_id,
             slide_order=0,
@@ -413,6 +453,7 @@ class VisualizationTaskService:
                     fixed_pptx_path=fixed_pptx,
                     render_output_dir=qa_render_dir,
                     ready_event=None,
+                    preview_attempt_id=attempt_id,
                 )
                 ready_outcome = _single_ready_outcome(qa_result.outcomes)
                 if ready_outcome is None:
@@ -430,8 +471,9 @@ class VisualizationTaskService:
                         page=registered_slide.slide_order,
                     ).pdf_path
 
-                storage.upload_pptx(task.job_id, final_pptx)
-                storage.upload_pdf(task.job_id, final_pdf)
+                storage.upload_regeneration_attempt_pptx(task.job_id, attempt_id, final_pptx)
+                storage.upload_regeneration_attempt_pdf(task.job_id, attempt_id, final_pdf)
+                canonical_preview_key = preview_key(task.job_id, registered_slide.slide_order)
 
                 await main_client.send_slide_event(
                     task.job_id,
@@ -446,8 +488,24 @@ class VisualizationTaskService:
                     occurred_at=self._now_iso(),
                     schema_version=task.schema_version,
                     current_fills=final_fills,
-                    gcs_preview_key=ready_outcome.gcs_preview_key,
+                    gcs_preview_key=canonical_preview_key,
                 )
+                try:
+                    storage.promote_regeneration_attempt(
+                        task.job_id,
+                        attempt_id,
+                        registered_slide.slide_order,
+                    )
+                except Exception as exc:
+                    logger.exception(
+                        "regenerate artifact promote failed: job_id=%s slide_id=%s attempt_id=%s",
+                        task.job_id,
+                        task.slide_id,
+                        attempt_id,
+                    )
+                    raise RetryableError(f"재생성 산출물 promote에 실패했습니다: {exc}") from exc
+        except RetryableError:
+            raise
         except MainServerError:
             raise
         except Exception as exc:
@@ -1140,6 +1198,23 @@ def _single_ready_outcome(outcomes: Sequence[Any]) -> Any | None:
         if getattr(outcome, "status", None) == "ready":
             return outcome
     return None
+
+
+_SAFE_ATTEMPT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_UNSAFE_ATTEMPT_ID_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def _regeneration_attempt_id(idempotency_key: str) -> str:
+    """Cloud Tasks idempotency key 를 GCS-safe attempt id 로 변환한다."""
+    stripped = idempotency_key.strip()
+    if _SAFE_ATTEMPT_ID_PATTERN.fullmatch(stripped):
+        return stripped
+
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()[:12]
+    slug = _UNSAFE_ATTEMPT_ID_CHARS.sub("-", stripped).strip("-_")[:40]
+    if not slug:
+        slug = "attempt"
+    return f"{slug}-{digest}"
 
 
 def _slide_xml_path(unpacked_dir: Path, slide_filename: str) -> Path:

--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -294,6 +294,8 @@ class VisualQAFixVerifyStep:
         """렌더된 슬라이드들을 QA 처리하고 슬라이드별 ready/error 콜백을 보낸다."""
         if not slides:
             raise ValueError("시각 QA 대상 슬라이드가 없습니다.")
+        if preview_attempt_id is not None and ready_event is not None:
+            raise ValueError("preview_attempt_id를 사용할 때 ready_event는 None이어야 합니다.")
 
         unpacked_root = Path(unpacked_dir)
         working_pptx = Path(working_pptx_path)

--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -289,6 +289,7 @@ class VisualQAFixVerifyStep:
         fixed_pptx_path: str | Path,
         render_output_dir: str | Path,
         ready_event: str | None = "slide_preview_ready",
+        preview_attempt_id: str | None = None,
     ) -> VisualQAPipelineResult:
         """렌더된 슬라이드들을 QA 처리하고 슬라이드별 ready/error 콜백을 보낸다."""
         if not slides:
@@ -314,6 +315,7 @@ class VisualQAFixVerifyStep:
             outcomes=outcomes,
             checked_orders=checked_orders,
             ready_event=ready_event,
+            preview_attempt_id=preview_attempt_id,
         )
 
         fix_attempts = 0
@@ -356,6 +358,7 @@ class VisualQAFixVerifyStep:
                     outcomes=outcomes,
                     checked_orders=checked_orders,
                     ready_event=ready_event,
+                    preview_attempt_id=preview_attempt_id,
                 )
 
             failed_orders = [*unfixed_orders, *recheck_failed_orders]
@@ -400,6 +403,7 @@ class VisualQAFixVerifyStep:
         outcomes: dict[int, SlidePreviewOutcome],
         checked_orders: list[int],
         ready_event: str | None,
+        preview_attempt_id: str | None,
     ) -> list[int]:
         failed_orders: list[int] = []
         for slide_order in candidate_orders:
@@ -419,6 +423,7 @@ class VisualQAFixVerifyStep:
                     job_id,
                     pending_slide,
                     ready_event=ready_event,
+                    preview_attempt_id=preview_attempt_id,
                 )
                 outcomes[slide_order] = SlidePreviewOutcome(
                     slide_id=pending_slide.slide.slide_id,
@@ -492,10 +497,23 @@ class VisualQAFixVerifyStep:
         pending_slide: _PendingSlide,
         *,
         ready_event: str | None,
+        preview_attempt_id: str | None,
     ) -> str:
         slide = pending_slide.slide
         metadata = preview_metadata(pending_slide.image_path)
-        gcs_key = self._storage.upload_preview(job_id, slide.slide_order, pending_slide.image_path)
+        if preview_attempt_id is None:
+            gcs_key = self._storage.upload_preview(
+                job_id,
+                slide.slide_order,
+                pending_slide.image_path,
+            )
+        else:
+            gcs_key = self._storage.upload_regeneration_attempt_preview(
+                job_id,
+                preview_attempt_id,
+                slide.slide_order,
+                pending_slide.image_path,
+            )
         if ready_event is None:
             return gcs_key
 

--- a/apps/pptx-worker/features/visualization/storage/gcs_client.py
+++ b/apps/pptx-worker/features/visualization/storage/gcs_client.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from google.cloud import storage
@@ -95,6 +96,41 @@ def pdf_key(job_id: str) -> str:
     """
     _validate_identifier(job_id, "job_id")
     return f"jobs/{job_id}/current.pdf"
+
+
+def regeneration_attempt_pptx_key(job_id: str, attempt_id: str) -> str:
+    """재생성 attempt PPTX 파일의 staging GCS 키를 반환한다."""
+    _validate_identifier(job_id, "job_id")
+    _validate_identifier(attempt_id, "attempt_id")
+    return f"jobs/{job_id}/attempts/{attempt_id}/current.pptx"
+
+
+def regeneration_attempt_pdf_key(job_id: str, attempt_id: str) -> str:
+    """재생성 attempt PDF 파일의 staging GCS 키를 반환한다."""
+    _validate_identifier(job_id, "job_id")
+    _validate_identifier(attempt_id, "attempt_id")
+    return f"jobs/{job_id}/attempts/{attempt_id}/current.pdf"
+
+
+def regeneration_attempt_preview_key(job_id: str, attempt_id: str, slide_order: int) -> str:
+    """재생성 attempt 프리뷰 이미지의 staging GCS 키를 반환한다."""
+    _validate_identifier(job_id, "job_id")
+    _validate_identifier(attempt_id, "attempt_id")
+    if not 1 <= slide_order <= 99:
+        raise ValueError(f"slide_order는 1~99 범위여야 합니다. (받은 값: {slide_order})")
+    return f"jobs/{job_id}/attempts/{attempt_id}/previews/slide-{slide_order:02d}.jpg"
+
+
+@dataclass(frozen=True, slots=True)
+class RegenerationArtifactKeys:
+    """재생성 attempt 산출물과 canonical 산출물의 GCS key 묶음."""
+
+    attempt_pptx_key: str
+    attempt_pdf_key: str
+    attempt_preview_key: str
+    canonical_pptx_key: str
+    canonical_pdf_key: str
+    canonical_preview_key: str
 
 
 def template_pptx_key(template_id: str) -> str:
@@ -220,9 +256,23 @@ class GcsClient:
         logger.debug("gcs upload %s <- %s", key, src)
         return key
 
+    def upload_regeneration_attempt_pptx(self, job_id: str, attempt_id: str, src: Path) -> str:
+        """재생성 PPTX 산출물을 attempt key 로 업로드한다."""
+        key = regeneration_attempt_pptx_key(job_id, attempt_id)
+        self._bucket.blob(key).upload_from_filename(str(src), content_type=_PPTX_CONTENT_TYPE)
+        logger.debug("gcs upload %s <- %s", key, src)
+        return key
+
     def upload_pdf(self, job_id: str, src: Path) -> str:
         """로컬 PDF 파일을 GCS에 업로드하고 GCS 키를 반환한다."""
         key = pdf_key(job_id)
+        self._bucket.blob(key).upload_from_filename(str(src), content_type="application/pdf")
+        logger.debug("gcs upload %s <- %s", key, src)
+        return key
+
+    def upload_regeneration_attempt_pdf(self, job_id: str, attempt_id: str, src: Path) -> str:
+        """재생성 PDF 산출물을 attempt key 로 업로드한다."""
+        key = regeneration_attempt_pdf_key(job_id, attempt_id)
         self._bucket.blob(key).upload_from_filename(str(src), content_type="application/pdf")
         logger.debug("gcs upload %s <- %s", key, src)
         return key
@@ -238,12 +288,102 @@ class GcsClient:
         logger.debug("gcs upload %s <- %s", key, src)
         return key
 
+    def upload_regeneration_attempt_preview(
+        self,
+        job_id: str,
+        attempt_id: str,
+        slide_order: int,
+        src: Path,
+    ) -> str:
+        """재생성 프리뷰 산출물을 attempt key 로 업로드한다."""
+        key = regeneration_attempt_preview_key(job_id, attempt_id, slide_order)
+        self._bucket.blob(key).upload_from_filename(str(src), content_type="image/jpeg")
+        logger.debug("gcs upload %s <- %s", key, src)
+        return key
+
     def download_preview(self, job_id: str, slide_order: int, dest: Path) -> None:
         """슬라이드 프리뷰 JPG를 GCS에서 로컬 경로로 다운로드한다."""
         key = preview_key(job_id, slide_order)
         dest.parent.mkdir(parents=True, exist_ok=True)
         self._bucket.blob(key).download_to_filename(str(dest))
         logger.debug("gcs download %s -> %s", key, dest)
+
+    def promote_regeneration_attempt(
+        self,
+        job_id: str,
+        attempt_id: str,
+        slide_order: int,
+    ) -> RegenerationArtifactKeys:
+        """재생성 attempt 산출물을 canonical key 로 promote 한다.
+
+        Main Backend callback 이 성공한 뒤에만 호출되어야 한다. Promote 중 일부 copy 가
+        실패하면 사전에 백업한 이전 canonical 객체를 가능한 범위에서 복원한다.
+        """
+        keys = RegenerationArtifactKeys(
+            attempt_pptx_key=regeneration_attempt_pptx_key(job_id, attempt_id),
+            attempt_pdf_key=regeneration_attempt_pdf_key(job_id, attempt_id),
+            attempt_preview_key=regeneration_attempt_preview_key(job_id, attempt_id, slide_order),
+            canonical_pptx_key=pptx_key(job_id),
+            canonical_pdf_key=pdf_key(job_id),
+            canonical_preview_key=preview_key(job_id, slide_order),
+        )
+        backups = [
+            (
+                keys.canonical_pptx_key,
+                _regeneration_rollback_key(job_id, attempt_id, "current.pptx"),
+            ),
+            (
+                keys.canonical_pdf_key,
+                _regeneration_rollback_key(job_id, attempt_id, "current.pdf"),
+            ),
+            (
+                keys.canonical_preview_key,
+                _regeneration_rollback_key(job_id, attempt_id, f"slide-{slide_order:02d}.jpg"),
+            ),
+        ]
+        promotions = [
+            (keys.attempt_pptx_key, keys.canonical_pptx_key),
+            (keys.attempt_pdf_key, keys.canonical_pdf_key),
+            (keys.attempt_preview_key, keys.canonical_preview_key),
+        ]
+
+        backed_up: list[tuple[str, str]] = []
+        try:
+            for source_key, backup_key in backups:
+                self._copy_blob(source_key, backup_key)
+                backed_up.append((source_key, backup_key))
+            for source_key, destination_key in promotions:
+                self._copy_blob(source_key, destination_key)
+        except Exception:
+            logger.exception(
+                "gcs regeneration promote failed; restoring previous canonical artifacts: "
+                "job_id=%s attempt_id=%s slide_order=%s",
+                job_id,
+                attempt_id,
+                slide_order,
+            )
+            for canonical_key, backup_key in reversed(backed_up):
+                try:
+                    self._copy_blob(backup_key, canonical_key)
+                except Exception:
+                    logger.exception(
+                        "gcs regeneration rollback failed: canonical_key=%s backup_key=%s",
+                        canonical_key,
+                        backup_key,
+                    )
+            raise
+        logger.info(
+            "gcs regeneration attempt promoted: job_id=%s attempt_id=%s slide_order=%s",
+            job_id,
+            attempt_id,
+            slide_order,
+        )
+        return keys
+
+    def _copy_blob(self, source_key: str, destination_key: str) -> None:
+        source_blob = self._bucket.blob(source_key)
+        self._bucket.copy_blob(source_blob, self._bucket, destination_key)
+        logger.debug("gcs copy %s -> %s", source_key, destination_key)
 
 
 # ---------------------------------------------------------------------------
@@ -270,3 +410,11 @@ def job_workdir(job_id: str) -> Generator[Path, None, None]:
         shutil.rmtree(workdir, ignore_errors=True)
         get_worker_metrics().set_tmp_disk_bytes_used(safe_directory_size(WORKER_TMP_ROOT))
         logger.debug("cleaned up workdir %s", workdir)
+
+
+def _regeneration_rollback_key(job_id: str, attempt_id: str, filename: str) -> str:
+    _validate_identifier(job_id, "job_id")
+    _validate_identifier(attempt_id, "attempt_id")
+    if "/" in filename or not filename:
+        raise ValueError(f"filename은 단일 파일명이어야 합니다. (받은 값: {filename!r})")
+    return f"jobs/{job_id}/attempts/{attempt_id}/rollback/{filename}"

--- a/specs/phase-1/07-phase2-regenerate-retry-pipeline.md
+++ b/specs/phase-1/07-phase2-regenerate-retry-pipeline.md
@@ -7,14 +7,15 @@ regenerate push 를 받아 단일 Slide 를 사용자 요청(재생성) 또는 �
 - 메인 컨텍스트 조회(currentFills·sourceSlideId) 후 GCS `jobs/{job_id}/current.pptx` 다운로드 → unpack → 대상 슬라이드 XML 만 수정한다.
 - `isRetry=false`: `userRequest` 를 LLM 으로 해석해 변경 지시를 만든다(폰트 10~48pt, 요소 슬라이드 밖 금지, 미지정 도형 불변, 사용자 명시 시에만 텍스트 변경).
 - `isRetry=true`: `userRequest` 없이 jobs.slide_plan 의 해당 슬라이드 `content_brief` 로 Phase 1 Step 3 로직을 재사용해 채운다.
-- 꼬리 공통: pack(`--original current.pptx`) → 해당 페이지만 soffice/pdftoppm 렌더 → 시각 QA(이슈 시 최대 2회 수정) → current.pptx/current.pdf 덮어쓰기 + 새 프리뷰 PUT 후 `slide_regenerated`(currentFills·gcsPreviewKey) 콜백.
-- 실패 시 `slide_preview_error` 콜백만 보내고, 상태 롤백/카운터 보상은 메인이 처리하므로 워커는 관여하지 않는다.
+- 꼬리 공통: pack(`--original current.pptx`) → 해당 페이지만 soffice/pdftoppm 렌더 → 시각 QA(이슈 시 최대 2회 수정) → PPTX/PDF/프리뷰를 `jobs/{job_id}/attempts/{attempt_id}/...` 에 먼저 PUT → `slide_regenerated`(currentFills·canonical gcsPreviewKey) 콜백 성공 후에만 current.pptx/current.pdf/canonical preview 로 promote 한다.
+- 실패 시 `slide_preview_error` 콜백만 보내고, Main commit 성공 전에는 canonical current.pptx/current.pdf/preview 를 덮어쓰지 않는다. 상태 롤백/카운터 보상은 메인이 처리하므로 워커는 관여하지 않는다.
 
 ## Approach
-`apps/pptx-worker/features/visualization/service.py` 에 재생성 핸들러를 두되 spec 05 의 편집·렌더·QA 컴포넌트를 재사용하고 머리(④ 새 내용 계산)만 `isRetry` 로 분기한다(§5.3). 동시성 제어·재생성 한도·`current.pptx` 덮어쓰기 직렬화(Job row lock)는 모두 메인 백엔드 책임이므로 워커는 push 메시지를 신뢰해 멱등 처리만 한다(§7.4). 워커 가드는 slide 상태가 `regenerating`(재생성) 또는 `generating`(재시도)일 때만 처리한다(§7.4.5).
+`apps/pptx-worker/features/visualization/service.py` 에 재생성 핸들러를 두되 spec 05 의 편집·렌더·QA 컴포넌트를 재사용하고 머리(④ 새 내용 계산)만 `isRetry` 로 분기한다(§5.3). 재생성 산출물은 Cloud Tasks `idempotencyKey` 기반 attempt id 아래에 먼저 업로드하고, Main Backend 의 `slide_regenerated` callback 이 2xx 로 성공한 뒤 GCS copy 로 canonical key 를 promote 한다. 동시성 제어·재생성 한도·`current.pptx` promote 직렬화(Job row lock)는 모두 메인 백엔드 책임이므로 워커는 push 메시지를 신뢰해 멱등 처리만 한다(§7.4). 워커 가드는 slide 상태가 `regenerating`(재생성) 또는 `generating`(재시도)일 때만 처리한다(§7.4.5).
 
 ## Verification
 - `isRetry=false` 로 "제목 크기 키워줘" 요청 시 지정 도형만 변경되고 미지정 도형은 그대로인지 검증한다.
 - `isRetry=true` 시 `userRequest` 없이 content_brief 로 슬라이드가 다시 채워지는지 확인한다.
-- 재생성 후 current.pptx/current.pdf 가 덮어써지고 해당 페이지 프리뷰만 갱신되며 `slide_regenerated` 콜백이 발신되는지 확인한다.
+- 재생성 후보 산출물이 attempt key 에 먼저 업로드되고, `slide_regenerated` 콜백 성공 후에만 current.pptx/current.pdf 및 해당 페이지 canonical preview 로 promote 되는지 확인한다.
+- `slide_regenerated` 콜백 실패 또는 attempt upload 실패 시 canonical current.pptx/current.pdf/preview 가 이전 completed 상태로 유지되는지 확인한다.
 - slide 상태가 `regenerating`/`generating` 이 아닐 때 push 가 와도 워커가 처리하지 않고 200 으로 skip 하는지 검증한다.

--- a/specs/phase-1/07-phase2-regenerate-retry-pipeline.md
+++ b/specs/phase-1/07-phase2-regenerate-retry-pipeline.md
@@ -11,7 +11,7 @@ regenerate push 를 받아 단일 Slide 를 사용자 요청(재생성) 또는 �
 - 실패 시 `slide_preview_error` 콜백만 보내고, Main commit 성공 전에는 canonical current.pptx/current.pdf/preview 를 덮어쓰지 않는다. 상태 롤백/카운터 보상은 메인이 처리하므로 워커는 관여하지 않는다.
 
 ## Approach
-`apps/pptx-worker/features/visualization/service.py` 에 재생성 핸들러를 두되 spec 05 의 편집·렌더·QA 컴포넌트를 재사용하고 머리(④ 새 내용 계산)만 `isRetry` 로 분기한다(§5.3). 재생성 산출물은 Cloud Tasks `idempotencyKey` 기반 attempt id 아래에 먼저 업로드하고, Main Backend 의 `slide_regenerated` callback 이 2xx 로 성공한 뒤 GCS copy 로 canonical key 를 promote 한다. 동시성 제어·재생성 한도·`current.pptx` promote 직렬화(Job row lock)는 모두 메인 백엔드 책임이므로 워커는 push 메시지를 신뢰해 멱등 처리만 한다(§7.4). 워커 가드는 slide 상태가 `regenerating`(재생성) 또는 `generating`(재시도)일 때만 처리한다(§7.4.5).
+`apps/pptx-worker/features/visualization/generation_pipeline.py` 의 `VisualizationTaskService` 재생성 경로에서 spec 05 의 편집·렌더·QA 컴포넌트를 재사용하고 머리(④ 새 내용 계산)만 `isRetry` 로 분기한다(§5.3). 재생성 산출물은 Cloud Tasks `idempotencyKey` 기반 attempt id 아래에 먼저 업로드하고, Main Backend 의 `slide_regenerated` callback 이 2xx 로 성공한 뒤 GCS copy 로 canonical key 를 promote 한다. `slide_regenerated` idempotency key 는 같은 슬라이드의 서로 다른 재생성 attempt 를 구분하도록 attempt id 를 포함한다. 동시성 제어·재생성 한도·`current.pptx` promote 직렬화(Job row lock)는 모두 메인 백엔드 책임이므로 워커는 push 메시지를 신뢰해 멱등 처리만 한다(§7.4). 워커 가드는 slide 상태가 `regenerating`(재생성) 또는 `generating`(재시도)일 때만 처리한다(§7.4.5).
 
 ## Verification
 - `isRetry=false` 로 "제목 크기 키워줘" 요청 시 지정 도형만 변경되고 미지정 도형은 그대로인지 검증한다.

--- a/specs/phase-1/12-gcs-client.md
+++ b/specs/phase-1/12-gcs-client.md
@@ -10,7 +10,7 @@ signed URL 을 경유하지 않고 IAM 직접 인증으로 템플릿과 잡 산�
 - 로컬 임시 파일은 `/tmp` 작업 디렉터리에서 처리하고 작업 종료 시 정리한다.
 
 ## Approach
-`apps/pptx-worker/features/visualization/storage/`(예: `gcs_client.py`)에 GCS 클라이언트를 둔다. 버킷 `folioo-visualizations` 에 워커 SA 의 IAM 직접 R/W 권한을 부여한다. 워커는 signed URL 을 발급하지 않고 canonical `gcsPreviewKey` 만 콜백하며 signed 변환은 메인이 담당한다(spec 06 참조). 재생성 attempt key 는 사용자 signed URL 대상이 아니며, promote 실패 시 가능한 범위에서 사전 백업한 이전 canonical 객체로 롤백한다.
+`apps/pptx-worker/features/visualization/storage/`(예: `gcs_client.py`)에 GCS 클라이언트를 둔다. 버킷 `folioo-visualizations` 에 워커 SA 의 IAM 직접 R/W 권한을 부여한다. 워커는 signed URL 을 발급하지 않고 canonical `gcsPreviewKey` 만 콜백하며 signed 변환은 메인이 담당한다(spec 06 참조). 재생성 attempt key 는 사용자 signed URL 대상이 아니며, promote 실패 시 가능한 범위에서 사전 백업한 이전 canonical 객체로 롤백한다. `attempts/` 와 `rollback/` prefix 는 재시도·장애 분석을 위해 즉시 삭제하지 않고, 버킷 lifecycle rule 또는 운영 GC 로 보존 기간을 관리한다.
 
 ## Verification
 - GCS PUT/GET 이 IAM 직접 인증으로 동작하는지(signed URL 미경유) 확인한다.

--- a/specs/phase-1/12-gcs-client.md
+++ b/specs/phase-1/12-gcs-client.md
@@ -5,13 +5,15 @@ signed URL 을 경유하지 않고 IAM 직접 인증으로 템플릿과 잡 산�
 
 ## Requirements
 - IAM 직접 인증으로 `templates/**` GET 과 `jobs/{job_id}/...`(current.pptx/current.pdf/previews) PUT/GET 을 수행한다(signed URL 미경유).
+- 재생성 경로는 Main commit 전 canonical key 를 덮어쓰지 않도록 `jobs/{job_id}/attempts/{attempt_id}/...` 에 staging 업로드한 뒤, callback 성공 후 GCS copy 로 canonical current.pptx/current.pdf/preview 에 promote 한다.
 - 프리뷰 key canonical 규칙은 `jobs/{job_id}/previews/slide-{slide_order:02d}.jpg` 이며 PPTX/PDF 경로는 §9.1 을 따른다.
 - 로컬 임시 파일은 `/tmp` 작업 디렉터리에서 처리하고 작업 종료 시 정리한다.
 
 ## Approach
-`apps/pptx-worker/features/visualization/storage/`(예: `gcs_client.py`)에 GCS 클라이언트를 둔다. 버킷 `folioo-visualizations` 에 워커 SA 의 IAM 직접 R/W 권한을 부여한다. 워커는 signed URL 을 발급하지 않고 `gcsPreviewKey` 만 콜백하며 signed 변환은 메인이 담당한다(spec 06 참조).
+`apps/pptx-worker/features/visualization/storage/`(예: `gcs_client.py`)에 GCS 클라이언트를 둔다. 버킷 `folioo-visualizations` 에 워커 SA 의 IAM 직접 R/W 권한을 부여한다. 워커는 signed URL 을 발급하지 않고 canonical `gcsPreviewKey` 만 콜백하며 signed 변환은 메인이 담당한다(spec 06 참조). 재생성 attempt key 는 사용자 signed URL 대상이 아니며, promote 실패 시 가능한 범위에서 사전 백업한 이전 canonical 객체로 롤백한다.
 
 ## Verification
 - GCS PUT/GET 이 IAM 직접 인증으로 동작하는지(signed URL 미경유) 확인한다.
 - 프리뷰/PPTX/PDF 경로가 canonical 규칙을 준수하는지 확인한다.
+- 재생성 attempt key 업로드와 callback 성공 후 promote, promote 실패 시 rollback 시도를 확인한다.
 - 작업 종료 후 로컬 임시 파일이 정리되는지 확인한다.

--- a/tasks/phase-1-pptx-worker/25-regeneration-gcs-promote-consistency.md
+++ b/tasks/phase-1-pptx-worker/25-regeneration-gcs-promote-consistency.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/07-phase2-regenerate-retry-pipeline.md"
 depends_on: ["1.07", "1.12", "1.23"]
 blocks: ["1.26"]
 estimate: "L"
-status: "todo"
+status: "done"
+completed_at: "2026-05-29"
 owner: ""
 sprint: ""
 ---
@@ -24,33 +25,49 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #240 본문과 현재 regenerate upload/callback 순서 확인
-- [ ] Main Backend commit, callback, signed URL 발급 책임이 Worker와 어떻게 분리되는지 확인
-- [ ] 프론트가 사용하는 canonical key 규칙과 export 경로 확인
+- [x] GitHub Issue #240 본문과 현재 regenerate upload/callback 순서 확인
+- [x] Main Backend commit, callback, signed URL 발급 책임이 Worker와 어떻게 분리되는지 확인
+- [x] 프론트가 사용하는 canonical key 규칙과 export 경로 확인
 
 ## 구현 체크리스트
 
-- [ ] regenerate/retry 경로에서 PPTX/PDF/preview가 업로드되는 순서 확인
-- [ ] `slide_regenerated` 콜백 전후로 canonical key가 언제 바뀌는지 정리
-- [ ] 콜백 실패, Main 5xx, Main 4xx, upload 실패, QA 실패 케이스별 현재 결과를 표로 정리
-- [ ] 초기 생성 경로와 재생성 경로의 canonical key 책임 차이 분리
-- [ ] 재생성 산출물을 먼저 attempt/staging key에 업로드하는 방식 검토
-- [ ] canonical `current.pptx`, `current.pdf`, `previews/slide-XX.jpg`가 언제 promote되는지 정의
-- [ ] Main Backend가 commit 후 promote를 요청/승인하는 계약이 필요한지 정리
-- [ ] Worker repo에서 구현 가능한 범위와 Main Backend 후속 구현 범위 분리
-- [ ] Main commit 성공 전 canonical key overwrite가 발생하지 않도록 업로드 순서 조정
-- [ ] 실패한 attempt 산출물이 프론트 signed URL 대상이 되지 않도록 key 반환 규칙 점검
-- [ ] retry 중복 실행과 attempt key 충돌이 생기지 않도록 idempotency key 또는 attempt id 활용 방안 정리
-- [ ] 성공/실패 callback payload가 기존 Main 계약과 호환되는지 확인
+- [x] regenerate/retry 경로에서 PPTX/PDF/preview가 업로드되는 순서 확인
+- [x] `slide_regenerated` 콜백 전후로 canonical key가 언제 바뀌는지 정리
+- [x] 콜백 실패, Main 5xx, Main 4xx, upload 실패, QA 실패 케이스별 현재 결과를 표로 정리
+- [x] 초기 생성 경로와 재생성 경로의 canonical key 책임 차이 분리
+- [x] 재생성 산출물을 먼저 attempt/staging key에 업로드하는 방식 검토
+- [x] canonical `current.pptx`, `current.pdf`, `previews/slide-XX.jpg`가 언제 promote되는지 정의
+- [x] Main Backend가 commit 후 promote를 요청/승인하는 계약이 필요한지 정리
+- [x] Worker repo에서 구현 가능한 범위와 Main Backend 후속 구현 범위 분리
+- [x] Main commit 성공 전 canonical key overwrite가 발생하지 않도록 업로드 순서 조정
+- [x] 실패한 attempt 산출물이 프론트 signed URL 대상이 되지 않도록 key 반환 규칙 점검
+- [x] retry 중복 실행과 attempt key 충돌이 생기지 않도록 idempotency key 또는 attempt id 활용 방안 정리
+- [x] 성공/실패 callback payload가 기존 Main 계약과 호환되는지 확인
 
 ## Definition of Done
 
-- [ ] Main commit 성공 전 canonical PPTX/PDF/preview overwrite가 일어나지 않음
-- [ ] 콜백 실패 시 DB 상태와 사용자 노출 산출물이 이전 completed 버전으로 일관됨
-- [ ] 성공 경로에서만 canonical key가 최신 결과로 promote됨
-- [ ] 실패한 attempt key가 프론트 preview/export 경로로 노출되지 않음
-- [ ] 관련 정합성 테스트 또는 계약 테스트 통과
-- [ ] `uv run ruff check .` 및 관련 worker 테스트 통과
+- [x] Main commit 성공 전 canonical PPTX/PDF/preview overwrite가 일어나지 않음
+- [x] 콜백 실패 시 DB 상태와 사용자 노출 산출물이 이전 completed 버전으로 일관됨
+- [x] 성공 경로에서만 canonical key가 최신 결과로 promote됨
+- [x] 실패한 attempt key가 프론트 preview/export 경로로 노출되지 않음
+- [x] 관련 정합성 테스트 또는 계약 테스트 통과
+- [x] `uv run ruff check .` 및 관련 worker 테스트 통과
+
+## 구현 결과
+
+- 재생성 attempt key: `jobs/{job_id}/attempts/{attempt_id}/current.pptx`, `current.pdf`, `previews/slide-XX.jpg`
+- canonical key: 기존 `jobs/{job_id}/current.pptx`, `current.pdf`, `previews/slide-XX.jpg` 유지
+- Worker 순서: attempt preview/PPTX/PDF 업로드 → `slide_regenerated` callback 성공 → canonical promote
+- `slide_regenerated.gcsPreviewKey` 는 프론트 signed URL 규칙을 깨지 않도록 canonical preview key 만 보낸다.
+
+| 케이스 | Worker 결과 | 사용자 노출 canonical |
+| --- | --- | --- |
+| QA 실패 | `slide_preview_error`, attempt/canonical 업로드 없음 | 이전 completed 유지 |
+| attempt upload 실패 | `slide_preview_error`, attempt key 를 callback 하지 않음 | 이전 completed 유지 |
+| Main callback 4xx/5xx/timeout | Cloud Tasks retry, promote 미실행 | 이전 completed 유지 |
+| promote 성공 | attempt 산출물을 canonical 로 copy | 최신 결과 |
+| promote 중 copy 실패 | 가능한 범위에서 backup canonical 로 rollback 후 Cloud Tasks retry | rollback 성공 시 이전 completed 유지 |
+| 중복 retry | 같은 idempotency key 기반 attempt id 재사용 | 같은 canonical 대상에 멱등 promote |
 
 ## 리스크 / 메모
 

--- a/tasks/phase-1-pptx-worker/25-regeneration-gcs-promote-consistency.md
+++ b/tasks/phase-1-pptx-worker/25-regeneration-gcs-promote-consistency.md
@@ -67,9 +67,11 @@ sprint: ""
 | Main callback 4xx/5xx/timeout | Cloud Tasks retry, promote 미실행 | 이전 completed 유지 |
 | promote 성공 | attempt 산출물을 canonical 로 copy | 최신 결과 |
 | promote 중 copy 실패 | 가능한 범위에서 backup canonical 로 rollback 후 Cloud Tasks retry | rollback 성공 시 이전 completed 유지 |
+| rollback 실패 | Worker 로그를 남기고 재시도 실패로 전파한다. 부분 canonical 혼합 가능성이 있으므로 운영 알림/수동 복구 정책은 1.26 handoff 범위다. | 운영 복구 전까지 불일치 가능 |
 | 중복 retry | 같은 idempotency key 기반 attempt id 재사용 | 같은 canonical 대상에 멱등 promote |
 
 ## 리스크 / 메모
 
 - Main Backend의 DB 트랜잭션, CAS, signed URL 발급 구현은 별도 저장소 책임이다.
 - 필요한 callback/promote 계약 변경은 1.26 handoff에 반영한다.
+- attempt/rollback prefix 는 재시도와 장애 분석을 위해 즉시 삭제하지 않는다. GCS lifecycle rule 또는 주기적 GC 보존 기간은 1.26 handoff에서 운영 정책으로 확정한다.

--- a/tasks/phase-1-pptx-worker/26-spec-task-main-backend-handoff.md
+++ b/tasks/phase-1-pptx-worker/26-spec-task-main-backend-handoff.md
@@ -72,3 +72,6 @@ sprint: ""
 - 이 task는 문서 정합성과 handoff가 범위다. 문서가 가리키는 코드 수정은 1.20~1.25에서 처리한다.
 - Main Backend 저장소가 별도로 있다면, 이 task 결과를 그쪽 이슈 생성의 원본으로 사용할 수 있게 작성한다.
 - 1.25 handoff에는 재생성 산출물 계약을 명시한다: Worker는 attempt key 업로드 후 `slide_regenerated` 2xx를 Main commit 성공으로 간주하고 canonical promote를 수행한다. Main은 실패한 attempt key를 signed URL 대상으로 노출하지 않고, `slide_regenerated` idempotency 처리와 promote 실패 재시도 중 사용자 노출 정책을 정리해야 한다.
+- Main Backend는 `slide_regenerated` callback 직후 canonical signed URL 발급 시점이 GCS promote 완료보다 앞설 수 있음을 전제로, promote 완료 확인 전에는 이전 preview 유지 또는 pending 상태 노출 정책을 정해야 한다.
+- Worker promote rollback 도 일부 GCS copy 실패 시 완전 원자성을 보장할 수 없으므로, Main/운영 handoff에는 부분 canonical 혼합 감지, 알림, 수동 복구 절차, job 단위 잠금/generation precondition 적용 가능성을 포함한다.
+- `jobs/{job_id}/attempts/{attempt_id}/...` 및 `rollback/` 객체는 즉시 삭제하지 않는다. 배포/운영 handoff에서 bucket lifecycle rule 또는 주기적 GC로 보존 기간을 정한다.

--- a/tasks/phase-1-pptx-worker/26-spec-task-main-backend-handoff.md
+++ b/tasks/phase-1-pptx-worker/26-spec-task-main-backend-handoff.md
@@ -71,3 +71,4 @@ sprint: ""
 
 - 이 task는 문서 정합성과 handoff가 범위다. 문서가 가리키는 코드 수정은 1.20~1.25에서 처리한다.
 - Main Backend 저장소가 별도로 있다면, 이 task 결과를 그쪽 이슈 생성의 원본으로 사용할 수 있게 작성한다.
+- 1.25 handoff에는 재생성 산출물 계약을 명시한다: Worker는 attempt key 업로드 후 `slide_regenerated` 2xx를 Main commit 성공으로 간주하고 canonical promote를 수행한다. Main은 실패한 attempt key를 signed URL 대상으로 노출하지 않고, `slide_regenerated` idempotency 처리와 promote 실패 재시도 중 사용자 노출 정책을 정리해야 한다.

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -147,10 +147,15 @@ class FakeStorage:
 
     def __init__(self) -> None:
         self.download_error: Exception | None = None
+        self.attempt_pptx_error: Exception | None = None
         self.downloaded_pptx: list[tuple[str, Path]] = []
         self.uploaded_pptx: list[tuple[str, Path]] = []
         self.uploaded_pdf: list[tuple[str, Path]] = []
         self.uploaded_previews: list[tuple[str, int, Path]] = []
+        self.uploaded_attempt_pptx: list[tuple[str, str, Path]] = []
+        self.uploaded_attempt_pdf: list[tuple[str, str, Path]] = []
+        self.uploaded_attempt_previews: list[tuple[str, str, int, Path]] = []
+        self.promoted_attempts: list[tuple[str, str, int]] = []
 
     def download_template(self, template_id: str, dest: Path) -> None:
         assert template_id == "blue"
@@ -173,13 +178,41 @@ class FakeStorage:
         self.uploaded_pptx.append((job_id, src))
         return f"jobs/{job_id}/current.pptx"
 
+    def upload_regeneration_attempt_pptx(
+        self,
+        job_id: str,
+        attempt_id: str,
+        src: Path,
+    ) -> str:
+        if self.attempt_pptx_error is not None:
+            raise self.attempt_pptx_error
+        self.uploaded_attempt_pptx.append((job_id, attempt_id, src))
+        return f"jobs/{job_id}/attempts/{attempt_id}/current.pptx"
+
     def upload_pdf(self, job_id: str, src: Path) -> str:
         self.uploaded_pdf.append((job_id, src))
         return f"jobs/{job_id}/current.pdf"
 
+    def upload_regeneration_attempt_pdf(self, job_id: str, attempt_id: str, src: Path) -> str:
+        self.uploaded_attempt_pdf.append((job_id, attempt_id, src))
+        return f"jobs/{job_id}/attempts/{attempt_id}/current.pdf"
+
     def upload_preview(self, job_id: str, slide_order: int, src: Path) -> str:
         self.uploaded_previews.append((job_id, slide_order, src))
         return f"jobs/{job_id}/previews/slide-{slide_order:02d}.jpg"
+
+    def upload_regeneration_attempt_preview(
+        self,
+        job_id: str,
+        attempt_id: str,
+        slide_order: int,
+        src: Path,
+    ) -> str:
+        self.uploaded_attempt_previews.append((job_id, attempt_id, slide_order, src))
+        return f"jobs/{job_id}/attempts/{attempt_id}/previews/slide-{slide_order:02d}.jpg"
+
+    def promote_regeneration_attempt(self, job_id: str, attempt_id: str, slide_order: int) -> None:
+        self.promoted_attempts.append((job_id, attempt_id, slide_order))
 
 
 class FakeToolchain:
@@ -358,17 +391,26 @@ class FakeQAStep:
 
     async def process(self, *, job_id: str, slides: list[Any], **kwargs: Any) -> FakeQAResult:
         ready_event = kwargs.get("ready_event", "slide_preview_ready")
+        preview_attempt_id = kwargs.get("preview_attempt_id")
         outcomes = []
         for slide in slides:
             self.received_orders.append(slide.slide_order)
             status = self.statuses.get(slide.slide_order, "ready")
             if status == "ready":
                 if self.storage is not None:
-                    gcs_preview_key = self.storage.upload_preview(
-                        job_id,
-                        slide.slide_order,
-                        slide.image_path,
-                    )
+                    if preview_attempt_id is None:
+                        gcs_preview_key = self.storage.upload_preview(
+                            job_id,
+                            slide.slide_order,
+                            slide.image_path,
+                        )
+                    else:
+                        gcs_preview_key = self.storage.upload_regeneration_attempt_preview(
+                            job_id,
+                            preview_attempt_id,
+                            slide.slide_order,
+                            slide.image_path,
+                        )
                 else:
                     gcs_preview_key = f"jobs/{job_id}/previews/slide-{slide.slide_order:02d}.jpg"
                 if ready_event is not None:
@@ -558,9 +600,13 @@ async def test_regenerate_user_request_changes_only_requested_shape() -> None:
     assert event["current_fills"]["2"]["font_size_override"] == 28
     assert event["current_fills"]["3"]["text"] == "본문 유지"
     assert _events(context.main_client, "slide_preview_ready") == []
-    assert context.storage.uploaded_pptx
-    assert context.storage.uploaded_pdf
-    assert context.storage.uploaded_previews[0][:2] == ("job-1", 3)
+    assert context.storage.uploaded_pptx == []
+    assert context.storage.uploaded_pdf == []
+    assert context.storage.uploaded_previews == []
+    assert context.storage.uploaded_attempt_pptx[0][:2] == ("job-1", "task-key")
+    assert context.storage.uploaded_attempt_pdf[0][:2] == ("job-1", "task-key")
+    assert context.storage.uploaded_attempt_previews[0][:3] == ("job-1", "task-key", 3)
+    assert context.storage.promoted_attempts == [("job-1", "task-key", 3)]
 
 
 @pytest.mark.asyncio
@@ -580,6 +626,8 @@ async def test_retry_regenerate_uses_content_brief_without_user_request() -> Non
     regenerated_events = _events(context.main_client, "slide_regenerated")
     assert regenerated_events[0]["current_fills"] == applied_fills
     assert regenerated_events[0]["gcs_preview_key"] == "jobs/job-1/previews/slide-03.jpg"
+    assert context.storage.uploaded_attempt_pptx[0][:2] == ("job-1", "task-key")
+    assert context.storage.promoted_attempts == [("job-1", "task-key", 3)]
 
 
 @pytest.mark.asyncio
@@ -599,6 +647,10 @@ async def test_regenerate_failure_sends_preview_error_without_output_upload() ->
     assert context.storage.uploaded_pptx == []
     assert context.storage.uploaded_pdf == []
     assert context.storage.uploaded_previews == []
+    assert context.storage.uploaded_attempt_pptx == []
+    assert context.storage.uploaded_attempt_pdf == []
+    assert context.storage.uploaded_attempt_previews == []
+    assert context.storage.promoted_attempts == []
 
 
 def _regenerate_qa_failure_context() -> PipelineContext:
@@ -682,6 +734,65 @@ async def test_regenerate_error_scenarios_send_preview_error_without_current_upl
     assert context.storage.uploaded_pptx == []
     assert context.storage.uploaded_pdf == []
     assert context.storage.uploaded_previews == []
+    assert context.storage.uploaded_attempt_pptx == []
+    assert context.storage.uploaded_attempt_pdf == []
+    assert context.storage.promoted_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_regenerate_callback_failure_keeps_canonical_outputs_unchanged() -> None:
+    """성공 후보 업로드 후 callback 이 실패하면 canonical promote 를 실행하지 않는다."""
+    context = PipelineContext(main_client=FakeMainClient(fail_slide_events={"slide_regenerated"}))
+
+    with pytest.raises(RetryableError):
+        await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
+
+    assert context.storage.uploaded_attempt_previews[0][:3] == ("job-1", "task-key", 3)
+    assert context.storage.uploaded_attempt_pptx[0][:2] == ("job-1", "task-key")
+    assert context.storage.uploaded_attempt_pdf[0][:2] == ("job-1", "task-key")
+    assert context.storage.uploaded_pptx == []
+    assert context.storage.uploaded_pdf == []
+    assert context.storage.uploaded_previews == []
+    assert context.storage.promoted_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_regenerate_attempt_upload_failure_does_not_expose_attempt_key() -> None:
+    """attempt 업로드 실패는 preview error 로 수렴하고 attempt key 를 callback 하지 않는다."""
+    context = PipelineContext()
+    context.storage.attempt_pptx_error = OSError("attempt upload failed")
+
+    await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
+
+    assert _events(context.main_client, "slide_regenerated") == []
+    error_events = _events(context.main_client, "slide_preview_error")
+    assert len(error_events) == 1
+    assert "attempt upload failed" in error_events[0]["message"]
+    assert "gcs_preview_key" not in error_events[0]
+    assert context.storage.uploaded_attempt_previews[0][:3] == ("job-1", "task-key", 3)
+    assert context.storage.uploaded_attempt_pptx == []
+    assert context.storage.uploaded_pptx == []
+    assert context.storage.uploaded_pdf == []
+    assert context.storage.uploaded_previews == []
+    assert context.storage.promoted_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_regenerate_push_reuses_same_attempt_key() -> None:
+    """같은 idempotency key 재시도는 같은 attempt key 로 업로드/promote 되어 충돌 범위가 고정된다."""
+    context = PipelineContext()
+
+    await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
+    await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
+
+    assert [item[1] for item in context.storage.uploaded_attempt_pptx] == [
+        "task-key",
+        "task-key",
+    ]
+    assert context.storage.promoted_attempts == [
+        ("job-1", "task-key", 3),
+        ("job-1", "task-key", 3),
+    ]
 
 
 class PipelineContext:

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -596,6 +596,7 @@ async def test_regenerate_user_request_changes_only_requested_shape() -> None:
     assert len(regenerated_events) == 1
     event = regenerated_events[0]
     assert event["slide_order"] == 3
+    assert event["idempotency_key"] == "job-1:slide:slide-3:slide_regenerated:task-key"
     assert event["gcs_preview_key"] == "jobs/job-1/previews/slide-03.jpg"
     assert event["current_fills"]["2"]["font_size_override"] == 28
     assert event["current_fills"]["3"]["text"] == "본문 유지"
@@ -605,7 +606,9 @@ async def test_regenerate_user_request_changes_only_requested_shape() -> None:
     assert context.storage.uploaded_previews == []
     assert context.storage.uploaded_attempt_pptx[0][:2] == ("job-1", "task-key")
     assert context.storage.uploaded_attempt_pdf[0][:2] == ("job-1", "task-key")
-    assert context.storage.uploaded_attempt_previews[0][:3] == ("job-1", "task-key", 3)
+    assert any(
+        item[:3] == ("job-1", "task-key", 3) for item in context.storage.uploaded_attempt_previews
+    )
     assert context.storage.promoted_attempts == [("job-1", "task-key", 3)]
 
 
@@ -747,7 +750,9 @@ async def test_regenerate_callback_failure_keeps_canonical_outputs_unchanged() -
     with pytest.raises(RetryableError):
         await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
 
-    assert context.storage.uploaded_attempt_previews[0][:3] == ("job-1", "task-key", 3)
+    assert any(
+        item[:3] == ("job-1", "task-key", 3) for item in context.storage.uploaded_attempt_previews
+    )
     assert context.storage.uploaded_attempt_pptx[0][:2] == ("job-1", "task-key")
     assert context.storage.uploaded_attempt_pdf[0][:2] == ("job-1", "task-key")
     assert context.storage.uploaded_pptx == []
@@ -788,6 +793,12 @@ async def test_duplicate_regenerate_push_reuses_same_attempt_key() -> None:
     assert [item[1] for item in context.storage.uploaded_attempt_pptx] == [
         "task-key",
         "task-key",
+    ]
+    assert [
+        event["idempotency_key"] for event in _events(context.main_client, "slide_regenerated")
+    ] == [
+        "job-1:slide:slide-3:slide_regenerated:task-key",
+        "job-1:slide:slide-3:slide_regenerated:task-key",
     ]
     assert context.storage.promoted_attempts == [
         ("job-1", "task-key", 3),

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -466,6 +466,29 @@ async def test_preview_attempt_id_uploads_regenerate_preview_to_attempt_key(
 
 
 @pytest.mark.asyncio
+async def test_preview_attempt_id_rejects_ready_event(tmp_path: Path) -> None:
+    """attempt preview key 가 ready callback payload 로 노출되는 조합을 차단한다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    qa = FakeQA({1: [_passed()]})
+    step = context.make_step(qa=qa, renderer=FakeRenderer(pages=[1]))
+
+    with pytest.raises(ValueError, match="ready_event"):
+        await step.process(
+            job_id="job-1",
+            slides=context.slides,
+            unpacked_dir=context.unpacked_dir,
+            working_pptx_path=context.working_pptx,
+            fixed_pptx_path=context.fixed_pptx,
+            render_output_dir=context.render_dir,
+            preview_attempt_id="attempt-1",
+        )
+
+    assert context.storage.uploads == []
+    assert context.storage.attempt_uploads == []
+    assert context.main_client.events == []
+
+
+@pytest.mark.asyncio
 async def test_failed_after_max_attempts_preserves_non_retryable_issue(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -80,10 +80,21 @@ class FakeStorage:
 
     def __init__(self) -> None:
         self.uploads: list[tuple[str, int, Path]] = []
+        self.attempt_uploads: list[tuple[str, str, int, Path]] = []
 
     def upload_preview(self, job_id: str, slide_order: int, src: Path) -> str:
         self.uploads.append((job_id, slide_order, src))
         return preview_key(job_id, slide_order)
+
+    def upload_regeneration_attempt_preview(
+        self,
+        job_id: str,
+        attempt_id: str,
+        slide_order: int,
+        src: Path,
+    ) -> str:
+        self.attempt_uploads.append((job_id, attempt_id, slide_order, src))
+        return f"jobs/{job_id}/attempts/{attempt_id}/previews/slide-{slide_order:02d}.jpg"
 
 
 class FakeMainClient:
@@ -424,6 +435,34 @@ async def test_ready_event_can_be_suppressed_after_preview_upload(tmp_path: Path
     assert result.outcomes[0].status == "ready"
     assert result.outcomes[0].gcs_preview_key == "jobs/job-1/previews/slide-01.jpg"
     assert result.outcomes[0].current_fills["2"]["text"] == "Folioo KPI 10%"
+
+
+@pytest.mark.asyncio
+async def test_preview_attempt_id_uploads_regenerate_preview_to_attempt_key(
+    tmp_path: Path,
+) -> None:
+    """재생성 QA 경로는 canonical preview 대신 attempt preview key 로 업로드할 수 있다."""
+    context = _make_step_context(tmp_path, slide_orders=[1])
+    qa = FakeQA({1: [_passed()]})
+    step = context.make_step(qa=qa, renderer=FakeRenderer(pages=[1]))
+
+    result = await step.process(
+        job_id="job-1",
+        slides=context.slides,
+        unpacked_dir=context.unpacked_dir,
+        working_pptx_path=context.working_pptx,
+        fixed_pptx_path=context.fixed_pptx,
+        render_output_dir=context.render_dir,
+        ready_event=None,
+        preview_attempt_id="attempt-1",
+    )
+
+    assert context.storage.uploads == []
+    assert context.storage.attempt_uploads[0][:3] == ("job-1", "attempt-1", 1)
+    assert (
+        result.outcomes[0].gcs_preview_key == "jobs/job-1/attempts/attempt-1/previews/slide-01.jpg"
+    )
+    assert context.main_client.events == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
+++ b/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
@@ -1,6 +1,6 @@
 """GCS 클라이언트 단위 테스트"""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -11,6 +11,9 @@ from features.visualization.storage.gcs_client import (
     pdf_key,
     pptx_key,
     preview_key,
+    regeneration_attempt_pdf_key,
+    regeneration_attempt_pptx_key,
+    regeneration_attempt_preview_key,
     template_meta_key,
     template_pptx_key,
     template_thumbnail_key,
@@ -45,6 +48,20 @@ class TestCanonicalKeys:
     def test_pdf_key(self):
         assert pdf_key("job-abc") == "jobs/job-abc/current.pdf"
 
+    def test_regeneration_attempt_keys(self):
+        assert (
+            regeneration_attempt_pptx_key("job-abc", "attempt-1")
+            == "jobs/job-abc/attempts/attempt-1/current.pptx"
+        )
+        assert (
+            regeneration_attempt_pdf_key("job-abc", "attempt-1")
+            == "jobs/job-abc/attempts/attempt-1/current.pdf"
+        )
+        assert (
+            regeneration_attempt_preview_key("job-abc", "attempt-1", 3)
+            == "jobs/job-abc/attempts/attempt-1/previews/slide-03.jpg"
+        )
+
     def test_template_pptx_key(self):
         assert template_pptx_key("blue") == "templates/blue/template.pptx"
 
@@ -68,6 +85,10 @@ class TestValidateIdentifier:
     def test_key_helpers_reject_slash_in_job_id(self):
         with pytest.raises(ValueError):
             pptx_key("job/42")
+
+    def test_attempt_key_helpers_reject_slash_in_attempt_id(self):
+        with pytest.raises(ValueError):
+            regeneration_attempt_pptx_key("job-42", "attempt/1")
 
     @pytest.mark.parametrize(
         "helper",
@@ -165,6 +186,22 @@ class TestUploadPptx:
         )
 
 
+class TestUploadRegenerationAttemptPptx:
+    def test_returns_attempt_key(self, mock_gcs, tmp_path):
+        client, mock_bucket, mock_blob, _ = mock_gcs
+        src = tmp_path / "output.pptx"
+        src.touch()
+
+        key = client.upload_regeneration_attempt_pptx("job-42", "attempt-1", src)
+
+        assert key == "jobs/job-42/attempts/attempt-1/current.pptx"
+        mock_bucket.blob.assert_called_once_with("jobs/job-42/attempts/attempt-1/current.pptx")
+        mock_blob.upload_from_filename.assert_called_once_with(
+            str(src),
+            content_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        )
+
+
 class TestUploadPdf:
     def test_returns_canonical_key(self, mock_gcs, tmp_path):
         client, mock_bucket, mock_blob, _ = mock_gcs
@@ -175,6 +212,21 @@ class TestUploadPdf:
 
         assert key == "jobs/job-42/current.pdf"
         mock_bucket.blob.assert_called_once_with("jobs/job-42/current.pdf")
+        mock_blob.upload_from_filename.assert_called_once_with(
+            str(src), content_type="application/pdf"
+        )
+
+
+class TestUploadRegenerationAttemptPdf:
+    def test_returns_attempt_key(self, mock_gcs, tmp_path):
+        client, mock_bucket, mock_blob, _ = mock_gcs
+        src = tmp_path / "output.pdf"
+        src.touch()
+
+        key = client.upload_regeneration_attempt_pdf("job-42", "attempt-1", src)
+
+        assert key == "jobs/job-42/attempts/attempt-1/current.pdf"
+        mock_bucket.blob.assert_called_once_with("jobs/job-42/attempts/attempt-1/current.pdf")
         mock_blob.upload_from_filename.assert_called_once_with(
             str(src), content_type="application/pdf"
         )
@@ -200,6 +252,21 @@ class TestUploadPreview:
         mock_blob.upload_from_filename.assert_called_once_with(str(src), content_type="image/jpeg")
 
 
+class TestUploadRegenerationAttemptPreview:
+    def test_returns_attempt_key(self, mock_gcs, tmp_path):
+        client, mock_bucket, mock_blob, _ = mock_gcs
+        src = tmp_path / "slide.jpg"
+        src.touch()
+
+        key = client.upload_regeneration_attempt_preview("job-42", "attempt-1", 3, src)
+
+        assert key == "jobs/job-42/attempts/attempt-1/previews/slide-03.jpg"
+        mock_bucket.blob.assert_called_once_with(
+            "jobs/job-42/attempts/attempt-1/previews/slide-03.jpg"
+        )
+        mock_blob.upload_from_filename.assert_called_once_with(str(src), content_type="image/jpeg")
+
+
 class TestDownloadPreview:
     def test_calls_correct_key(self, mock_gcs, tmp_path):
         client, mock_bucket, mock_blob, _ = mock_gcs
@@ -209,6 +276,60 @@ class TestDownloadPreview:
 
         mock_bucket.blob.assert_called_once_with("jobs/job-42/previews/slide-01.jpg")
         mock_blob.download_to_filename.assert_called_once_with(str(dest))
+
+
+class TestPromoteRegenerationAttempt:
+    def test_copies_attempt_artifacts_to_canonical_after_backup(self, mock_gcs):
+        client, mock_bucket, _, _ = mock_gcs
+
+        keys = client.promote_regeneration_attempt("job-42", "attempt-1", 3)
+
+        assert keys.canonical_pptx_key == "jobs/job-42/current.pptx"
+        assert keys.canonical_pdf_key == "jobs/job-42/current.pdf"
+        assert keys.canonical_preview_key == "jobs/job-42/previews/slide-03.jpg"
+        assert mock_bucket.copy_blob.call_args_list == [
+            call(
+                mock_bucket.blob.return_value,
+                mock_bucket,
+                "jobs/job-42/attempts/attempt-1/rollback/current.pptx",
+            ),
+            call(
+                mock_bucket.blob.return_value,
+                mock_bucket,
+                "jobs/job-42/attempts/attempt-1/rollback/current.pdf",
+            ),
+            call(
+                mock_bucket.blob.return_value,
+                mock_bucket,
+                "jobs/job-42/attempts/attempt-1/rollback/slide-03.jpg",
+            ),
+            call(mock_bucket.blob.return_value, mock_bucket, "jobs/job-42/current.pptx"),
+            call(mock_bucket.blob.return_value, mock_bucket, "jobs/job-42/current.pdf"),
+            call(mock_bucket.blob.return_value, mock_bucket, "jobs/job-42/previews/slide-03.jpg"),
+        ]
+
+    def test_restore_backups_when_promote_copy_fails(self, mock_gcs):
+        client, mock_bucket, _, _ = mock_gcs
+        mock_bucket.copy_blob.side_effect = [
+            None,
+            None,
+            None,
+            None,
+            RuntimeError("copy failed"),
+            None,
+            None,
+            None,
+        ]
+
+        with pytest.raises(RuntimeError, match="copy failed"):
+            client.promote_regeneration_attempt("job-42", "attempt-1", 3)
+
+        destinations = [item.args[2] for item in mock_bucket.copy_blob.call_args_list]
+        assert destinations[-3:] == [
+            "jobs/job-42/previews/slide-03.jpg",
+            "jobs/job-42/current.pdf",
+            "jobs/job-42/current.pptx",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
+++ b/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
@@ -118,6 +118,19 @@ def mock_gcs(tmp_path):
         yield client, mock_bucket, mock_blob, tmp_path
 
 
+def _use_distinct_blob_mocks(mock_bucket):
+    """bucket.blob(key) 호출마다 key 별 Blob mock 을 반환한다."""
+    blobs: dict[str, MagicMock] = {}
+
+    def _blob(name: str) -> MagicMock:
+        if name not in blobs:
+            blobs[name] = MagicMock(name=f"blob:{name}")
+        return blobs[name]
+
+    mock_bucket.blob.side_effect = _blob
+    return blobs
+
+
 class TestDownloadTemplate:
     def test_calls_correct_key(self, mock_gcs):
         client, mock_bucket, mock_blob, tmp_path = mock_gcs
@@ -281,6 +294,7 @@ class TestDownloadPreview:
 class TestPromoteRegenerationAttempt:
     def test_copies_attempt_artifacts_to_canonical_after_backup(self, mock_gcs):
         client, mock_bucket, _, _ = mock_gcs
+        blobs = _use_distinct_blob_mocks(mock_bucket)
 
         keys = client.promote_regeneration_attempt("job-42", "attempt-1", 3)
 
@@ -289,27 +303,40 @@ class TestPromoteRegenerationAttempt:
         assert keys.canonical_preview_key == "jobs/job-42/previews/slide-03.jpg"
         assert mock_bucket.copy_blob.call_args_list == [
             call(
-                mock_bucket.blob.return_value,
+                blobs["jobs/job-42/current.pptx"],
                 mock_bucket,
                 "jobs/job-42/attempts/attempt-1/rollback/current.pptx",
             ),
             call(
-                mock_bucket.blob.return_value,
+                blobs["jobs/job-42/current.pdf"],
                 mock_bucket,
                 "jobs/job-42/attempts/attempt-1/rollback/current.pdf",
             ),
             call(
-                mock_bucket.blob.return_value,
+                blobs["jobs/job-42/previews/slide-03.jpg"],
                 mock_bucket,
                 "jobs/job-42/attempts/attempt-1/rollback/slide-03.jpg",
             ),
-            call(mock_bucket.blob.return_value, mock_bucket, "jobs/job-42/current.pptx"),
-            call(mock_bucket.blob.return_value, mock_bucket, "jobs/job-42/current.pdf"),
-            call(mock_bucket.blob.return_value, mock_bucket, "jobs/job-42/previews/slide-03.jpg"),
+            call(
+                blobs["jobs/job-42/attempts/attempt-1/current.pptx"],
+                mock_bucket,
+                "jobs/job-42/current.pptx",
+            ),
+            call(
+                blobs["jobs/job-42/attempts/attempt-1/current.pdf"],
+                mock_bucket,
+                "jobs/job-42/current.pdf",
+            ),
+            call(
+                blobs["jobs/job-42/attempts/attempt-1/previews/slide-03.jpg"],
+                mock_bucket,
+                "jobs/job-42/previews/slide-03.jpg",
+            ),
         ]
 
     def test_restore_backups_when_promote_copy_fails(self, mock_gcs):
         client, mock_bucket, _, _ = mock_gcs
+        blobs = _use_distinct_blob_mocks(mock_bucket)
         mock_bucket.copy_blob.side_effect = [
             None,
             None,
@@ -324,11 +351,22 @@ class TestPromoteRegenerationAttempt:
         with pytest.raises(RuntimeError, match="copy failed"):
             client.promote_regeneration_attempt("job-42", "attempt-1", 3)
 
-        destinations = [item.args[2] for item in mock_bucket.copy_blob.call_args_list]
-        assert destinations[-3:] == [
-            "jobs/job-42/previews/slide-03.jpg",
-            "jobs/job-42/current.pdf",
-            "jobs/job-42/current.pptx",
+        assert mock_bucket.copy_blob.call_args_list[-3:] == [
+            call(
+                blobs["jobs/job-42/attempts/attempt-1/rollback/slide-03.jpg"],
+                mock_bucket,
+                "jobs/job-42/previews/slide-03.jpg",
+            ),
+            call(
+                blobs["jobs/job-42/attempts/attempt-1/rollback/current.pdf"],
+                mock_bucket,
+                "jobs/job-42/current.pdf",
+            ),
+            call(
+                blobs["jobs/job-42/attempts/attempt-1/rollback/current.pptx"],
+                mock_bucket,
+                "jobs/job-42/current.pptx",
+            ),
         ]
 
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #240

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 재생성/retry 산출물을 canonical key에 바로 덮어쓰지 않고 `jobs/{job_id}/attempts/{attempt_id}/...` staging key에 먼저 업로드하도록 변경했습니다.
- `slide_regenerated` callback 성공 후에만 attempt PPTX/PDF/preview를 canonical `current.pptx`, `current.pdf`, `previews/slide-XX.jpg`로 promote하도록 Worker 순서를 정리했습니다.
- `slide_regenerated.gcsPreviewKey`는 프론트 signed URL 규칙을 깨지 않도록 canonical preview key만 전달하고, 실패한 attempt key는 callback payload에 노출하지 않도록 고정했습니다.
- GCS promote 중 copy 실패 시 사전 백업한 이전 canonical 객체로 rollback을 시도하도록 보강했습니다.
- callback 실패, attempt upload 실패, promote 성공/rollback, 중복 regenerate retry에 대한 정합성 테스트를 추가했습니다.
- Task 1.25/spec 문서를 완료 상태와 신규 attempt/promote 계약에 맞춰 갱신하고, Task 1.26 Main Backend handoff 메모를 추가했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`189 files already formatted`)
  - `uv run pytest` 통과 (`792 passed`)
  - `uv run pytest tests/test_pptx_worker` 통과 (`192 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- Main Backend DB 트랜잭션/CAS/signed URL 구현은 별도 저장소 범위입니다.
- Worker는 `slide_regenerated` 2xx를 Main commit 성공으로 간주하고 canonical promote를 수행합니다. Main 쪽에서는 실패한 attempt key를 signed URL 대상으로 노출하지 않는 정책과 promote retry 중 사용자 노출 정책을 이어서 정리해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 슬라이드 재생성 파이프라인의 안정성을 강화했습니다. 이제 재생성 결과물을 임시 위치에 먼저 업로드한 후 확인 단계 성공 시에만 최종 확정하는 방식으로 변경되었습니다.
  
* **버그 수정**
  * 재생성 작업 중 오류 발생 시 이전 상태로 복구하는 롤백 메커니즘이 추가되어 데이터 일관성이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->