### PR TITLE
[Fix] 첨삭 LLM 출력 안정화: originalText 코드 조합 및 JSON 복구

### DIFF
--- a/features/correction/generator.py
+++ b/features/correction/generator.py
@@ -6,9 +6,18 @@ import re
 from common.llm.client import get_llm
 
 from .config import get_correction_llm_config, get_correction_validation_config
-from .prompts.correction_prompt import correction_generator_prompt, format_portfolio_for_correction
+from .prompts.correction_prompt import (
+    build_portfolio_correction_line_map,
+    correction_generator_prompt,
+    format_portfolio_for_correction,
+)
 from .prompts.generator import overall_summary_prompt
-from .schemas import REQUIRED_CORRECTION_FIELDS, PortfolioCorrectionResult, SingleCorrectionOutput
+from .schemas import (
+    REQUIRED_CORRECTION_FIELDS,
+    PortfolioCorrectionResult,
+    SingleCorrectionDecisionOutput,
+    SingleCorrectionOutput,
+)
 
 _generator: "CorrectionGenerator | None" = None
 _ALLOWED_TYPES = {"reduce", "keep", "emphasize"}
@@ -16,8 +25,12 @@ _FIELD_HEADER_PATTERN = re.compile(
     r"^\[[^\]]+ - (?P<field_name>description|contributions|achievements|insights)\]$"
 )
 _NUMBERED_LINE_PATTERN = re.compile(r"^\d+\.\s+")
-_CODE_FENCE_PATTERN = re.compile(
+_FULL_CODE_FENCE_PATTERN = re.compile(
     r"^\s*```(?:[a-zA-Z0-9_-]+)?\s*\n(?P<body>.*?)\n?\s*```\s*$",
+    re.DOTALL,
+)
+_CODE_FENCE_PATTERN = re.compile(
+    r"```(?:[a-zA-Z0-9_-]+)?\s*\n(?P<body>.*?)\n?\s*```",
     re.DOTALL,
 )
 logger = logging.getLogger(__name__)
@@ -68,16 +81,19 @@ class CorrectionGenerator:
             emphasis_points: 강조 포인트 텍스트
 
         Returns:
-            SingleCorrectionOutput: 검증을 통과한 첨삭 결과 또는 재시도 소진 시 마지막 결과
+            SingleCorrectionOutput: 검증을 통과한 최종 첨삭 결과
 
         Raises:
-            CorrectionGenerationError: LLM 호출/파싱이 연속 실패해 결과를 만들지 못한 경우
+            CorrectionGenerationError: LLM 호출/파싱/검증 실패로 결과를 만들지 못한 경우
         """
         validation_feedback = "없음"
-        last_output: SingleCorrectionOutput | None = None
         last_error_message: str | None = None
-        portfolio_data_text = _format_portfolio_data_for_prompt(portfolio_data)
-        field_line_counts = _get_field_line_counts_from_formatted_text(portfolio_data_text)
+        normalized_portfolio = _normalize_portfolio_data(portfolio_data)
+        portfolio_data_text = format_portfolio_for_correction(normalized_portfolio)
+        original_text_map = build_portfolio_correction_line_map(normalized_portfolio)
+        field_line_counts = {
+            field_name: len(line_map) for field_name, line_map in original_text_map.items()
+        }
         total_attempts = self._max_retries + 1
 
         logger.debug(
@@ -106,7 +122,7 @@ class CorrectionGenerator:
                 chain = correction_generator_prompt | self._llm
                 raw_response = chain.invoke(prompt_variables)
                 response_text = _coerce_llm_text_response(raw_response)
-                output: SingleCorrectionOutput = _parse_single_correction_output(response_text)
+                output = _parse_single_correction_decision_output(response_text)
                 logger.info("LLM 첨삭 생성 시도 %s/%s 완료", attempt, total_attempts)
             except Exception as exc:
                 last_error_message = f"LLM 호출/파싱 실패: {exc}"
@@ -119,11 +135,10 @@ class CorrectionGenerator:
                 )
                 continue
 
-            last_output = output
             validation_errors = self._validate(output=output, field_line_counts=field_line_counts)
             if not validation_errors:
                 logger.info("검증 통과 (시도 %s/%s)", attempt, total_attempts)
-                return output
+                return _combine_decision_with_original_text(output, original_text_map)
 
             last_error_message = "; ".join(validation_errors)
             validation_feedback = f"이전 출력 보완 필요: {last_error_message}"
@@ -133,14 +148,6 @@ class CorrectionGenerator:
                 total_attempts,
                 last_error_message,
             )
-
-        if last_output is not None:
-            logger.warning(
-                "재시도 소진 후 마지막 출력 반환 (%s회 시도): %s",
-                total_attempts,
-                last_error_message or "검증 실패",
-            )
-            return last_output
 
         raise CorrectionGenerationError(
             "첨삭 생성에 실패했습니다. "
@@ -179,7 +186,7 @@ class CorrectionGenerator:
 
     def _validate(
         self,
-        output: SingleCorrectionOutput,
+        output: SingleCorrectionDecisionOutput | SingleCorrectionOutput,
         portfolio_data: dict | None = None,
         field_line_counts: dict[str, int] | None = None,
     ) -> list[str]:
@@ -218,6 +225,49 @@ class CorrectionGenerator:
                 )
 
             line_count = field_line_counts.get(field_name, 0)
+            expected_line_numbers = list(range(1, line_count + 1))
+            actual_line_numbers = [line.line_number for line in field.lines]
+            if actual_line_numbers != expected_line_numbers:
+                actual_line_number_set = set(actual_line_numbers)
+                expected_line_number_set = set(expected_line_numbers)
+                missing_line_numbers = [
+                    line_number
+                    for line_number in expected_line_numbers
+                    if line_number not in actual_line_number_set
+                ]
+                duplicated_line_numbers = sorted(
+                    {
+                        line_number
+                        for line_number in actual_line_numbers
+                        if actual_line_numbers.count(line_number) > 1
+                    }
+                )
+                out_of_range_line_numbers = [
+                    line_number
+                    for line_number in actual_line_numbers
+                    if line_number not in expected_line_number_set
+                ]
+
+                line_context = f"expected={expected_line_numbers}, actual={actual_line_numbers}"
+                if missing_line_numbers:
+                    errors.append(
+                        f"{field_name}의 line_number 누락: {missing_line_numbers}. {line_context}"
+                    )
+                if duplicated_line_numbers:
+                    errors.append(
+                        f"{field_name}의 line_number 중복: {duplicated_line_numbers}. {line_context}"
+                    )
+                if out_of_range_line_numbers:
+                    errors.append(
+                        f"{field_name}의 line_number 범위 초과: {out_of_range_line_numbers}. {line_context}"
+                    )
+                if not (
+                    missing_line_numbers or duplicated_line_numbers or out_of_range_line_numbers
+                ):
+                    errors.append(
+                        f"{field_name}의 line_number 순서가 원본과 일치하지 않습니다. {line_context}"
+                    )
+
             for line in field.lines:
                 if line.type not in _ALLOWED_TYPES:
                     errors.append(f"{field_name}의 type 값이 유효하지 않습니다: {line.type}")
@@ -237,11 +287,6 @@ class CorrectionGenerator:
                             f"{field_name}의 {line.line_number}번 라인 comment가 비어 있습니다."
                         )
 
-                if line.line_number < 1 or line.line_number > line_count:
-                    errors.append(
-                        f"{field_name}의 line_number {line.line_number}가 원본 라인 수({line_count})를 벗어났습니다."
-                    )
-
         return errors
 
 
@@ -258,20 +303,24 @@ def _strip_json_code_fence(text: str) -> str:
         str: 펜스가 제거되고 양끝 공백이 정리된 문자열. 펜스가 없으면 원본을 strip한 값.
     """
     stripped = text.strip()
-    match = _CODE_FENCE_PATTERN.match(stripped)
+    match = _FULL_CODE_FENCE_PATTERN.match(stripped)
+    if match is not None:
+        return match.group("body").strip()
+
+    match = _CODE_FENCE_PATTERN.search(stripped)
     if match is not None:
         return match.group("body").strip()
     return stripped
 
 
-def _parse_single_correction_output(text: str) -> SingleCorrectionOutput:
-    """LLM 텍스트 응답을 ``SingleCorrectionOutput``으로 파싱한다.
+def _parse_single_correction_decision_output(text: str) -> SingleCorrectionDecisionOutput:
+    """LLM 텍스트 응답을 ``SingleCorrectionDecisionOutput``으로 파싱한다.
 
     Args:
         text: LLM이 반환한 JSON 문자열 (마크다운 코드펜스 포함 가능)
 
     Returns:
-        SingleCorrectionOutput: 스키마 검증을 통과한 첨삭 결과
+        SingleCorrectionDecisionOutput: 스키마 검증을 통과한 첨삭 판단 결과
 
     Raises:
         ValueError: 응답이 비어 있는 경우
@@ -280,13 +329,48 @@ def _parse_single_correction_output(text: str) -> SingleCorrectionOutput:
     cleaned = _strip_json_code_fence(text)
     if not cleaned:
         raise ValueError("LLM 응답이 비어 있습니다.")
-    return SingleCorrectionOutput.model_validate_json(cleaned)
+    return SingleCorrectionDecisionOutput.model_validate_json(cleaned)
+
+
+def _parse_single_correction_output(text: str) -> SingleCorrectionDecisionOutput:
+    """이전 private helper 이름을 유지하며 decision 스키마로 파싱한다."""
+    return _parse_single_correction_decision_output(text)
+
+
+def _combine_decision_with_original_text(
+    decision_output: SingleCorrectionDecisionOutput,
+    original_text_map: dict[str, dict[int, str]],
+) -> SingleCorrectionOutput:
+    """LLM decision 결과에 코드가 보유한 원문 텍스트를 결합한다."""
+    fields: list[dict] = []
+    for field in decision_output.fields:
+        field_line_map = original_text_map.get(field.field_name, {})
+        lines: list[dict] = []
+        for line in field.lines:
+            try:
+                original_text = field_line_map[line.line_number]
+            except KeyError as exc:
+                raise ValueError(
+                    f"{field.field_name}의 {line.line_number}번 원문을 찾을 수 없습니다."
+                ) from exc
+            lines.append(
+                {
+                    "line_number": line.line_number,
+                    "original_text": original_text,
+                    "type": line.type,
+                    "comment": line.comment,
+                }
+            )
+        fields.append({"field_name": field.field_name, "lines": lines})
+
+    return SingleCorrectionOutput.model_validate({"fields": fields})
 
 
 def _get_field_line_counts(portfolio_data: dict) -> dict[str, int]:
     """필드별 번호 매김 대상 라인 수를 계산"""
-    formatted_text = _format_portfolio_data_for_prompt(portfolio_data)
-    return _get_field_line_counts_from_formatted_text(formatted_text)
+    normalized_portfolio = _normalize_portfolio_data(portfolio_data)
+    line_map = build_portfolio_correction_line_map(normalized_portfolio)
+    return {field_name: len(field_line_map) for field_name, field_line_map in line_map.items()}
 
 
 def _get_field_line_counts_from_formatted_text(formatted_text: str) -> dict[str, int]:
@@ -346,15 +430,15 @@ def _coerce_field_value_to_text(value: object) -> str:
     return str(value)
 
 
-def _format_portfolio_data_for_prompt(portfolio_data: dict) -> str:
+def _normalize_portfolio_data(portfolio_data: dict) -> dict[str, str]:
     """
-    포트폴리오 입력을 첨삭 프롬프트용 텍스트로 변환
+    포트폴리오 입력을 필드별 문자열로 정규화
 
     Args:
         portfolio_data: 필드별 문자열 또는 dict(lines/text/content/value) 형태 데이터
 
     Returns:
-        str: format_portfolio_for_correction() 규칙을 따른 멀티라인 문자열
+        dict[str, str]: 필수 첨삭 필드별 줄바꿈 유지 텍스트
     """
     if not isinstance(portfolio_data, dict):
         raise TypeError("portfolio_data는 dict 타입이어야 합니다.")
@@ -365,7 +449,20 @@ def _format_portfolio_data_for_prompt(portfolio_data: dict) -> str:
             portfolio_data.get(field_name)
         )
 
-    return format_portfolio_for_correction(normalized_portfolio)
+    return normalized_portfolio
+
+
+def _format_portfolio_data_for_prompt(portfolio_data: dict) -> str:
+    """
+    포트폴리오 입력을 첨삭 프롬프트용 텍스트로 변환
+
+    Args:
+        portfolio_data: 필드별 문자열 또는 dict(lines/text/content/value) 형태 데이터
+
+    Returns:
+        str: format_portfolio_for_correction() 규칙을 따른 멀티라인 문자열
+    """
+    return format_portfolio_for_correction(_normalize_portfolio_data(portfolio_data))
 
 
 def _format_portfolio_corrections_for_summary(

--- a/features/correction/generator.py
+++ b/features/correction/generator.py
@@ -3,6 +3,8 @@
 import logging
 import re
 
+from pydantic import ValidationError
+
 from common.llm.client import get_llm
 
 from .config import get_correction_llm_config, get_correction_validation_config
@@ -21,10 +23,6 @@ from .schemas import (
 
 _generator: "CorrectionGenerator | None" = None
 _ALLOWED_TYPES = {"reduce", "keep", "emphasize"}
-_FIELD_HEADER_PATTERN = re.compile(
-    r"^\[[^\]]+ - (?P<field_name>description|contributions|achievements|insights)\]$"
-)
-_NUMBERED_LINE_PATTERN = re.compile(r"^\d+\.\s+")
 _FULL_CODE_FENCE_PATTERN = re.compile(
     r"^\s*```(?:[a-zA-Z0-9_-]+)?\s*\n(?P<body>.*?)\n?\s*```\s*$",
     re.DOTALL,
@@ -94,6 +92,7 @@ class CorrectionGenerator:
         field_line_counts = {
             field_name: len(line_map) for field_name, line_map in original_text_map.items()
         }
+        _ensure_portfolio_has_correction_lines(field_line_counts)
         total_attempts = self._max_retries + 1
 
         logger.debug(
@@ -219,12 +218,14 @@ class CorrectionGenerator:
             if field is None:
                 continue
 
-            if len(field.lines) < self._min_lines_per_field:
+            line_count = field_line_counts.get(field_name, 0)
+            if line_count == 0:
+                errors.append(f"{field_name}의 첨삭 대상 원본 라인이 없습니다.")
+            elif len(field.lines) < self._min_lines_per_field:
                 errors.append(
                     f"{field_name} 필드는 최소 {self._min_lines_per_field}개 라인이 필요합니다."
                 )
 
-            line_count = field_line_counts.get(field_name, 0)
             expected_line_numbers = list(range(1, line_count + 1))
             actual_line_numbers = [line.line_number for line in field.lines]
             if actual_line_numbers != expected_line_numbers:
@@ -302,15 +303,40 @@ def _strip_json_code_fence(text: str) -> str:
     Returns:
         str: 펜스가 제거되고 양끝 공백이 정리된 문자열. 펜스가 없으면 원본을 strip한 값.
     """
-    stripped = text.strip()
-    match = _FULL_CODE_FENCE_PATTERN.match(stripped)
-    if match is not None:
-        return match.group("body").strip()
+    candidates = _get_json_response_candidates(text)
+    return candidates[0] if candidates else ""
 
-    match = _CODE_FENCE_PATTERN.search(stripped)
-    if match is not None:
-        return match.group("body").strip()
-    return stripped
+
+def _get_json_response_candidates(text: str) -> list[str]:
+    """LLM 응답에서 JSON으로 검증해 볼 후보 문자열을 순서대로 추출한다."""
+    stripped = text.strip()
+    if not stripped:
+        return []
+
+    candidates: list[str] = []
+
+    def append_candidate(candidate: str) -> None:
+        candidate = candidate.strip()
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+
+    full_match = _FULL_CODE_FENCE_PATTERN.match(stripped)
+    if full_match is not None:
+        append_candidate(full_match.group("body"))
+        if not candidates:
+            return []
+
+    fence_bodies = [match.group("body") for match in _CODE_FENCE_PATTERN.finditer(stripped)]
+    for body in reversed(fence_bodies):
+        append_candidate(body)
+
+    first_json_brace = stripped.find("{")
+    last_json_brace = stripped.rfind("}")
+    if 0 <= first_json_brace < last_json_brace:
+        append_candidate(stripped[first_json_brace : last_json_brace + 1])
+
+    append_candidate(stripped)
+    return candidates
 
 
 def _parse_single_correction_decision_output(text: str) -> SingleCorrectionDecisionOutput:
@@ -326,15 +352,20 @@ def _parse_single_correction_decision_output(text: str) -> SingleCorrectionDecis
         ValueError: 응답이 비어 있는 경우
         pydantic.ValidationError: JSON 파싱은 됐지만 스키마 검증에 실패한 경우
     """
-    cleaned = _strip_json_code_fence(text)
-    if not cleaned:
+    candidates = _get_json_response_candidates(text)
+    if not candidates:
         raise ValueError("LLM 응답이 비어 있습니다.")
-    return SingleCorrectionDecisionOutput.model_validate_json(cleaned)
 
+    last_error: ValidationError | None = None
+    for candidate in candidates:
+        try:
+            return SingleCorrectionDecisionOutput.model_validate_json(candidate)
+        except ValidationError as exc:
+            last_error = exc
 
-def _parse_single_correction_output(text: str) -> SingleCorrectionDecisionOutput:
-    """이전 private helper 이름을 유지하며 decision 스키마로 파싱한다."""
-    return _parse_single_correction_decision_output(text)
+    if last_error is not None:
+        raise last_error
+    raise ValueError("LLM 응답에서 검증 가능한 JSON 객체를 찾을 수 없습니다.")
 
 
 def _combine_decision_with_original_text(
@@ -373,28 +404,17 @@ def _get_field_line_counts(portfolio_data: dict) -> dict[str, int]:
     return {field_name: len(field_line_map) for field_name, field_line_map in line_map.items()}
 
 
-def _get_field_line_counts_from_formatted_text(formatted_text: str) -> dict[str, int]:
-    """포맷팅된 텍스트에서 필드별 번호 라인 수를 추출"""
-    line_counts = {field_name: 0 for field_name in REQUIRED_CORRECTION_FIELDS}
-    current_field_name: str | None = None
-
-    for raw_line in formatted_text.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-
-        header_match = _FIELD_HEADER_PATTERN.match(line)
-        if header_match is not None:
-            current_field_name = header_match.group("field_name")
-            continue
-
-        if current_field_name is None:
-            continue
-
-        if _NUMBERED_LINE_PATTERN.match(line) is not None:
-            line_counts[current_field_name] += 1
-
-    return line_counts
+def _ensure_portfolio_has_correction_lines(field_line_counts: dict[str, int]) -> None:
+    """LLM 호출 전에 첨삭 대상 라인이 없는 입력을 실패 처리한다."""
+    empty_fields = [
+        field_name
+        for field_name in REQUIRED_CORRECTION_FIELDS
+        if field_line_counts.get(field_name, 0) == 0
+    ]
+    if empty_fields:
+        raise CorrectionGenerationError(
+            f"첨삭 대상 원본 라인이 없는 필드가 있습니다: {', '.join(empty_fields)}"
+        )
 
 
 def _coerce_field_value_to_text(value: object) -> str:
@@ -450,19 +470,6 @@ def _normalize_portfolio_data(portfolio_data: dict) -> dict[str, str]:
         )
 
     return normalized_portfolio
-
-
-def _format_portfolio_data_for_prompt(portfolio_data: dict) -> str:
-    """
-    포트폴리오 입력을 첨삭 프롬프트용 텍스트로 변환
-
-    Args:
-        portfolio_data: 필드별 문자열 또는 dict(lines/text/content/value) 형태 데이터
-
-    Returns:
-        str: format_portfolio_for_correction() 규칙을 따른 멀티라인 문자열
-    """
-    return format_portfolio_for_correction(_normalize_portfolio_data(portfolio_data))
 
 
 def _format_portfolio_corrections_for_summary(

--- a/features/correction/prompts/__init__.py
+++ b/features/correction/prompts/__init__.py
@@ -1,6 +1,7 @@
 """첨삭 프롬프트 패키지"""
 
 from .correction_prompt import (
+    build_portfolio_correction_line_map,
     correction_generator_prompt,
     format_portfolio_for_correction,
     get_correction_prompt,
@@ -8,6 +9,7 @@ from .correction_prompt import (
 from .generator import overall_summary_prompt
 
 __all__ = [
+    "build_portfolio_correction_line_map",
     "format_portfolio_for_correction",
     "get_correction_prompt",
     "correction_generator_prompt",

--- a/features/correction/prompts/correction_prompt.py
+++ b/features/correction/prompts/correction_prompt.py
@@ -35,7 +35,7 @@ CORRECTION_SYSTEM_PROMPT = """
 - line_number는 입력에 표시된 숫자를 그대로 사용하세요.
 - line_number는 전체 문서 기준으로 이어서 세지 말고, 각 field 내부에서 1부터 다시 시작하는 번호만 사용하세요.
 - 다른 field의 line_number를 가져오거나 섞지 마세요.
-- original_text는 번호를 제외한 원문을 그대로 넣으세요.
+- original_text 또는 originalText는 절대 출력하지 마세요. 원문 텍스트는 서버 코드가 채웁니다.
 
 # 첨삭 타입 기준
 - reduce: 직무와 무관하거나 장황한 내용, 일반론, 비핵심 보조 업무
@@ -56,13 +56,14 @@ CORRECTION_SYSTEM_PROMPT = """
 - emphasize는 가능하면 comment 끝에 "수정 예시: ..."를 추가하세요.
 
 # 출력 제약
-- 출력은 SingleCorrectionOutput 스키마에 정확히 맞춰야 합니다.
+- 출력은 SingleCorrectionDecisionOutput 스키마에 정확히 맞춰야 합니다.
 - 각 field 객체는 반드시 1개씩만 반환하세요.
 - type은 reduce, keep, emphasize만 사용하세요.
-- 응답은 추가 설명이나 마크다운 코드펜스(```) 없이, 유효한 JSON object 하나만 반환하세요.
-- 모든 line 객체는 line_number, original_text, type, comment 키를 모두 포함해야 하며, keep 타입은 comment를 null로 설정하세요.
+- 응답은 추가 설명 문장, Markdown 코드블록, ```json, ``` 없이 순수 JSON object 하나만 반환하세요.
+- 모든 line 객체는 line_number, type, comment 키만 포함해야 하며, keep 타입은 comment를 null로 설정하세요.
+- 모든 line 객체에는 original_text 또는 originalText 키를 포함하지 마세요.
 - JSON 구조 예시:
-  {{"fields": [{{"field_name": "description", "lines": [{{"line_number": 1, "original_text": "...", "type": "keep", "comment": null}}]}}]}}
+  {{"fields": [{{"field_name": "description", "lines": [{{"line_number": 1, "type": "keep", "comment": null}}]}}]}}
 """.strip()
 
 CORRECTION_GENERATOR_SYSTEM_TEMPLATE = f"""
@@ -125,6 +126,45 @@ def _is_subheader_line(line: str) -> bool:
     return _SUBHEADER_PATTERN.match(line) is not None
 
 
+def _format_field_for_correction(field_lines: list[str]) -> tuple[list[str], dict[int, str]]:
+    """필드 라인을 첨삭 대상 텍스트와 원문 라인맵으로 변환"""
+    output_lines: list[str] = []
+    original_text_by_line_number: dict[int, str] = {}
+    line_number = 0
+    latest_numbered_line_index: int | None = None
+    latest_line_number: int | None = None
+
+    for line in field_lines:
+        if _is_subheader_line(line):
+            output_lines.append(line)
+            latest_numbered_line_index = None
+            latest_line_number = None
+            continue
+
+        bullet_match = _BULLET_PATTERN.match(line)
+        if bullet_match is not None:
+            line_number += 1
+            bullet_content = bullet_match.group("content").strip()
+            output_lines.append(f"{line_number}. {bullet_content}")
+            original_text_by_line_number[line_number] = bullet_content
+            latest_numbered_line_index = len(output_lines) - 1
+            latest_line_number = line_number
+            continue
+
+        if latest_numbered_line_index is None or latest_line_number is None:
+            output_lines.append(line)
+            continue
+
+        output_lines[latest_numbered_line_index] = (
+            f"{output_lines[latest_numbered_line_index]} {line}"
+        )
+        original_text_by_line_number[latest_line_number] = (
+            f"{original_text_by_line_number[latest_line_number]} {line}"
+        )
+
+    return output_lines, original_text_by_line_number
+
+
 def format_portfolio_for_correction(portfolio: dict) -> str:
     """
     첨삭용 포트폴리오 텍스트 포맷팅
@@ -145,34 +185,34 @@ def format_portfolio_for_correction(portfolio: dict) -> str:
         output_lines.append(f"[{title} - {field_name}]")
 
         field_lines = _normalize_lines(portfolio.get(field_name))
-        line_number = 0
-        latest_numbered_line_index: int | None = None
-
-        for line in field_lines:
-            if _is_subheader_line(line):
-                output_lines.append(line)
-                latest_numbered_line_index = None
-                continue
-
-            bullet_match = _BULLET_PATTERN.match(line)
-            if bullet_match is not None:
-                line_number += 1
-                bullet_content = bullet_match.group("content").strip()
-                output_lines.append(f"{line_number}. {bullet_content}")
-                latest_numbered_line_index = len(output_lines) - 1
-                continue
-
-            if latest_numbered_line_index is None:
-                output_lines.append(line)
-                continue
-
-            output_lines[latest_numbered_line_index] = (
-                f"{output_lines[latest_numbered_line_index]} {line}"
-            )
+        field_output_lines, _ = _format_field_for_correction(field_lines)
+        output_lines.extend(field_output_lines)
 
         output_lines.append("")
 
     return "\n".join(output_lines).strip()
+
+
+def build_portfolio_correction_line_map(portfolio: dict) -> dict[str, dict[int, str]]:
+    """
+    첨삭 대상 원문 라인맵 생성
+
+    Args:
+        portfolio: description/contributions/achievements/insights를 포함한 포트폴리오 dict
+
+    Returns:
+        field_name -> line_number -> original_text 매핑
+    """
+    if not isinstance(portfolio, dict):
+        raise TypeError("portfolio는 dict 타입이어야 합니다.")
+
+    line_map: dict[str, dict[int, str]] = {}
+    for field_name in _CORRECTION_FIELD_ORDER:
+        field_lines = _normalize_lines(portfolio.get(field_name))
+        _, original_text_by_line_number = _format_field_for_correction(field_lines)
+        line_map[field_name] = original_text_by_line_number
+
+    return line_map
 
 
 def get_correction_prompt() -> ChatPromptTemplate:
@@ -212,6 +252,7 @@ __all__ = [
     "CORRECTION_GENERATOR_SYSTEM_TEMPLATE",
     "CORRECTION_HUMAN_PROMPT",
     "CORRECTION_SYSTEM_PROMPT",
+    "build_portfolio_correction_line_map",
     "correction_generator_prompt",
     "format_portfolio_for_correction",
     "get_correction_prompt",

--- a/features/correction/schemas.py
+++ b/features/correction/schemas.py
@@ -3,9 +3,61 @@
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 REQUIRED_CORRECTION_FIELDS = ("description", "contributions", "achievements", "insights")
+
+
+def _validate_required_correction_fields(field_names: list[str]) -> None:
+    """필수 첨삭 필드가 정확히 1회씩 포함되는지 검증"""
+    missing_fields = [name for name in REQUIRED_CORRECTION_FIELDS if name not in field_names]
+    duplicated_fields = sorted({name for name in field_names if field_names.count(name) > 1})
+
+    if missing_fields or duplicated_fields:
+        problems: list[str] = []
+        if missing_fields:
+            problems.append(f"누락: {', '.join(missing_fields)}")
+        if duplicated_fields:
+            problems.append(f"중복: {', '.join(duplicated_fields)}")
+        raise ValueError(
+            "fields에는 description, contributions, achievements, insights가 "
+            f"각각 정확히 1회씩 포함되어야 합니다. ({'; '.join(problems)})"
+        )
+
+
+class CorrectionDecisionLine(BaseModel):
+    """LLM이 판단해야 하는 라인별 첨삭 결과"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    line_number: int = Field(..., ge=1, description="라인 번호")
+    type: Literal["reduce", "keep", "emphasize"] = Field(..., description="첨삭 타입")
+    comment: str | None = Field(..., description="첨삭 코멘트 (keep인 경우 null 허용)")
+
+
+class CorrectionDecisionField(BaseModel):
+    """LLM이 판단해야 하는 필드별 첨삭 결과"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_name: Literal["description", "contributions", "achievements", "insights"] = Field(
+        ..., description="첨삭 대상 필드명"
+    )
+    lines: list[CorrectionDecisionLine] = Field(..., description="라인별 첨삭 목록")
+
+
+class SingleCorrectionDecisionOutput(BaseModel):
+    """단일 포트폴리오용 LLM decision 스키마"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fields: list[CorrectionDecisionField] = Field(..., description="필드별 첨삭 판단 결과")
+
+    @model_validator(mode="after")
+    def validate_required_sections(self) -> "SingleCorrectionDecisionOutput":
+        """필수 섹션 4개가 정확히 1회씩 포함되는지 검증"""
+        _validate_required_correction_fields([field.field_name for field in self.fields])
+        return self
 
 
 class CorrectionLine(BaseModel):
@@ -27,29 +79,14 @@ class CorrectionField(BaseModel):
 
 
 class SingleCorrectionOutput(BaseModel):
-    """단일 포트폴리오용 LLM Structured Output 스키마"""
+    """단일 포트폴리오용 서버 저장 최종 스키마"""
 
     fields: list[CorrectionField] = Field(..., description="필드별 첨삭 결과")
 
     @model_validator(mode="after")
     def validate_required_sections(self) -> "SingleCorrectionOutput":
         """필수 섹션 4개가 정확히 1회씩 포함되는지 검증"""
-        field_names = [field.field_name for field in self.fields]
-
-        missing_fields = [name for name in REQUIRED_CORRECTION_FIELDS if name not in field_names]
-        duplicated_fields = sorted({name for name in field_names if field_names.count(name) > 1})
-
-        if missing_fields or duplicated_fields:
-            problems: list[str] = []
-            if missing_fields:
-                problems.append(f"누락: {', '.join(missing_fields)}")
-            if duplicated_fields:
-                problems.append(f"중복: {', '.join(duplicated_fields)}")
-            raise ValueError(
-                "fields에는 description, contributions, achievements, insights가 "
-                f"각각 정확히 1회씩 포함되어야 합니다. ({'; '.join(problems)})"
-            )
-
+        _validate_required_correction_fields([field.field_name for field in self.fields])
         return self
 
 

--- a/tests/test_features/test_correction/test_correction_prompt.py
+++ b/tests/test_features/test_correction/test_correction_prompt.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.prompts import ChatPromptTemplate
 
 from features.correction.prompts import (
+    build_portfolio_correction_line_map,
     correction_generator_prompt,
     format_portfolio_for_correction,
     get_correction_prompt,
@@ -47,8 +48,9 @@ def test_correction_prompt_removes_overall_summary_instruction():
 
     assert len(messages) == 2
     assert "overall_summary" not in messages[0].content
-    assert "SingleCorrectionOutput" in messages[0].content
+    assert "SingleCorrectionDecisionOutput" in messages[0].content
     assert "comment는 null" in messages[0].content
+    assert "original_text 또는 originalText는 절대 출력하지 마세요" in messages[0].content
 
 
 def test_correction_generator_prompt_has_required_input_variables():
@@ -80,6 +82,8 @@ def test_correction_generator_prompt_includes_field_scoped_validation_rules():
     assert "각 field 내부에서 1부터 다시 시작" in messages[0].content
     assert "중복 반환이나 일부 누락은 허용되지 않습니다" in messages[0].content
     assert "각각 정확히 1회씩 포함" in messages[0].content
+    assert "line_number, type, comment 키만 포함" in messages[0].content
+    assert "Markdown 코드블록" in messages[0].content
     assert "이전 시도 피드백\n없음" in messages[0].content
 
 
@@ -152,6 +156,31 @@ def test_format_portfolio_for_correction_numbers_only_bullet_lines():
 
     assert "[배운 점 - insights]" in formatted
     assert "1. **성장한 부분:** 우선순위 조율 역량 강화" in formatted
+
+
+def test_build_portfolio_correction_line_map_matches_formatter_rules():
+    """라인맵은 포맷터와 같은 소구분/불릿/이어지는 줄 병합 규칙을 사용한다."""
+    portfolio = {
+        "description": "- 첫 줄\n이어지는 설명\n일반 헤더\n- 둘째 줄",
+        "contributions": "**[역할]**\n- 기여 첫 줄\n기여 추가 설명",
+        "achievements": "**1) 리소스 부족**\n- 성과 첫 줄",
+        "insights": "- 배운 점",
+    }
+
+    formatted = format_portfolio_for_correction(portfolio)
+    line_map = build_portfolio_correction_line_map(portfolio)
+
+    assert "1. 첫 줄 이어지는 설명 일반 헤더" in formatted
+    assert "2. 둘째 줄" in formatted
+    assert line_map["description"] == {
+        1: "첫 줄 이어지는 설명 일반 헤더",
+        2: "둘째 줄",
+    }
+    assert "**[역할]**" in formatted
+    assert line_map["contributions"] == {1: "기여 첫 줄 기여 추가 설명"}
+    assert "**1) 리소스 부족**" in formatted
+    assert line_map["achievements"] == {1: "성과 첫 줄"}
+    assert line_map["insights"] == {1: "배운 점"}
 
 
 def test_format_portfolio_for_correction_raises_type_error_for_invalid_portfolio():

--- a/tests/test_features/test_correction/test_generator.py
+++ b/tests/test_features/test_correction/test_generator.py
@@ -11,7 +11,6 @@ from features.correction.generator import (
     _combine_decision_with_original_text,
     _format_portfolio_corrections_for_summary,
     _parse_single_correction_decision_output,
-    _parse_single_correction_output,
     _strip_json_code_fence,
     get_correction_generator,
     reset_correction_generator,
@@ -302,6 +301,34 @@ def test_generate_raises_error_when_llm_fails_without_output(monkeypatch: pytest
             },
             emphasis_points="강조 포인트",
         )
+
+
+def test_generate_fails_fast_when_portfolio_has_no_numbered_line(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """첨삭 대상 번호 라인이 없는 필드는 LLM 호출 전 실패 처리한다."""
+    from features.correction import generator
+
+    chain = DummyChain([_decision_json(line_number=1)])
+    monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
+    monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
+
+    with pytest.raises(CorrectionGenerationError, match="description"):
+        CorrectionGenerator(max_retries=2).generate(
+            company_name="테스트 회사",
+            job_title="백엔드",
+            job_description="채용 공고",
+            company_insight="인사이트",
+            portfolio_data={
+                "description": "불릿 없는 설명",
+                "contributions": "- contri",
+                "achievements": "- ach",
+                "insights": "- ins",
+            },
+            emphasis_points="강조 포인트",
+        )
+
+    assert chain.calls == []
 
 
 def test_generate_overall_summary(monkeypatch: pytest.MonkeyPatch):
@@ -660,6 +687,30 @@ def test_parse_single_correction_decision_output_accepts_fenced_json():
     assert parsed == _decision_output(line_number=1)
 
 
+def test_parse_single_correction_decision_output_uses_valid_fenced_candidate():
+    """여러 코드펜스 중 decision 스키마로 검증되는 JSON 후보를 선택한다."""
+    invalid_example = '{"fields": [{"field_name": "description", "lines": []}]}'
+    valid_payload = _decision_json(line_number=1)
+
+    parsed = _parse_single_correction_decision_output(
+        "예시는 아래와 같습니다.\n"
+        f"```json\n{invalid_example}\n```\n"
+        "실제 응답입니다.\n"
+        f"```json\n{valid_payload}\n```"
+    )
+
+    assert parsed == _decision_output(line_number=1)
+
+
+def test_parse_single_correction_decision_output_accepts_embedded_json_object():
+    """코드펜스 없이 설명에 섞인 JSON 객체도 검증 가능한 경우 복구한다."""
+    parsed = _parse_single_correction_decision_output(
+        f"응답은 다음과 같습니다.\n{_decision_json(line_number=1)}"
+    )
+
+    assert parsed == _decision_output(line_number=1)
+
+
 def test_parse_single_correction_decision_output_rejects_original_text():
     """LLM decision 스키마는 original_text 출력을 거부한다."""
     payload = _output(line_number=1).model_dump_json()
@@ -683,13 +734,13 @@ def test_combine_decision_with_original_text_uses_line_map():
     assert combined == _output(line_number=1)
 
 
-def test_parse_single_correction_output_raises_on_empty():
+def test_parse_single_correction_decision_output_raises_on_empty():
     """공백/펜스만 들어 있으면 ValueError를 발생시킨다."""
     with pytest.raises(ValueError, match="LLM 응답이 비어 있습니다"):
         _parse_single_correction_decision_output("```json\n\n```")
 
 
-def test_parse_single_correction_output_raises_on_invalid_json():
+def test_parse_single_correction_decision_output_raises_on_invalid_json():
     """깨진 JSON은 ValidationError로 전파된다."""
     with pytest.raises(ValidationError):
-        _parse_single_correction_output("{not valid json")
+        _parse_single_correction_decision_output("{not valid json")

--- a/tests/test_features/test_correction/test_generator.py
+++ b/tests/test_features/test_correction/test_generator.py
@@ -8,13 +8,19 @@ from features.correction.generator import (
     CorrectionGenerationError,
     CorrectionGenerator,
     _coerce_llm_text_response,
+    _combine_decision_with_original_text,
     _format_portfolio_corrections_for_summary,
+    _parse_single_correction_decision_output,
     _parse_single_correction_output,
     _strip_json_code_fence,
     get_correction_generator,
     reset_correction_generator,
 )
-from features.correction.schemas import PortfolioCorrectionResult, SingleCorrectionOutput
+from features.correction.schemas import (
+    PortfolioCorrectionResult,
+    SingleCorrectionDecisionOutput,
+    SingleCorrectionOutput,
+)
 
 
 class DummyChain:
@@ -99,17 +105,97 @@ def _output(line_number: int = 1, comment: str | None = "좋습니다.") -> Sing
     )
 
 
-def _output_json(line_number: int = 1, comment: str | None = "좋습니다.") -> str:
-    """`_output()`을 JSON 문자열로 직렬화한다."""
-    return _output(line_number=line_number, comment=comment).model_dump_json()
+def _output_with_description_line_numbers(
+    line_numbers: list[int],
+) -> SingleCorrectionOutput:
+    """description 필드 라인 번호를 지정한 최종 출력 객체를 생성한다."""
+    output = _output().model_dump()
+    output["fields"][0]["lines"] = [
+        {
+            "line_number": line_number,
+            "original_text": f"desc {line_number}",
+            "type": "keep",
+            "comment": None,
+        }
+        for line_number in line_numbers
+    ]
+    return SingleCorrectionOutput.model_validate(output)
+
+
+def _decision_output(
+    line_number: int = 1,
+    comment: str | None = "좋습니다.",
+) -> SingleCorrectionDecisionOutput:
+    """LLM decision 전용 출력 객체를 생성한다."""
+    return SingleCorrectionDecisionOutput.model_validate(
+        {
+            "fields": [
+                {
+                    "field_name": "description",
+                    "lines": [
+                        {
+                            "line_number": line_number,
+                            "type": "keep",
+                            "comment": comment,
+                        }
+                    ],
+                },
+                {
+                    "field_name": "contributions",
+                    "lines": [
+                        {
+                            "line_number": 1,
+                            "type": "reduce",
+                            "comment": "좋습니다.",
+                        }
+                    ],
+                },
+                {
+                    "field_name": "achievements",
+                    "lines": [
+                        {
+                            "line_number": 1,
+                            "type": "emphasize",
+                            "comment": "좋습니다.",
+                        }
+                    ],
+                },
+                {
+                    "field_name": "insights",
+                    "lines": [
+                        {
+                            "line_number": 1,
+                            "type": "keep",
+                            "comment": "좋습니다.",
+                        }
+                    ],
+                },
+            ]
+        }
+    )
+
+
+def _decision_json(line_number: int = 1, comment: str | None = "좋습니다.") -> str:
+    """`_decision_output()`을 JSON 문자열로 직렬화한다."""
+    return _decision_output(line_number=line_number, comment=comment).model_dump_json()
+
+
+def _portfolio_data_for_output() -> dict:
+    """`_output()`의 original_text와 같은 원문을 가진 포트폴리오 입력을 생성한다."""
+    return {
+        "description": "- desc",
+        "contributions": "- contri",
+        "achievements": "- ach",
+        "insights": "- ins",
+    }
 
 
 def test_generate_retry_with_validation_feedback(monkeypatch: pytest.MonkeyPatch):
     """검증 실패 시 피드백을 포함해 재시도한다."""
     from features.correction import generator
 
-    invalid = _output_json(line_number=2)
-    valid = _output_json(line_number=1)
+    invalid = _decision_json(line_number=2)
+    valid = _decision_json(line_number=1)
 
     chain = DummyChain([invalid, valid])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
@@ -120,12 +206,7 @@ def test_generate_retry_with_validation_feedback(monkeypatch: pytest.MonkeyPatch
         job_title="백엔드",
         job_description="채용 공고",
         company_insight="인사이트",
-        portfolio_data={
-            "description": "- 한 줄",
-            "contributions": "- 한 줄",
-            "achievements": "- 한 줄",
-            "insights": "- 한 줄",
-        },
+        portfolio_data=_portfolio_data_for_output(),
         emphasis_points="강조 포인트",
     )
 
@@ -138,7 +219,7 @@ def test_generate_retries_on_fenced_json_then_succeeds(monkeypatch: pytest.Monke
     """LLM이 ```json``` 코드펜스로 감싼 JSON을 반환해도 파싱 후 진행한다."""
     from features.correction import generator
 
-    fenced = f"```json\n{_output_json(line_number=1)}\n```"
+    fenced = f"```json\n{_decision_json(line_number=1)}\n```"
     chain = DummyChain([fenced])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
     monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
@@ -148,12 +229,7 @@ def test_generate_retries_on_fenced_json_then_succeeds(monkeypatch: pytest.Monke
         job_title="백엔드",
         job_description="채용 공고",
         company_insight="인사이트",
-        portfolio_data={
-            "description": "- 한 줄",
-            "contributions": "- 한 줄",
-            "achievements": "- 한 줄",
-            "insights": "- 한 줄",
-        },
+        portfolio_data=_portfolio_data_for_output(),
         emphasis_points="강조 포인트",
     )
 
@@ -164,7 +240,7 @@ def test_generate_retries_when_response_is_invalid_json(monkeypatch: pytest.Monk
     """첫 응답이 JSON 파싱 실패하면 피드백을 포함해 재시도한다."""
     from features.correction import generator
 
-    chain = DummyChain(["```json\n{not valid json\n```", _output_json(line_number=1)])
+    chain = DummyChain(["```json\n{not valid json\n```", _decision_json(line_number=1)])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
     monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
 
@@ -173,12 +249,7 @@ def test_generate_retries_when_response_is_invalid_json(monkeypatch: pytest.Monk
         job_title="백엔드",
         job_description="채용 공고",
         company_insight="인사이트",
-        portfolio_data={
-            "description": "- 한 줄",
-            "contributions": "- 한 줄",
-            "achievements": "- 한 줄",
-            "insights": "- 한 줄",
-        },
+        portfolio_data=_portfolio_data_for_output(),
         emphasis_points="강조 포인트",
     )
 
@@ -187,30 +258,26 @@ def test_generate_retries_when_response_is_invalid_json(monkeypatch: pytest.Monk
     assert chain.calls[1]["validation_feedback"].startswith("LLM 호출/파싱 실패:")
 
 
-def test_generate_returns_last_output_when_retries_exhausted(monkeypatch: pytest.MonkeyPatch):
-    """재시도 소진 시 마지막 출력을 반환한다."""
+def test_generate_raises_when_retries_exhausted_by_validation(monkeypatch: pytest.MonkeyPatch):
+    """재시도 소진 시 검증 실패 출력을 반환하지 않고 예외를 발생시킨다."""
     from features.correction import generator
 
-    invalid_last = _output_json(line_number=3)
+    invalid_last = _decision_json(line_number=3)
     chain = DummyChain([invalid_last, invalid_last, invalid_last])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
     monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
 
-    result = CorrectionGenerator(max_retries=2).generate(
-        company_name="테스트 회사",
-        job_title="백엔드",
-        job_description="채용 공고",
-        company_insight="인사이트",
-        portfolio_data={
-            "description": "- 한 줄",
-            "contributions": "- 한 줄",
-            "achievements": "- 한 줄",
-            "insights": "- 한 줄",
-        },
-        emphasis_points="강조 포인트",
-    )
+    with pytest.raises(CorrectionGenerationError, match="line_number 범위 초과"):
+        CorrectionGenerator(max_retries=2).generate(
+            company_name="테스트 회사",
+            job_title="백엔드",
+            job_description="채용 공고",
+            company_insight="인사이트",
+            portfolio_data=_portfolio_data_for_output(),
+            emphasis_points="강조 포인트",
+        )
 
-    assert result == _output(line_number=3)
+    assert len(chain.calls) == 3
 
 
 def test_generate_raises_error_when_llm_fails_without_output(monkeypatch: pytest.MonkeyPatch):
@@ -373,11 +440,50 @@ def test_validate_counts_only_numbered_lines_with_subheaders(monkeypatch: pytest
         "insights": "- 한 줄",
     }
 
-    valid_errors = validator._validate(_output(line_number=3), portfolio_data=portfolio_data)
-    invalid_errors = validator._validate(_output(line_number=4), portfolio_data=portfolio_data)
+    valid_errors = validator._validate(
+        _output_with_description_line_numbers([1, 2, 3]),
+        portfolio_data=portfolio_data,
+    )
+    invalid_errors = validator._validate(
+        _output_with_description_line_numbers([1, 2, 4]),
+        portfolio_data=portfolio_data,
+    )
 
-    assert "description의 line_number 3가 원본 라인 수(3)를 벗어났습니다." not in valid_errors
-    assert "description의 line_number 4가 원본 라인 수(3)를 벗어났습니다." in invalid_errors
+    assert not valid_errors
+    assert any("description의 line_number 누락: [3]" in error for error in invalid_errors)
+    assert any("description의 line_number 범위 초과: [4]" in error for error in invalid_errors)
+
+
+def test_validate_detects_missing_duplicate_and_ordered_line_numbers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """라인 번호 누락, 중복, 순서 불일치를 검증 오류로 반환한다."""
+    from features.correction import generator
+
+    monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
+    validator = CorrectionGenerator(max_retries=0)
+    portfolio_data = {
+        "description": "- 첫 줄\n- 둘째 줄",
+        "contributions": "- 한 줄",
+        "achievements": "- 한 줄",
+        "insights": "- 한 줄",
+    }
+
+    duplicate_errors = validator._validate(
+        _output_with_description_line_numbers([1, 1]),
+        portfolio_data=portfolio_data,
+    )
+    reordered_errors = validator._validate(
+        _output_with_description_line_numbers([2, 1]),
+        portfolio_data=portfolio_data,
+    )
+
+    assert any("description의 line_number 누락: [2]" in error for error in duplicate_errors)
+    assert any("description의 line_number 중복: [1]" in error for error in duplicate_errors)
+    assert any(
+        "description의 line_number 순서가 원본과 일치하지 않습니다" in error
+        for error in reordered_errors
+    )
 
 
 def test_correction_yaml_max_retries_has_priority(monkeypatch: pytest.MonkeyPatch):
@@ -538,6 +644,7 @@ def test_correction_generator_singleton(monkeypatch: pytest.MonkeyPatch):
         ('```\n{"fields": []}\n```', '{"fields": []}'),
         ('  ```json\n  {"fields": []}\n  ```  ', '{"fields": []}'),
         ('```JSON\n{"fields": []}\n```', '{"fields": []}'),
+        ('응답:\n```json\n{"fields": []}\n```\n끝', '{"fields": []}'),
     ],
 )
 def test_strip_json_code_fence(raw: str, expected: str):
@@ -545,18 +652,41 @@ def test_strip_json_code_fence(raw: str, expected: str):
     assert _strip_json_code_fence(raw) == expected
 
 
-def test_parse_single_correction_output_accepts_fenced_json():
+def test_parse_single_correction_decision_output_accepts_fenced_json():
     """```json``` 펜스로 감싸진 JSON도 정상 파싱된다."""
-    payload = _output_json(line_number=1)
-    parsed = _parse_single_correction_output(f"```json\n{payload}\n```")
+    payload = _decision_json(line_number=1)
+    parsed = _parse_single_correction_decision_output(f"```json\n{payload}\n```")
 
-    assert parsed == _output(line_number=1)
+    assert parsed == _decision_output(line_number=1)
+
+
+def test_parse_single_correction_decision_output_rejects_original_text():
+    """LLM decision 스키마는 original_text 출력을 거부한다."""
+    payload = _output(line_number=1).model_dump_json()
+
+    with pytest.raises(ValidationError):
+        _parse_single_correction_decision_output(payload)
+
+
+def test_combine_decision_with_original_text_uses_line_map():
+    """decision 결과에 라인맵의 원문을 결합해 최종 출력으로 변환한다."""
+    combined = _combine_decision_with_original_text(
+        _decision_output(line_number=1),
+        {
+            "description": {1: "desc"},
+            "contributions": {1: "contri"},
+            "achievements": {1: "ach"},
+            "insights": {1: "ins"},
+        },
+    )
+
+    assert combined == _output(line_number=1)
 
 
 def test_parse_single_correction_output_raises_on_empty():
     """공백/펜스만 들어 있으면 ValueError를 발생시킨다."""
     with pytest.raises(ValueError, match="LLM 응답이 비어 있습니다"):
-        _parse_single_correction_output("```json\n\n```")
+        _parse_single_correction_decision_output("```json\n\n```")
 
 
 def test_parse_single_correction_output_raises_on_invalid_json():

--- a/tests/test_features/test_correction/test_schemas.py
+++ b/tests/test_features/test_correction/test_schemas.py
@@ -12,6 +12,7 @@ from features.correction.schemas import (
     CorrectionOutput,
     CorrectionStatus,
     PortfolioCorrectionResult,
+    SingleCorrectionDecisionOutput,
     SingleCorrectionOutput,
 )
 
@@ -63,6 +64,74 @@ def _sample_fields() -> list[dict]:
             ],
         },
     ]
+
+
+def _sample_decision_fields() -> list[dict]:
+    return [
+        {
+            "field_name": "description",
+            "lines": [
+                {
+                    "line_number": 1,
+                    "type": "keep",
+                    "comment": None,
+                }
+            ],
+        },
+        {
+            "field_name": "contributions",
+            "lines": [
+                {
+                    "line_number": 1,
+                    "type": "keep",
+                    "comment": None,
+                }
+            ],
+        },
+        {
+            "field_name": "achievements",
+            "lines": [
+                {
+                    "line_number": 1,
+                    "type": "keep",
+                    "comment": None,
+                }
+            ],
+        },
+        {
+            "field_name": "insights",
+            "lines": [
+                {
+                    "line_number": 1,
+                    "type": "keep",
+                    "comment": None,
+                }
+            ],
+        },
+    ]
+
+
+def test_single_correction_decision_output_schema_excludes_original_text():
+    """LLM decision 스키마는 원문 없이 판단 값만 포함한다."""
+    output = SingleCorrectionDecisionOutput.model_validate({"fields": _sample_decision_fields()})
+
+    assert output.fields[0].field_name == "description"
+    assert not hasattr(output.fields[0].lines[0], "original_text")
+
+
+def test_single_correction_decision_output_rejects_original_text():
+    """LLM decision 스키마는 original_text/originalText 추가 출력을 거부한다."""
+    fields = _sample_decision_fields()
+    fields[0]["lines"][0]["original_text"] = "원문"
+
+    with pytest.raises(ValueError):
+        SingleCorrectionDecisionOutput.model_validate({"fields": fields})
+
+    fields = _sample_decision_fields()
+    fields[0]["lines"][0]["originalText"] = "원문"
+
+    with pytest.raises(ValueError):
+        SingleCorrectionDecisionOutput.model_validate({"fields": fields})
 
 
 def test_single_correction_output_schema():

--- a/tests/test_features/test_correction/test_service.py
+++ b/tests/test_features/test_correction/test_service.py
@@ -863,6 +863,7 @@ async def test_run_generation_failure_updates_failed_status():
     await service._run_generation(1)
 
     assert client.updated_statuses[-1] == {"correction_id": 1, "status": "FAILED"}
+    assert client.updated_results == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #247

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 첨삭 생성 LLM 전용 `SingleCorrectionDecisionOutput` 스키마를 추가해 `original_text`/`originalText` 출력 없이 `line_number`, `type`, `comment`만 받도록 변경했습니다.
- 기존 `SingleCorrectionOutput`은 서버 저장용 최종 스키마로 유지하고, 포트폴리오 원문 라인맵을 기준으로 최종 결과의 `original_text`를 코드에서 조합하도록 했습니다.
- `format_portfolio_for_correction()`와 같은 소구분 헤더, bullet, 이어지는 일반 줄 병합 규칙을 쓰는 `build_portfolio_correction_line_map()`을 추가했습니다.
- 프롬프트에 순수 JSON object 출력, Markdown 코드블록 금지, 원문 텍스트 출력 금지 제약을 명확히 반영했습니다.
- fenced JSON 응답에서 복구 가능한 JSON 본문을 추출하고 decision 스키마로 재검증하도록 파싱 fallback을 보강했습니다.
- field별 expected/actual line number가 정확히 일치하는지 검증하고, 누락/중복/범위 초과/순서 불일치를 재시도 피드백에 포함하도록 했습니다.
- 재시도 소진 시 검증 실패한 마지막 출력을 성공 결과로 반환하지 않고 실패 처리하도록 변경했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check --fix .` 통과
  - `uv run ruff format .` 통과 (`1 file reformatted, 189 files left unchanged`)
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`190 files already formatted`)
  - `uv run pytest tests/test_features/test_correction` 통과 (`116 passed`)
  - `uv run pytest` 통과 (`830 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 별도 배포 전 수동 작업은 없습니다.
- 모델 교체나 `CORRECTION_LLM_MODEL` 운영 설정 변경은 이번 PR 범위가 아닙니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 첨삭 생성 시 검증 오류에 대한 상세한 오류 메시지 제공 (누락/중복/범위 초과 등)
  * 잘못된 형식의 응답을 거부하여 데이터 정확성 강화
  * 재시도 실패 시 명확한 오류 발생으로 불완전한 결과 반환 방지

* **개선**
  * 라인 번호 추적 정확도 향상
  * 포트폴리오 데이터 정규화로 처리 일관성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->