### PR TITLE
[Fix] 인터뷰 연장 모드 4단계 완료 조건 강화

### DIFF
--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -112,7 +112,7 @@ class InterviewService:
 
     @staticmethod
     def _is_regular_interview_complete_state(current_state: dict) -> bool:
-        """4단계 정규 인터뷰가 완료된 상태인지 판단한다."""
+        """4단계 정규 인터뷰가 완료된 상태인지 보수적으로 판단한다."""
         if not bool(current_state.get("all_stages_complete")):
             return False
 
@@ -125,7 +125,7 @@ class InterviewService:
 
         stage_progress = current_state.get("stage_progress")
         if not isinstance(stage_progress, dict):
-            return True
+            return False
 
         if "is_complete" in stage_progress:
             return bool(stage_progress["is_complete"])
@@ -133,7 +133,7 @@ class InterviewService:
         fixed_q_used = stage_progress.get("fixed_q_used")
         fixed_q_total = stage_progress.get("fixed_q_total")
         if fixed_q_used is None or fixed_q_total is None:
-            return True
+            return False
 
         try:
             return int(fixed_q_used) >= int(fixed_q_total)

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -116,6 +116,7 @@ class InterviewService:
         if not bool(current_state.get("all_stages_complete")):
             return False
 
+        # current_stage가 없는 구형/오염 상태는 안전하게 완료로 보지 않는다.
         try:
             current_stage = int(current_state.get("current_stage") or 0)
         except (TypeError, ValueError):

--- a/features/interview/service.py
+++ b/features/interview/service.py
@@ -111,11 +111,41 @@ class InterviewService:
         }
 
     @staticmethod
+    def _is_regular_interview_complete_state(current_state: dict) -> bool:
+        """4단계 정규 인터뷰가 완료된 상태인지 판단한다."""
+        if not bool(current_state.get("all_stages_complete")):
+            return False
+
+        try:
+            current_stage = int(current_state.get("current_stage") or 0)
+        except (TypeError, ValueError):
+            return False
+        if current_stage != 4:
+            return False
+
+        stage_progress = current_state.get("stage_progress")
+        if not isinstance(stage_progress, dict):
+            return True
+
+        if "is_complete" in stage_progress:
+            return bool(stage_progress["is_complete"])
+
+        fixed_q_used = stage_progress.get("fixed_q_used")
+        fixed_q_total = stage_progress.get("fixed_q_total")
+        if fixed_q_used is None or fixed_q_total is None:
+            return True
+
+        try:
+            return int(fixed_q_used) >= int(fixed_q_total)
+        except (TypeError, ValueError):
+            return False
+
+    @staticmethod
     def _should_auto_start_extension(current_state: dict, max_extensions: int) -> bool:
         """완료된 일반 세션의 후속 채팅을 연장 모드 첫 입력으로 처리할지 판단한다."""
         extension_count = int(current_state.get("extension_count") or 0)
         return (
-            bool(current_state.get("all_stages_complete"))
+            InterviewService._is_regular_interview_complete_state(current_state)
             and not bool(current_state.get("is_extended_mode", False))
             and extension_count < max_extensions
         )
@@ -370,8 +400,8 @@ class InterviewService:
             raise ValueError(f"세션을 찾을 수 없습니다: {session_id}")
 
         global_config = get_global_config()
-        if not current_state["all_stages_complete"]:
-            raise ValueError("연장은 모든 단계 완료 후에만 시작할 수 있습니다.")
+        if not self._is_regular_interview_complete_state(current_state):
+            raise ValueError("연장은 4단계 정규 인터뷰 완료 후에만 시작할 수 있습니다.")
 
         if int(current_state.get("extension_count") or 0) >= global_config.max_extensions:
             raise ValueError("최대 연장 횟수에 도달하여 더 이상 연장할 수 없습니다.")
@@ -422,7 +452,7 @@ class InterviewService:
             return
 
         global_config = get_global_config()
-        if not current_state["all_stages_complete"]:
+        if not self._is_regular_interview_complete_state(current_state):
             yield {
                 "event": SSEEventType.ERROR,
                 "data": json.dumps(
@@ -430,7 +460,7 @@ class InterviewService:
                         "type": SSEEventType.ERROR,
                         "error": {
                             "code": SSEErrorCode.LLM_ERROR,
-                            "message": "연장은 모든 단계 완료 후에만 시작할 수 있습니다.",
+                            "message": "연장은 4단계 정규 인터뷰 완료 후에만 시작할 수 있습니다.",
                         },
                     },
                     ensure_ascii=False,

--- a/tests/test_features/test_interview/test_analyst.py
+++ b/tests/test_features/test_interview/test_analyst.py
@@ -185,6 +185,40 @@ def test_run_moves_to_next_stage_when_dynamic_followup_enabled(monkeypatch):
     assert result["next_node"] == "question_generator"
 
 
+def test_run_moves_from_stage_3_to_stage_4_without_extension(monkeypatch):
+    """3단계 완료 시 연장 모드가 아니라 4단계 첫 질문 생성으로 라우팅한다."""
+    response = AnalystResponse(fields=[])
+    monkeypatch.setattr(
+        analyst, "get_analyst_llm", lambda temperature=0.3: _mock_analyst_llm(response)
+    )
+    monkeypatch.setattr(
+        analyst,
+        "get_global_config",
+        lambda: _DummyGlobalConfig(max_extensions=1, extension_turns_per_session=18),
+    )
+
+    state = get_initial_interview_state(
+        user_id="test_user",
+        session_id="test_session",
+        experience_name="테스트 경험",
+    )
+    state["current_stage"] = 3
+    stage_3_config = load_stage_config(3)
+    state["stage_progress"]["fixed_q_total"] = len(stage_3_config.fixed_questions)
+    state["stage_progress"]["fixed_q_used"] = state["stage_progress"]["fixed_q_total"]
+
+    result = analyst.run(state)
+    stage_4_config = load_stage_config(4)
+
+    assert result["current_stage"] == 4
+    assert result["is_extended_mode"] is False
+    assert result["all_stages_complete"] is False
+    assert result["stage_progress"]["fixed_q_used"] == 0
+    assert result["stage_progress"]["fixed_q_total"] == len(stage_4_config.fixed_questions)
+    assert result["stage_progress"]["is_complete"] is False
+    assert result["next_node"] == "question_generator"
+
+
 def test_run_keeps_stage_when_fixed_questions_remain_even_if_required_fields_complete(
     monkeypatch,
 ):

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -83,6 +83,96 @@ def _completed_stage_4_progress() -> dict:
     }
 
 
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ({}, False),
+        ({"all_stages_complete": True}, False),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 3,
+                "stage_progress": _completed_stage_4_progress(),
+            },
+            False,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": _completed_stage_4_progress(),
+            },
+            True,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": "4",
+                "stage_progress": {"is_complete": True},
+            },
+            True,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": {
+                    "fixed_q_used": 3,
+                    "fixed_q_total": 3,
+                    "is_complete": False,
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": {"fixed_q_used": 3, "fixed_q_total": 3},
+            },
+            True,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": {"fixed_q_used": 2, "fixed_q_total": 3},
+            },
+            False,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": None,
+            },
+            False,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": {"fixed_q_used": 3},
+            },
+            False,
+        ),
+        (
+            {
+                "all_stages_complete": True,
+                "current_stage": 4,
+                "stage_progress": {"fixed_q_used": "invalid", "fixed_q_total": 3},
+            },
+            False,
+        ),
+    ],
+)
+def test_is_regular_interview_complete_state(state, expected):
+    """4단계 정규 인터뷰 완료 판정 분기를 고정한다."""
+    assert (
+        interview_service.InterviewService._is_regular_interview_complete_state(state) is expected
+    )
+
+
 @pytest.mark.asyncio
 async def test_create_session_validation_error(monkeypatch):
     """필수 파라미터 누락 시 예외 발생 테스트"""
@@ -701,7 +791,7 @@ async def test_extend_session_raises_when_not_completed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_extend_session_raises_when_completion_flag_is_set_before_stage_four(monkeypatch):
+async def test_extend_session_raises_when_completion_flag_set_before_stage_4(monkeypatch):
     """완료 플래그가 잘못 켜진 3단계 상태는 명시적 연장도 차단한다."""
     dummy_graph = DummyGraph()
     dummy_graph.state_snapshot = DummyStateSnapshot(

--- a/tests/test_features/test_interview/test_service.py
+++ b/tests/test_features/test_interview/test_service.py
@@ -72,6 +72,17 @@ def _build_service(monkeypatch, dummy_graph):
     return interview_service.InterviewService()
 
 
+def _completed_stage_4_progress() -> dict:
+    return {
+        "fixed_q_used": 3,
+        "fixed_q_total": 3,
+        "generated_q_used": 0,
+        "generated_q_max": 0,
+        "force_all_generated_q": False,
+        "is_complete": True,
+    }
+
+
 @pytest.mark.asyncio
 async def test_create_session_validation_error(monkeypatch):
     """필수 파라미터 누락 시 예외 발생 테스트"""
@@ -413,6 +424,8 @@ async def test_process_message_auto_starts_extension_for_completed_legacy_sessio
             "all_stages_complete": True,
             "is_extended_mode": False,
             "extension_count": 0,
+            "current_stage": 4,
+            "stage_progress": _completed_stage_4_progress(),
         }
     )
     dummy_graph.invoke_result = {
@@ -470,6 +483,76 @@ async def test_process_message_auto_starts_extension_for_completed_legacy_sessio
 
 
 @pytest.mark.asyncio
+async def test_process_message_does_not_auto_start_extension_before_stage_four(monkeypatch):
+    """완료 플래그가 잘못 켜져 있어도 4단계 완료 전이면 자동 연장으로 넘기지 않는다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "messages": [AIMessage(content="3단계 마지막 질문")],
+            "all_stages_complete": True,
+            "is_extended_mode": False,
+            "extension_count": 0,
+            "current_stage": 3,
+            "stage_progress": {
+                "fixed_q_used": 3,
+                "fixed_q_total": 3,
+                "generated_q_used": 0,
+                "generated_q_max": 0,
+                "force_all_generated_q": False,
+                "is_complete": True,
+            },
+        }
+    )
+    dummy_graph.invoke_result = {
+        "messages": [
+            AIMessage(content="3단계 마지막 질문"),
+            HumanMessage(content="3단계 마지막 답변"),
+            AIMessage(content="4단계 첫 질문"),
+        ],
+        "current_stage": 4,
+        "stage_progress": {
+            "fixed_q_used": 1,
+            "fixed_q_total": 3,
+            "generated_q_used": 0,
+            "generated_q_max": 0,
+            "force_all_generated_q": False,
+            "is_complete": False,
+        },
+        "overall_completion_percentage": 0.0,
+        "all_stages_complete": False,
+        "is_extended_mode": False,
+        "extension_turns_used": 0,
+        "extension_turns_max": 18,
+    }
+    monkeypatch.setattr(
+        interview_service,
+        "get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = _build_service(monkeypatch, dummy_graph)
+
+    result = await service.process_message(
+        session_id="session_1",
+        message="3단계 마지막 답변",
+    )
+
+    assert result["current_stage"] == 4
+    assert result["is_extended_mode"] is False
+    assert result["ai_response"] == "4단계 첫 질문"
+    invocation = dummy_graph.invocations[0]
+    assert "is_extended_mode" not in invocation["state"]
+    assert "extension_count" not in invocation["state"]
+
+
+@pytest.mark.asyncio
 async def test_process_message_resets_current_turn_files_when_no_files(monkeypatch):
     """파일이 없는 턴에도 current_turn_files를 빈 리스트로 초기화한다."""
     dummy_graph = DummyGraph()
@@ -506,6 +589,8 @@ async def test_extend_session_success(monkeypatch):
             "session_id": "session_1",
             "messages": previous_messages,
             "all_stages_complete": True,
+            "current_stage": 4,
+            "stage_progress": _completed_stage_4_progress(),
             "extension_count": 0,
         }
     )
@@ -558,6 +643,8 @@ async def test_extend_session_raises_when_no_new_ai_response(monkeypatch):
             "session_id": "session_1",
             "messages": previous_messages,
             "all_stages_complete": True,
+            "current_stage": 4,
+            "stage_progress": _completed_stage_4_progress(),
             "extension_count": 0,
         }
     )
@@ -609,7 +696,45 @@ async def test_extend_session_raises_when_not_completed(monkeypatch):
     )
     service = _build_service(monkeypatch, dummy_graph)
 
-    with pytest.raises(ValueError, match="모든 단계 완료"):
+    with pytest.raises(ValueError, match="4단계 정규 인터뷰 완료"):
+        await service.extend_session("session_1")
+
+
+@pytest.mark.asyncio
+async def test_extend_session_raises_when_completion_flag_is_set_before_stage_four(monkeypatch):
+    """완료 플래그가 잘못 켜진 3단계 상태는 명시적 연장도 차단한다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.state_snapshot = DummyStateSnapshot(
+        values={
+            "session_id": "session_1",
+            "all_stages_complete": True,
+            "current_stage": 3,
+            "stage_progress": {
+                "fixed_q_used": 3,
+                "fixed_q_total": 3,
+                "generated_q_used": 0,
+                "generated_q_max": 0,
+                "force_all_generated_q": False,
+                "is_complete": True,
+            },
+            "extension_count": 0,
+        }
+    )
+    monkeypatch.setattr(
+        interview_service,
+        "get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = _build_service(monkeypatch, dummy_graph)
+
+    with pytest.raises(ValueError, match="4단계 정규 인터뷰 완료"):
         await service.extend_session("session_1")
 
 
@@ -621,6 +746,8 @@ async def test_extend_session_raises_when_max_extensions_reached(monkeypatch):
         values={
             "session_id": "session_1",
             "all_stages_complete": True,
+            "current_stage": 4,
+            "stage_progress": _completed_stage_4_progress(),
             "extension_count": 1,
         }
     )

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -55,6 +55,17 @@ class DummyGraph:
             self.state_snapshot.values = {**self.state_snapshot.values, **state}
 
 
+def _completed_stage_4_progress() -> dict:
+    return {
+        "fixed_q_used": 3,
+        "fixed_q_total": 3,
+        "generated_q_used": 0,
+        "generated_q_max": 0,
+        "force_all_generated_q": False,
+        "is_complete": True,
+    }
+
+
 @pytest.mark.anyio
 async def test_create_session_stream_yields_delta_and_complete(monkeypatch):
     """첫 질문 생성 시 토큰과 완료 이벤트를 순서대로 전송하는지 테스트"""
@@ -405,6 +416,8 @@ async def test_process_message_stream_auto_starts_extension_after_regular_comple
         "all_stages_complete": True,
         "is_extended_mode": False,
         "extension_count": 0,
+        "current_stage": 4,
+        "stage_progress": _completed_stage_4_progress(),
     }
     final_state = {
         "messages": [
@@ -465,6 +478,103 @@ async def test_process_message_stream_auto_starts_extension_after_regular_comple
 
 
 @pytest.mark.anyio
+async def test_process_message_stream_does_not_auto_start_extension_before_stage_four(monkeypatch):
+    """완료 플래그가 잘못 켜져도 4단계 완료 전이면 채팅 스트림을 자동 연장하지 않는다."""
+    dummy_graph = DummyGraph()
+    dummy_graph.stream_events = [
+        {
+            "event": LangGraphEventType.ON_CHAT_MODEL_STREAM,
+            "metadata": {"langgraph_node": "question_generator"},
+            "data": {"chunk": DummyChunk("4단계 첫 질문")},
+        }
+    ]
+
+    monkeypatch.setattr(
+        "features.interview.service.build_graph", lambda checkpointer=None: dummy_graph
+    )
+    monkeypatch.setattr("features.interview.service.get_checkpointer", lambda: object())
+    monkeypatch.setattr(
+        "features.interview.service.get_global_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "max_extensions": 1,
+                "extension_turns_per_session": 18,
+            },
+        )(),
+    )
+    service = InterviewService()
+
+    previous_messages = [AIMessage(content="3단계 마지막 질문")]
+    initial_state = {
+        "session_id": "session-1",
+        "messages": previous_messages,
+        "all_stages_complete": True,
+        "is_extended_mode": False,
+        "extension_count": 0,
+        "current_stage": 3,
+        "stage_progress": {
+            "fixed_q_used": 3,
+            "fixed_q_total": 3,
+            "generated_q_used": 0,
+            "generated_q_max": 0,
+            "force_all_generated_q": False,
+            "is_complete": True,
+        },
+    }
+    final_state = {
+        "messages": [
+            *previous_messages,
+            HumanMessage(content="3단계 마지막 답변"),
+            AIMessage(content="4단계 첫 질문"),
+        ],
+        "current_stage": 4,
+        "stage_progress": {
+            "fixed_q_used": 1,
+            "fixed_q_total": 3,
+            "generated_q_used": 0,
+            "generated_q_max": 0,
+            "force_all_generated_q": False,
+            "is_complete": False,
+        },
+        "overall_completion_percentage": 0.0,
+        "all_stages_complete": False,
+        "is_extended_mode": False,
+        "extension_turns_used": 0,
+        "extension_turns_max": 18,
+    }
+    states = [initial_state, final_state]
+
+    async def _get_session_state(_session_id: str):
+        if states:
+            return states.pop(0)
+        return final_state
+
+    monkeypatch.setattr(service, "get_session_state", _get_session_state)
+
+    events = [
+        event
+        async for event in service.process_message_stream(
+            session_id="session-1",
+            message="3단계 마지막 답변",
+        )
+    ]
+
+    invocation = dummy_graph.astream_calls[0]["state"]
+    assert "is_extended_mode" not in invocation
+    assert "extension_count" not in invocation
+
+    complete_event = next(
+        event for event in events if event["event"] == SSEEventType.MESSAGE_COMPLETE
+    )
+    complete_payload = json.loads(complete_event["data"])
+    assert complete_payload["message"]["ai_response"] == "4단계 첫 질문"
+    assert complete_payload["message"]["current_stage"] == 4
+    assert complete_payload["message"]["is_extended_mode"] is False
+
+
+@pytest.mark.anyio
 async def test_extend_session_stream_yields_delta_and_complete(monkeypatch):
     """연장 시작 스트림에서 토큰과 완료 이벤트를 순서대로 전송한다."""
     dummy_graph = DummyGraph()
@@ -496,6 +606,8 @@ async def test_extend_session_stream_yields_delta_and_complete(monkeypatch):
     initial_state = {
         "session_id": "session-1",
         "all_stages_complete": True,
+        "current_stage": 4,
+        "stage_progress": _completed_stage_4_progress(),
         "extension_count": 0,
     }
     final_state = {
@@ -577,6 +689,8 @@ async def test_extend_session_stream_uses_new_ai_response_when_no_tokens(monkeyp
         "session_id": "session-1",
         "messages": previous_messages,
         "all_stages_complete": True,
+        "current_stage": 4,
+        "stage_progress": _completed_stage_4_progress(),
         "extension_count": 0,
     }
     final_state = {
@@ -713,6 +827,8 @@ async def test_extend_session_stream_sets_failed_status_on_cancellation(monkeypa
     initial_state = {
         "session_id": "session-1",
         "all_stages_complete": True,
+        "current_stage": 4,
+        "stage_progress": _completed_stage_4_progress(),
         "extension_count": 0,
     }
 

--- a/tests/test_features/test_interview/test_service_session_stream.py
+++ b/tests/test_features/test_interview/test_service_session_stream.py
@@ -478,7 +478,7 @@ async def test_process_message_stream_auto_starts_extension_after_regular_comple
 
 
 @pytest.mark.anyio
-async def test_process_message_stream_does_not_auto_start_extension_before_stage_four(monkeypatch):
+async def test_process_message_stream_no_auto_extension_before_stage_4(monkeypatch):
     """완료 플래그가 잘못 켜져도 4단계 완료 전이면 채팅 스트림을 자동 연장하지 않는다."""
     dummy_graph = DummyGraph()
     dummy_graph.stream_events = [


### PR DESCRIPTION
## 📌 관련 이슈

- 없음 (PR #234 후속 피드백 대응)

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 자동 연장 시작 조건을 `all_stages_complete` 단독 판단에서 4단계 정규 인터뷰 완료 상태 확인으로 강화했습니다.
- `/extend` 및 `/extend/stream` 명시 연장 경로도 4단계 완료 상태에서만 시작되도록 동일한 guard를 적용했습니다.
- 저장 상태가 비정상적으로 `all_stages_complete=True`인 3단계 세션에서도 `/chat`과 `/chat/stream`이 자동 연장으로 진입하지 않고 4단계 진행을 유지하는 회귀 테스트를 추가했습니다.
- 3단계 완료 시 연장 모드가 아닌 4단계 첫 질문 생성으로 라우팅되는 Analyst 회귀 테스트를 추가했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`190 files already formatted`)
  - `uv run pytest -q` 통과 (`827 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- PR #234의 정상 플로우인 4단계 완료 직후 첫 연장 질문 자동 생성은 유지합니다.
- 이번 변경은 잘못 저장된 완료 플래그나 레거시 상태로 인해 4단계 전 자동 연장이 시작되는 경우를 방어합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인터뷰 4단계 완료 상태 판정 로직 개선으로 연장 모드 자동 시작 조건 정밀화
  * 연장 허용 거부 시 에러 메시지를 더 명확하게 개선

* **테스트**
  * 인터뷰 단계 전환 및 연장 모드 시작 조건에 대한 테스트 커버리지 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->