### PR TITLE
[Fix] PDF 포트폴리오 첨삭 입력 포맷 보정

### DIFF
--- a/features/correction/prompts/correction_prompt.py
+++ b/features/correction/prompts/correction_prompt.py
@@ -13,7 +13,9 @@ _FIELD_TITLE_BY_NAME = {
 }
 
 _BULLET_PATTERN = re.compile(r"^\s*[-*]\s+(?P<content>.+)$")
-_SUBHEADER_PATTERN = re.compile(r"^\s*(?:\*\*)?(?:\[[^\]]+\]|\d+\)\s*\S.+)(?:\*\*)?\s*$")
+_SUBHEADER_PATTERN = re.compile(
+    r"^\s*(?:\*\*)?(?:\[[^\]]+\]|\d+\)\s*\S.+|#\s*\d+(?:\s+\S.*)?)(?:\*\*)?\s*$"
+)
 _EMPTY_TEXT_VALUES = {"", "0"}
 
 CORRECTION_SYSTEM_PROMPT = """
@@ -133,6 +135,7 @@ def _format_field_for_correction(field_lines: list[str]) -> tuple[list[str], dic
     line_number = 0
     latest_numbered_line_index: int | None = None
     latest_line_number: int | None = None
+    has_bullet_line = any(_BULLET_PATTERN.match(line) is not None for line in field_lines)
 
     for line in field_lines:
         if _is_subheader_line(line):
@@ -147,6 +150,14 @@ def _format_field_for_correction(field_lines: list[str]) -> tuple[list[str], dic
             bullet_content = bullet_match.group("content").strip()
             output_lines.append(f"{line_number}. {bullet_content}")
             original_text_by_line_number[line_number] = bullet_content
+            latest_numbered_line_index = len(output_lines) - 1
+            latest_line_number = line_number
+            continue
+
+        if not has_bullet_line:
+            line_number += 1
+            output_lines.append(f"{line_number}. {line}")
+            original_text_by_line_number[line_number] = line
             latest_numbered_line_index = len(output_lines) - 1
             latest_line_number = line_number
             continue

--- a/features/correction/prompts/correction_prompt.py
+++ b/features/correction/prompts/correction_prompt.py
@@ -13,6 +13,7 @@ _FIELD_TITLE_BY_NAME = {
 }
 
 _BULLET_PATTERN = re.compile(r"^\s*[-*]\s+(?P<content>.+)$")
+_NUMBERED_LINE_PATTERN = re.compile(r"^\s*\d+\.\s+(?P<content>.+)$")
 _SUBHEADER_PATTERN = re.compile(
     r"^\s*(?:\*\*)?(?:\[[^\]]+\]|\d+\)\s*\S.+|#\s*\d+(?:\s+\S.*)?)(?:\*\*)?\s*$"
 )
@@ -156,8 +157,14 @@ def _format_field_for_correction(field_lines: list[str]) -> tuple[list[str], dic
 
         if not has_bullet_line:
             line_number += 1
-            output_lines.append(f"{line_number}. {line}")
-            original_text_by_line_number[line_number] = line
+            numbered_line_match = _NUMBERED_LINE_PATTERN.match(line)
+            original_text = (
+                numbered_line_match.group("content").strip()
+                if numbered_line_match is not None
+                else line
+            )
+            output_lines.append(f"{line_number}. {original_text}")
+            original_text_by_line_number[line_number] = original_text
             latest_numbered_line_index = len(output_lines) - 1
             latest_line_number = line_number
             continue

--- a/features/correction/service.py
+++ b/features/correction/service.py
@@ -31,9 +31,8 @@ _FIELD_NAME_TO_SERVER = {
 }
 
 
-def _get_portfolio_text_field(portfolio: dict, *field_names: str) -> object:
-    """여러 서버 필드명 후보 중 비어 있지 않은 첫 값을 반환한다."""
-    fallback: object = ""
+def _get_portfolio_text_field(portfolio: dict, *field_names: str) -> str:
+    """여러 서버 필드명 후보 중 비어 있지 않은 첫 문자열 값을 반환한다."""
     for field_name in field_names:
         if field_name not in portfolio:
             continue
@@ -42,12 +41,12 @@ def _get_portfolio_text_field(portfolio: dict, *field_names: str) -> object:
         if value is None:
             continue
 
-        fallback = value
-        if isinstance(value, str) and value.strip() in {"", "0"}:
+        normalized = str(value).strip()
+        if normalized in {"", "0"}:
             continue
-        return value
+        return normalized
 
-    return fallback if fallback is not None else ""
+    return ""
 
 
 def _to_upper_status(status: CorrectionStatus) -> str:

--- a/features/correction/service.py
+++ b/features/correction/service.py
@@ -31,6 +31,25 @@ _FIELD_NAME_TO_SERVER = {
 }
 
 
+def _get_portfolio_text_field(portfolio: dict, *field_names: str) -> object:
+    """여러 서버 필드명 후보 중 비어 있지 않은 첫 값을 반환한다."""
+    fallback: object = ""
+    for field_name in field_names:
+        if field_name not in portfolio:
+            continue
+
+        value = portfolio[field_name]
+        if value is None:
+            continue
+
+        fallback = value
+        if isinstance(value, str) and value.strip() in {"", "0"}:
+            continue
+        return value
+
+    return fallback if fallback is not None else ""
+
+
 def _to_upper_status(status: CorrectionStatus) -> str:
     """CorrectionStatus enum을 메인 서버가 기대하는 UPPER_CASE 문자열로 변환"""
     return status.value.upper()
@@ -222,10 +241,14 @@ class CorrectionService:
 
         portfolio = await self._portfolio_client.get_portfolio(portfolio_id)
         portfolio_output = {
-            "description": portfolio.get("description", ""),
-            "contributions": portfolio.get("responsibilities", ""),
-            "achievements": portfolio.get("problemSolving", ""),
-            "insights": portfolio.get("learnings", ""),
+            "description": _get_portfolio_text_field(portfolio, "description"),
+            "contributions": _get_portfolio_text_field(
+                portfolio, "responsibilities", "contributions", "responsibility"
+            ),
+            "achievements": _get_portfolio_text_field(
+                portfolio, "problemSolving", "problem_solving", "achievements"
+            ),
+            "insights": _get_portfolio_text_field(portfolio, "learnings", "learning", "insights"),
         }
         logger.debug(
             "포트폴리오 첨삭 입력 요약 (correction_id: %s, portfolio_id: %s, description_length: %s, contributions_length: %s, achievements_length: %s, insights_length: %s)",

--- a/features/portfolio/pdf_extraction/service.py
+++ b/features/portfolio/pdf_extraction/service.py
@@ -87,7 +87,10 @@ class PdfExtractionService:
         try:
             await self._correction_client.complete_pdf_extraction(
                 correction_id,
-                activities=[activity.model_dump() for activity in activities],
+                activities=[
+                    activity.model_dump()
+                    for activity in self._format_activities_for_callback(activities)
+                ],
                 source_type="EXTERNAL",
             )
         except Exception:
@@ -100,6 +103,37 @@ class PdfExtractionService:
         if stripped.startswith("- "):
             return stripped[2:]
         return value
+
+    @classmethod
+    def _format_bullet_line_for_callback(cls, value: str) -> str:
+        """메인 서버 저장 문자열이 포트폴리오 생성 결과처럼 bullet 라인이 되도록 정리한다."""
+        normalized = cls._normalize_structured_text(value).strip()
+        if not normalized:
+            return ""
+        return f"- {normalized}"
+
+    @classmethod
+    def _format_activities_for_callback(cls, activities: list[PdfActivity]) -> list[PdfActivity]:
+        """PDF 추출 완료 callback 전송용으로 텍스트 리스트를 bullet 라인으로 변환한다."""
+        formatted_activities: list[PdfActivity] = []
+        for activity in activities:
+            formatted_activities.append(
+                activity.model_copy(
+                    update={
+                        "detail": [
+                            cls._format_bullet_line_for_callback(item) for item in activity.detail
+                        ],
+                        "responsibility": [
+                            cls._format_bullet_line_for_callback(item)
+                            for item in activity.responsibility
+                        ],
+                        "learning": [
+                            cls._format_bullet_line_for_callback(item) for item in activity.learning
+                        ],
+                    }
+                )
+            )
+        return formatted_activities
 
     @classmethod
     def _validate_result(cls, result: PdfExtractionResult) -> list[PdfActivity]:

--- a/features/portfolio/pdf_extraction/service.py
+++ b/features/portfolio/pdf_extraction/service.py
@@ -113,6 +113,12 @@ class PdfExtractionService:
         return f"- {normalized}"
 
     @classmethod
+    def _format_bullet_lines_for_callback(cls, values: list[str]) -> list[str]:
+        """빈 항목을 제외하고 callback 전송용 bullet 라인 목록을 생성한다."""
+        formatted_lines = [cls._format_bullet_line_for_callback(value) for value in values]
+        return [line for line in formatted_lines if line]
+
+    @classmethod
     def _format_activities_for_callback(cls, activities: list[PdfActivity]) -> list[PdfActivity]:
         """PDF 추출 완료 callback 전송용으로 텍스트 리스트를 bullet 라인으로 변환한다."""
         formatted_activities: list[PdfActivity] = []
@@ -120,16 +126,11 @@ class PdfExtractionService:
             formatted_activities.append(
                 activity.model_copy(
                     update={
-                        "detail": [
-                            cls._format_bullet_line_for_callback(item) for item in activity.detail
-                        ],
-                        "responsibility": [
-                            cls._format_bullet_line_for_callback(item)
-                            for item in activity.responsibility
-                        ],
-                        "learning": [
-                            cls._format_bullet_line_for_callback(item) for item in activity.learning
-                        ],
+                        "detail": cls._format_bullet_lines_for_callback(activity.detail),
+                        "responsibility": cls._format_bullet_lines_for_callback(
+                            activity.responsibility
+                        ),
+                        "learning": cls._format_bullet_lines_for_callback(activity.learning),
                     }
                 )
             )

--- a/tests/test_features/test_correction/test_correction_prompt.py
+++ b/tests/test_features/test_correction/test_correction_prompt.py
@@ -183,6 +183,48 @@ def test_build_portfolio_correction_line_map_matches_formatter_rules():
     assert line_map["insights"] == {1: "배운 점"}
 
 
+def test_format_portfolio_for_correction_numbers_plain_lines_when_no_bullets():
+    """불릿 없는 외부 포트폴리오 텍스트도 첨삭 대상 번호 라인으로 변환한다."""
+    portfolio = {
+        "description": (
+            '배경: "관광 1번지" 명동의 카페\n'
+            "외국인 관광객 비율이 30% 이상인 카페에서 6개월간 근무했습니다.\n"
+            "Zero Complaint: 주문 실수로 인한 컴플레인 0건"
+        ),
+        "contributions": '외국인 고객에게 "Try this with Oat Milk"라며 옵션을 제안했습니다.',
+        "achievements": (
+            "#1\n"
+            '상황: "Less Sweet", "No Ice" 등 커스텀 주문 오류가 빈번했습니다.\n'
+            "전략: 커스텀 주문 가이드북을 직접 제작했습니다.\n"
+            "이유: 말로 설명하는 데는 한계가 있었습니다."
+        ),
+        "insights": "고객에게 특별한 경험을 제공하는 계기가 되었습니다.",
+    }
+
+    formatted = format_portfolio_for_correction(portfolio)
+    line_map = build_portfolio_correction_line_map(portfolio)
+
+    assert '1. 배경: "관광 1번지" 명동의 카페' in formatted
+    assert "2. 외국인 관광객 비율이 30% 이상인 카페에서 6개월간 근무했습니다." in formatted
+    assert "3. Zero Complaint: 주문 실수로 인한 컴플레인 0건" in formatted
+    assert '1. 외국인 고객에게 "Try this with Oat Milk"라며 옵션을 제안했습니다.' in formatted
+    assert "#1" in formatted
+    assert '1. 상황: "Less Sweet", "No Ice" 등 커스텀 주문 오류가 빈번했습니다.' in formatted
+    assert "2. 전략: 커스텀 주문 가이드북을 직접 제작했습니다." in formatted
+    assert "3. 이유: 말로 설명하는 데는 한계가 있었습니다." in formatted
+    assert "1. 고객에게 특별한 경험을 제공하는 계기가 되었습니다." in formatted
+    assert line_map["description"] == {
+        1: '배경: "관광 1번지" 명동의 카페',
+        2: "외국인 관광객 비율이 30% 이상인 카페에서 6개월간 근무했습니다.",
+        3: "Zero Complaint: 주문 실수로 인한 컴플레인 0건",
+    }
+    assert line_map["achievements"] == {
+        1: '상황: "Less Sweet", "No Ice" 등 커스텀 주문 오류가 빈번했습니다.',
+        2: "전략: 커스텀 주문 가이드북을 직접 제작했습니다.",
+        3: "이유: 말로 설명하는 데는 한계가 있었습니다.",
+    }
+
+
 def test_format_portfolio_for_correction_raises_type_error_for_invalid_portfolio():
     """portfolio가 dict 타입이 아닐 때 TypeError를 발생시키는지 테스트"""
     with pytest.raises(TypeError, match="portfolio는 dict 타입이어야 합니다"):

--- a/tests/test_features/test_correction/test_correction_prompt.py
+++ b/tests/test_features/test_correction/test_correction_prompt.py
@@ -225,6 +225,27 @@ def test_format_portfolio_for_correction_numbers_plain_lines_when_no_bullets():
     }
 
 
+def test_format_portfolio_for_correction_renumbers_existing_numbered_plain_lines():
+    """이미 번호가 붙은 외부 plain line은 번호 접두사를 제거한 뒤 다시 번호를 매긴다."""
+    portfolio = {
+        "description": "1. 첫 설명\n2. 둘째 설명",
+        "contributions": "1. 첫 담당\n2. 둘째 담당",
+        "achievements": "#1\n1. 상황 설명\n2. 전략 설명",
+        "insights": "1. 배운 점",
+    }
+
+    formatted = format_portfolio_for_correction(portfolio)
+    line_map = build_portfolio_correction_line_map(portfolio)
+
+    assert "1. 첫 설명" in formatted
+    assert "2. 둘째 설명" in formatted
+    assert "1. 1. 첫 설명" not in formatted
+    assert "1. 상황 설명" in formatted
+    assert "1. 1. 상황 설명" not in formatted
+    assert line_map["description"] == {1: "첫 설명", 2: "둘째 설명"}
+    assert line_map["achievements"] == {1: "상황 설명", 2: "전략 설명"}
+
+
 def test_format_portfolio_for_correction_raises_type_error_for_invalid_portfolio():
     """portfolio가 dict 타입이 아닐 때 TypeError를 발생시키는지 테스트"""
     with pytest.raises(TypeError, match="portfolio는 dict 타입이어야 합니다"):

--- a/tests/test_features/test_correction/test_generator.py
+++ b/tests/test_features/test_correction/test_generator.py
@@ -303,32 +303,32 @@ def test_generate_raises_error_when_llm_fails_without_output(monkeypatch: pytest
         )
 
 
-def test_generate_fails_fast_when_portfolio_has_no_numbered_line(
+def test_generate_accepts_plain_lines_when_field_has_no_bullets(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """첨삭 대상 번호 라인이 없는 필드는 LLM 호출 전 실패 처리한다."""
+    """불릿 없는 필드도 plain line fallback으로 첨삭 대상 라인을 만든다."""
     from features.correction import generator
 
     chain = DummyChain([_decision_json(line_number=1)])
     monkeypatch.setattr(generator, "correction_generator_prompt", DummyPrompt(chain))
     monkeypatch.setattr(generator, "get_llm", lambda **_: DummyLLM())
 
-    with pytest.raises(CorrectionGenerationError, match="description"):
-        CorrectionGenerator(max_retries=2).generate(
-            company_name="테스트 회사",
-            job_title="백엔드",
-            job_description="채용 공고",
-            company_insight="인사이트",
-            portfolio_data={
-                "description": "불릿 없는 설명",
-                "contributions": "- contri",
-                "achievements": "- ach",
-                "insights": "- ins",
-            },
-            emphasis_points="강조 포인트",
-        )
+    result = CorrectionGenerator(max_retries=2).generate(
+        company_name="테스트 회사",
+        job_title="백엔드",
+        job_description="채용 공고",
+        company_insight="인사이트",
+        portfolio_data={
+            "description": "desc",
+            "contributions": "- contri",
+            "achievements": "- ach",
+            "insights": "- ins",
+        },
+        emphasis_points="강조 포인트",
+    )
 
-    assert chain.calls == []
+    assert result == _output()
+    assert len(chain.calls) == 1
 
 
 def test_generate_overall_summary(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_features/test_correction/test_service.py
+++ b/tests/test_features/test_correction/test_service.py
@@ -839,6 +839,44 @@ async def test_run_generation_supports_external_snake_case_portfolio_fields():
 
 
 @pytest.mark.asyncio
+async def test_run_generation_skips_empty_placeholders_and_stringifies_fields():
+    """빈 값과 '0' placeholder는 건너뛰고 선택한 필드는 문자열로 정규화한다."""
+    client = DummyCorrectionClient()
+    client.corrections[1] = _make_correction(
+        status="GENERATING",
+        company_insight="인사이트",
+        highlight_point="강조",
+        portfolio_ids=[77],
+    )
+    generator = DummyGenerator()
+    portfolio_client = DummyPortfolioClient(
+        portfolios={
+            77: {
+                "id": 77,
+                "description": 123,
+                "responsibilities": "0",
+                "responsibility": " 담당 업무 ",
+                "problemSolving": "",
+                "problem_solving": "문제 해결",
+                "learnings": None,
+                "learning": "배운 점",
+            }
+        }
+    )
+    service = CorrectionService(client, portfolio_client, generator, DummyRagPipeline())
+
+    await service._run_generation(1)
+
+    assert generator.calls[0]["portfolio_output"] == {
+        "description": "123",
+        "contributions": "담당 업무",
+        "achievements": "문제 해결",
+        "insights": "배운 점",
+    }
+    assert client.updated_results
+
+
+@pytest.mark.asyncio
 async def test_run_generation_does_not_block_event_loop():
     """_run_generation의 LLM 호출은 이벤트 루프를 블로킹하지 않는다."""
 

--- a/tests/test_features/test_correction/test_service.py
+++ b/tests/test_features/test_correction/test_service.py
@@ -804,6 +804,41 @@ async def test_run_generation_success_calls_generator_and_saves_result():
 
 
 @pytest.mark.asyncio
+async def test_run_generation_supports_external_snake_case_portfolio_fields():
+    """외부 PDF 포트폴리오의 snake_case 필드명도 첨삭 입력으로 사용한다."""
+    client = DummyCorrectionClient()
+    client.corrections[1] = _make_correction(
+        status="GENERATING",
+        company_insight="인사이트",
+        highlight_point="강조",
+        portfolio_ids=[77],
+    )
+    generator = DummyGenerator()
+    portfolio_client = DummyPortfolioClient(
+        portfolios={
+            77: {
+                "id": 77,
+                "description": "상세",
+                "responsibility": "담당 업무",
+                "problem_solving": "문제 해결",
+                "learning": "배운 점",
+            }
+        }
+    )
+    service = CorrectionService(client, portfolio_client, generator, DummyRagPipeline())
+
+    await service._run_generation(1)
+
+    assert generator.calls[0]["portfolio_output"] == {
+        "description": "상세",
+        "contributions": "담당 업무",
+        "achievements": "문제 해결",
+        "insights": "배운 점",
+    }
+    assert client.updated_results
+
+
+@pytest.mark.asyncio
 async def test_run_generation_does_not_block_event_loop():
     """_run_generation의 LLM 호출은 이벤트 루프를 블로킹하지 않는다."""
 

--- a/tests/test_features/test_portfolio/test_pdf_extraction_service.py
+++ b/tests/test_features/test_portfolio/test_pdf_extraction_service.py
@@ -148,8 +148,8 @@ async def test_background_extraction_success_calls_complete_callback(monkeypatch
             [
                 {
                     "activity_name": "프로젝트 A",
-                    "detail": ["상세 설명"],
-                    "responsibility": ["담당 업무"],
+                    "detail": ["- 상세 설명"],
+                    "responsibility": ["- 담당 업무"],
                     "problem_solving": [
                         {
                             "no": 1,
@@ -158,7 +158,7 @@ async def test_background_extraction_success_calls_complete_callback(monkeypatch
                             "reason": "이유",
                         }
                     ],
-                    "learning": ["배운 점"],
+                    "learning": ["- 배운 점"],
                 }
             ],
             "EXTERNAL",
@@ -349,6 +349,35 @@ def test_validate_result_removes_only_leading_dash_bullets_from_structured_field
             reason="선택 이유",
         )
     ]
+
+
+def test_format_activities_for_callback_adds_single_dash_bullet_to_text_lists():
+    """완료 콜백 전송용 텍스트 리스트는 기존 포트폴리오처럼 dash bullet으로 정규화한다."""
+    service = PdfExtractionService(
+        correction_client=DummyCorrectionClient(),
+        generator=DummyGenerator(),
+    )
+    activity = PdfActivity(
+        activity_name="Project A",
+        detail=["상세", "- 이미 bullet", "  - 공백 bullet"],
+        responsibility=["담당 업무"],
+        problem_solving=[
+            PdfProblemSolvingItem(
+                no=1,
+                situation="문제 상황",
+                strategy="대응 전략",
+                reason="선택 이유",
+            )
+        ],
+        learning=["배운 점"],
+    )
+
+    formatted = service._format_activities_for_callback([activity])
+
+    assert formatted[0].detail == ["- 상세", "- 이미 bullet", "- 공백 bullet"]
+    assert formatted[0].responsibility == ["- 담당 업무"]
+    assert formatted[0].learning == ["- 배운 점"]
+    assert formatted[0].problem_solving == activity.problem_solving
 
 
 def test_validate_file_allows_pdf_extension_for_wrong_mime_type():

--- a/tests/test_features/test_portfolio/test_pdf_extraction_service.py
+++ b/tests/test_features/test_portfolio/test_pdf_extraction_service.py
@@ -380,6 +380,27 @@ def test_format_activities_for_callback_adds_single_dash_bullet_to_text_lists():
     assert formatted[0].problem_solving == activity.problem_solving
 
 
+def test_format_activities_for_callback_removes_empty_text_items():
+    """완료 콜백 전송용 텍스트 리스트에서 빈 항목은 제거한다."""
+    service = PdfExtractionService(
+        correction_client=DummyCorrectionClient(),
+        generator=DummyGenerator(),
+    )
+    activity = PdfActivity(
+        activity_name="Project A",
+        detail=["", "   ", "- ", "상세"],
+        responsibility=["  - ", "담당 업무"],
+        problem_solving=[],
+        learning=["", "배운 점"],
+    )
+
+    formatted = service._format_activities_for_callback([activity])
+
+    assert formatted[0].detail == ["- 상세"]
+    assert formatted[0].responsibility == ["- 담당 업무"]
+    assert formatted[0].learning == ["- 배운 점"]
+
+
 def test_validate_file_allows_pdf_extension_for_wrong_mime_type():
     """MIME이 잘못돼도 .pdf 확장자면 fallback 허용한다."""
     service = PdfExtractionService(


### PR DESCRIPTION
## 📌 관련 이슈

- 없음

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PDF 추출 완료 callback 전송 직전에 detail/responsibility/learning 텍스트를 기존 포트폴리오 생성 결과와 같은 dash bullet 형식으로 정규화했습니다.
- 첨삭용 포트폴리오 라인맵이 bullet 없는 외부 포트폴리오 plain line도 번호 매김 대상으로 처리하도록 fallback을 추가했습니다.
- PDF/외부 포트폴리오 응답에서 responsibility, problem_solving, learning 같은 필드명도 첨삭 입력으로 읽을 수 있도록 fallback을 보강했습니다.
- PDF callback 포맷, plain line 첨삭 라인맵, snake_case 필드 fallback 회귀 테스트를 추가했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`190 files already formatted`)
  - `uv run pytest` 통과 (`851 passed`)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- API 엔드포인트와 callback schema 계약은 변경하지 않았습니다.
- 기존에 저장된 77번과 같은 plain text 포트폴리오도 첨삭 생성에서 라인 0개로 실패하지 않도록 방어합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 포트폴리오 텍스트 필드 선택 알고리즘 개선으로 여러 후보 필드 중 유효한 값을 자동으로 선택.

* **Bug Fixes**
  * 불릿 포인트가 없는 필드도 자동으로 번호가 지정되도록 개선.
  * PDF 추출 완료 시 활동 정보 포매팅 정규화.

* **Tests**
  * 첨삭 포맷팅 검증 테스트 추가.
  * 외부 포트폴리오 필드 변환 처리 검증 테스트 추가.
  * 활동 정보 포매팅 검증 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Teamie71/folioo-ai/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->