### PR TITLE
[PPTX] 워커 GCP 배포 준비 및 메인 콜백 계약 정합화

### DIFF
--- a/apps/pptx-worker/Dockerfile
+++ b/apps/pptx-worker/Dockerfile
@@ -10,6 +10,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
 ENV PORT=8080
 ENV JAVA_TOOL_OPTIONS=-Xmx512m
 ENV PPTX_WORKER_RECYCLE_AFTER=20
+ENV ANTHROPIC_PPTX_SKILL_DIR=/app/apps/pptx-worker/toolchain
 ENV PYTHONPATH=/app:/app/apps/pptx-worker
 ENV PATH=/app/.venv/bin:$PATH
 

--- a/apps/pptx-worker/features/visualization/qa.py
+++ b/apps/pptx-worker/features/visualization/qa.py
@@ -773,7 +773,6 @@ class VisualQAFixVerifyStep:
         preview_attempt_id: str | None,
     ) -> str:
         slide = pending_slide.slide
-        metadata = preview_metadata(pending_slide.image_path)
         if preview_attempt_id is None:
             gcs_key = self._storage.upload_preview(
                 job_id,
@@ -799,9 +798,6 @@ class VisualQAFixVerifyStep:
             occurred_at=self._now_iso(),
             gcs_preview_key=gcs_key,
             current_fills=dict(slide.current_fills),
-            preview_width=metadata.width,
-            preview_height=metadata.height,
-            preview_byte_size=metadata.byte_size,
         )
         return gcs_key
 

--- a/apps/pptx-worker/features/visualization/storage/gcs_client.py
+++ b/apps/pptx-worker/features/visualization/storage/gcs_client.py
@@ -1,6 +1,7 @@
 """GCS 직접 R/W 클라이언트 — IAM 인증, signed URL 미경유"""
 
 import logging
+import os
 import re
 import shutil
 import tempfile
@@ -14,7 +15,8 @@ from pptx_worker.metrics import WORKER_TMP_ROOT, get_worker_metrics, safe_direct
 
 logger = logging.getLogger(__name__)
 
-BUCKET_NAME = "folioo-visualizations"
+DEFAULT_BUCKET_NAME = "folioo-visualizations"
+BUCKET_NAME = os.getenv("GCS_BUCKET", DEFAULT_BUCKET_NAME)
 
 _PPTX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 
@@ -193,9 +195,10 @@ class GcsClient:
     signed URL 발급은 메인 백엔드 전담이므로 이 클라이언트에는 없다.
     """
 
-    def __init__(self, bucket_name: str = BUCKET_NAME) -> None:
+    def __init__(self, bucket_name: str | None = None) -> None:
         self._storage_client = storage.Client()
-        self._bucket = self._storage_client.bucket(bucket_name)
+        resolved_bucket_name = bucket_name or os.getenv("GCS_BUCKET", DEFAULT_BUCKET_NAME)
+        self._bucket = self._storage_client.bucket(resolved_bucket_name)
 
     # ------------------------------------------------------------------
     # 템플릿 (읽기 전용)

--- a/apps/pptx-worker/toolchain/scripts/clean.py
+++ b/apps/pptx-worker/toolchain/scripts/clean.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""PPTX 작업 디렉터리에서 presentation.xml 이 참조하지 않는 slide part 를 정리한다."""
+
+from __future__ import annotations
+
+import argparse
+import posixpath
+import sys
+from pathlib import Path
+
+import defusedxml.minidom
+
+PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+CONTENT_TYPES_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
+SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("unpacked_dir", type=Path)
+    return parser.parse_args()
+
+
+def _relationship_id(node) -> str:
+    return node.getAttributeNS(RELATIONSHIPS_NS, "id") or node.getAttribute("r:id")
+
+
+def _slide_filename_from_target(target: str) -> str | None:
+    if not target:
+        return None
+    if target.startswith("/"):
+        normalized = posixpath.normpath(target.lstrip("/"))
+    else:
+        normalized = posixpath.normpath(posixpath.join("ppt", target))
+    prefix = "ppt/slides/"
+    if not normalized.startswith(prefix):
+        return None
+    return normalized.removeprefix(prefix)
+
+
+def _write_xml(path: Path, dom) -> None:
+    path.write_bytes(dom.toxml(encoding="UTF-8"))
+
+
+def _clean_presentation_relationships(root: Path) -> set[str]:
+    presentation_path = root / "ppt" / "presentation.xml"
+    rels_path = root / "ppt" / "_rels" / "presentation.xml.rels"
+    presentation_dom = defusedxml.minidom.parse(str(presentation_path))
+    rels_dom = defusedxml.minidom.parse(str(rels_path))
+
+    slide_id_lists = presentation_dom.getElementsByTagNameNS(PRESENTATION_NS, "sldIdLst")
+    if not slide_id_lists:
+        raise ValueError("presentation.xml missing p:sldIdLst")
+    active_rids = {
+        _relationship_id(node)
+        for node in slide_id_lists[0].childNodes
+        if node.nodeType == node.ELEMENT_NODE and node.localName == "sldId"
+    }
+
+    active_slide_filenames: set[str] = set()
+    removed_slide_filenames: set[str] = set()
+    relationships = [
+        node
+        for node in rels_dom.getElementsByTagNameNS(PACKAGE_RELATIONSHIPS_NS, "Relationship")
+        if node.getAttribute("Type") == SLIDE_RELATIONSHIP_TYPE
+    ]
+    for rel in relationships:
+        slide_filename = _slide_filename_from_target(rel.getAttribute("Target"))
+        if not slide_filename:
+            continue
+        if rel.getAttribute("Id") in active_rids:
+            active_slide_filenames.add(slide_filename)
+            continue
+        removed_slide_filenames.add(slide_filename)
+        rel.parentNode.removeChild(rel)
+        rel.unlink()
+
+    _write_xml(rels_path, rels_dom)
+    return removed_slide_filenames - active_slide_filenames
+
+
+def _remove_orphan_slide_files(root: Path, slide_filenames: set[str]) -> None:
+    for slide_filename in slide_filenames:
+        for path in (
+            root / "ppt" / "slides" / slide_filename,
+            root / "ppt" / "slides" / "_rels" / f"{slide_filename}.rels",
+        ):
+            path.unlink(missing_ok=True)
+
+
+def _clean_content_types(root: Path, removed_slide_filenames: set[str]) -> None:
+    content_types_path = root / "[Content_Types].xml"
+    if not content_types_path.is_file() or not removed_slide_filenames:
+        return
+    removed_part_names = {f"/ppt/slides/{filename}" for filename in removed_slide_filenames}
+    dom = defusedxml.minidom.parse(str(content_types_path))
+    overrides = [
+        node
+        for node in dom.getElementsByTagNameNS(CONTENT_TYPES_NS, "Override")
+        if node.getAttribute("PartName") in removed_part_names
+    ]
+    for override in overrides:
+        override.parentNode.removeChild(override)
+        override.unlink()
+    _write_xml(content_types_path, dom)
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.unpacked_dir.is_dir():
+        print(f"unpacked dir not found: {args.unpacked_dir}", file=sys.stderr)
+        return 2
+
+    removed = _clean_presentation_relationships(args.unpacked_dir)
+    _remove_orphan_slide_files(args.unpacked_dir, removed)
+    _clean_content_types(args.unpacked_dir, removed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/pptx-worker/toolchain/scripts/office/pack.py
+++ b/apps/pptx-worker/toolchain/scripts/office/pack.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""작업 디렉터리를 PPTX zip 패키지로 다시 묶는다."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("unpacked_dir", type=Path)
+    parser.add_argument("output_pptx", type=Path)
+    parser.add_argument("--original", type=Path, default=None)
+    parser.add_argument("--validate", default="true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.unpacked_dir.is_dir():
+        print(f"unpacked dir not found: {args.unpacked_dir}", file=sys.stderr)
+        return 2
+
+    args.output_pptx.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(args.output_pptx, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(args.unpacked_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(args.unpacked_dir).as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/pptx-worker/toolchain/scripts/office/unpack.py
+++ b/apps/pptx-worker/toolchain/scripts/office/unpack.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""PPTX 패키지를 작업 디렉터리에 안전하게 해제한다."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_pptx", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    return parser.parse_args()
+
+
+def _safe_members(archive: zipfile.ZipFile) -> list[zipfile.ZipInfo]:
+    members: list[zipfile.ZipInfo] = []
+    for member in archive.infolist():
+        target = Path(member.filename)
+        if target.is_absolute() or ".." in target.parts:
+            raise ValueError(f"unsafe zip member path: {member.filename}")
+        members.append(member)
+    return members
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.input_pptx.is_file():
+        print(f"input pptx not found: {args.input_pptx}", file=sys.stderr)
+        return 2
+
+    if args.output_dir.exists():
+        shutil.rmtree(args.output_dir)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(args.input_pptx) as archive:
+        archive.extractall(args.output_dir, members=_safe_members(archive))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/pptx-worker/toolchain/scripts/office/validate.py
+++ b/apps/pptx-worker/toolchain/scripts/office/validate.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""PPTX 작업 디렉터리의 핵심 패키지 구조를 검증한다."""
+
+from __future__ import annotations
+
+import argparse
+import posixpath
+import sys
+from pathlib import Path
+
+import defusedxml.minidom
+
+PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("unpacked_dir", type=Path)
+    parser.add_argument("--original", type=Path, default=None)
+    parser.add_argument("--auto-repair", action="store_true")
+    return parser.parse_args()
+
+
+def _relationship_id(node) -> str:
+    return node.getAttributeNS(RELATIONSHIPS_NS, "id") or node.getAttribute("r:id")
+
+
+def _slide_filename_from_target(target: str) -> str | None:
+    if not target:
+        return None
+    if target.startswith("/"):
+        normalized = posixpath.normpath(target.lstrip("/"))
+    else:
+        normalized = posixpath.normpath(posixpath.join("ppt", target))
+    prefix = "ppt/slides/"
+    if not normalized.startswith(prefix):
+        return None
+    return normalized.removeprefix(prefix)
+
+
+def _parse_xml(path: Path, errors: list[str]):
+    try:
+        return defusedxml.minidom.parse(str(path))
+    except Exception as exc:
+        errors.append(f"xml parse failed: {path}: {exc}")
+        return None
+
+
+def _validate(root: Path) -> list[str]:
+    errors: list[str] = []
+    required = [
+        root / "[Content_Types].xml",
+        root / "_rels" / ".rels",
+        root / "ppt" / "presentation.xml",
+        root / "ppt" / "_rels" / "presentation.xml.rels",
+    ]
+    for path in required:
+        if not path.is_file():
+            errors.append(f"missing required part: {path.relative_to(root)}")
+    if errors:
+        return errors
+
+    presentation_dom = _parse_xml(root / "ppt" / "presentation.xml", errors)
+    rels_dom = _parse_xml(root / "ppt" / "_rels" / "presentation.xml.rels", errors)
+    _parse_xml(root / "[Content_Types].xml", errors)
+    _parse_xml(root / "_rels" / ".rels", errors)
+    if errors or presentation_dom is None or rels_dom is None:
+        return errors
+
+    slide_id_lists = presentation_dom.getElementsByTagNameNS(PRESENTATION_NS, "sldIdLst")
+    if not slide_id_lists:
+        errors.append("presentation.xml missing p:sldIdLst")
+        return errors
+
+    slide_rids = [
+        _relationship_id(node)
+        for node in slide_id_lists[0].childNodes
+        if node.nodeType == node.ELEMENT_NODE and node.localName == "sldId"
+    ]
+    if not slide_rids:
+        errors.append("presentation.xml has no slides")
+        return errors
+
+    slide_targets: dict[str, str] = {}
+    for rel in rels_dom.getElementsByTagNameNS(PACKAGE_RELATIONSHIPS_NS, "Relationship"):
+        if rel.getAttribute("Type") != SLIDE_RELATIONSHIP_TYPE:
+            continue
+        slide_filename = _slide_filename_from_target(rel.getAttribute("Target"))
+        if slide_filename:
+            slide_targets[rel.getAttribute("Id")] = slide_filename
+
+    for rid in slide_rids:
+        slide_filename = slide_targets.get(rid)
+        if not slide_filename:
+            errors.append(f"missing slide relationship for {rid}")
+            continue
+        slide_path = root / "ppt" / "slides" / slide_filename
+        if not slide_path.is_file():
+            errors.append(f"missing slide part: ppt/slides/{slide_filename}")
+            continue
+        _parse_xml(slide_path, errors)
+
+    return errors
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.unpacked_dir.is_dir():
+        print(f"unpacked dir not found: {args.unpacked_dir}", file=sys.stderr)
+        return 2
+
+    errors = _validate(args.unpacked_dir)
+    if not errors:
+        return 0
+
+    for error in errors:
+        print(error, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/pptx-worker/cloud-run-service.yaml
+++ b/deploy/pptx-worker/cloud-run-service.yaml
@@ -1,48 +1,70 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: folioo-pptx-worker
-  labels:
-    app.kubernetes.io/name: folioo-pptx-worker
-    app.kubernetes.io/component: pptx-worker
-  annotations:
-    run.googleapis.com/ingress: all
-    run.googleapis.com/invoker-iam-disabled: "false"
+    name: folioo-pptx-worker
+    labels:
+        app: folioo-pptx-worker
+        component: pptx-worker
+    annotations:
+        run.googleapis.com/ingress: all
+        run.googleapis.com/invoker-iam-disabled: "false"
 spec:
-  template:
-    metadata:
-      annotations:
-        autoscaling.knative.dev/minScale: "0"
-        autoscaling.knative.dev/maxScale: "20"
-        run.googleapis.com/execution-environment: gen2
-        run.googleapis.com/cpu-throttling: "false"
-        folioo.ai/memory-budget: "4096Mi"
-        folioo.ai/tmp-required: "1Gi"
-    spec:
-      serviceAccountName: ${WORKER_RUNTIME_SERVICE_ACCOUNT}
-      containerConcurrency: 1
-      timeoutSeconds: 1800
-      containers:
-        - image: ${IMAGE_URI}
-          ports:
-            - name: http1
-              containerPort: 8080
-          env:
-            - name: PORT
-              value: "8080"
-            - name: JAVA_TOOL_OPTIONS
-              value: "-Xmx512m"
-            - name: PPTX_WORKER_RECYCLE_AFTER
-              value: "20"
-          resources:
-            limits:
-              cpu: "2"
-              memory: "5120Mi"
-          volumeMounts:
-            - name: pptx-worker-tmp
-              mountPath: /tmp
-      volumes:
-        - name: pptx-worker-tmp
-          emptyDir:
-            medium: Memory
-            sizeLimit: "1Gi"
+    template:
+        metadata:
+            annotations:
+                autoscaling.knative.dev/minScale: "0"
+                autoscaling.knative.dev/maxScale: "20"
+                run.googleapis.com/execution-environment: gen2
+                run.googleapis.com/cpu-throttling: "false"
+                folioo.ai/memory-budget: "4096Mi"
+                folioo.ai/tmp-required: "1Gi"
+        spec:
+            serviceAccountName: ${WORKER_RUNTIME_SERVICE_ACCOUNT}
+            containerConcurrency: 1
+            timeoutSeconds: 1800
+            containers:
+                - image: ${IMAGE_URI}
+                  ports:
+                      - name: http1
+                        containerPort: 8080
+                  env:
+                      - name: JAVA_TOOL_OPTIONS
+                        value: "-Xmx512m"
+                      - name: PPTX_WORKER_RECYCLE_AFTER
+                        value: "20"
+                      - name: ANTHROPIC_PPTX_SKILL_DIR
+                        value: "/app/apps/pptx-worker/toolchain"
+                      - name: GCS_BUCKET
+                        value: "${GCS_BUCKET}"
+                      - name: MAIN_BACKEND_URL
+                        value: "${MAIN_BACKEND_URL}"
+                      - name: MAIN_BACKEND_TIMEOUT
+                        value: "30"
+                      - name: OPENROUTER_BASE_URL
+                        value: "https://openrouter.ai/api/v1"
+                      - name: LLM_MODEL_NAME
+                        value: "${LLM_MODEL_NAME}"
+                      - name: FILE_PROCESSOR_MODEL_NAME
+                        value: "${FILE_PROCESSOR_MODEL_NAME}"
+                      - name: MAIN_BACKEND_API_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${MAIN_BACKEND_API_KEY_SECRET}
+                                key: latest
+                      - name: OPENROUTER_API_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${OPENROUTER_API_KEY_SECRET}
+                                key: latest
+                  resources:
+                      limits:
+                          cpu: "2"
+                          memory: "5120Mi"
+                  volumeMounts:
+                      - name: pptx-worker-tmp
+                        mountPath: /tmp
+            volumes:
+                - name: pptx-worker-tmp
+                  emptyDir:
+                      medium: Memory
+                      sizeLimit: "1Gi"

--- a/docs/architecture/pptx-main-backend-handoff.md
+++ b/docs/architecture/pptx-main-backend-handoff.md
@@ -1,0 +1,148 @@
+# PPTX 시각화 Main Backend Handoff
+
+이 문서는 `folioo-ai` 저장소의 PPTX Worker 구현이 실제 사용자 기능으로 연결되기 위해
+Main Backend와 운영 환경에서 닫아야 하는 계약을 정리한다. 상세 설계의 기준 문서는
+`docs/architecture/pptx-gen-plan-v6.md`이고, Cloud Run/GCP 절차는
+`deploy/pptx-worker/README.md`를 따른다.
+
+## Worker Repo 상태
+
+- Worker 런타임: `apps/pptx-worker/pptx_worker/main.py`
+- Cloud Tasks push handler: `POST /tasks/visualizations/generate`,
+  `POST /tasks/visualizations/regenerate`
+- Main callback/context client: `features.visualization.main_client.VisualizationMainClient`
+- GCS 직접 R/W: `features.visualization.storage.gcs_client.GcsClient`
+- 기본 PPTX toolchain: 이미지 내부 `/app/apps/pptx-worker/toolchain`
+- 배포 설정: `deploy/pptx-worker/cloud-run-service.yaml`
+
+Worker는 DB, 사용자 인증, SSE, signed URL, 재생성 quota, Cloud Tasks enqueue를 담당하지 않는다.
+이 항목은 Main Backend가 단독 소유한다.
+
+## Main Backend 필수 Public API
+
+프론트는 반드시 Main Backend만 호출한다.
+
+| API | Main 책임 |
+| --- | --- |
+| `POST /api/visualizations` | 사용자/포트폴리오 소유권 검증, `visualization_jobs` 생성, `viz.generate` enqueue, `202 { jobId }` 반환 |
+| `GET /api/visualizations/{jobId}/stream` | snapshot 즉시 발신, 이후 worker callback을 SSE로 fan-out |
+| `GET /api/visualizations/{jobId}/slides` | slide 목록, status, signed preview URL, remaining regeneration count 반환 |
+| `POST /api/visualizations/{jobId}/slides/{slideId}/regenerate` | Job row lock, slide CAS, quota 차감, `viz.regenerate` enqueue |
+| `POST /api/visualizations/{jobId}/slides/{slideId}/retry` | error slide를 quota 차감 없이 `generating`으로 전이 후 retry enqueue |
+| `GET /api/visualizations/{jobId}/export/status` | `compute_can_export()` 결과 반환 |
+| `POST /api/visualizations/{jobId}/export` | `compute_can_export()` 재검증 후 PPTX/PDF signed URL 발급 |
+
+`can_export`는 저장 컬럼이 아니라 파생 상태다. `job.status == completed`이고 모든 slide가
+`completed`이며 `gcs_pptx_key`가 있을 때만 export 가능하다.
+
+## Main Backend 필수 Internal API
+
+Worker는 `MAIN_BACKEND_URL`과 `MAIN_BACKEND_API_KEY` 기반 `X-API-Key`로 아래 API를 호출한다.
+응답 envelope은 `{ isSuccess, result }` 형식을 지원해야 한다.
+
+| API | Main 책임 |
+| --- | --- |
+| `GET /internal/visualizations/{jobId}` | `portfolioText`, `templateId`, `slidePlan`, status 등 job context 반환 |
+| `GET /internal/visualizations/{jobId}/slides/{slideId}` | `currentFills`, `sourceSlideId`, `slideFilename`, status 등 slide context 반환 |
+| `POST /internal/visualizations/{jobId}/slide-plan` | slide rows 일괄 생성/조회, `slides[]`에 `id`를 포함해 반환 |
+| `POST /internal/visualizations/{jobId}/slides/{slideId}/events` | slide 상태/preview/fills 갱신, signed preview URL 발급, SSE emit |
+| `POST /internal/visualizations/{jobId}/events` | pipeline stage 또는 all_completed 처리, export 상태 재계산, SSE emit |
+
+최상위 API 필드는 camelCase, `slidePlan`/`currentFills` JSONB 내부 필드는 snake_case를 유지한다.
+Worker는 callback마다 이벤트 단위 idempotency key를 보내므로 Main은 해당 key로 중복 처리를 막아야 한다.
+
+## Cloud Tasks 계약
+
+Main Backend는 큐에만 enqueue하고 Worker를 직접 호출하지 않는다.
+
+Generate payload:
+
+```json
+{
+  "messageType": "viz.generate",
+  "jobId": "job-id",
+  "portfolioId": "portfolio-id",
+  "userId": "user-id",
+  "templateId": "template-id",
+  "callbackBaseUrl": "https://main-backend.example",
+  "idempotencyKey": "uuid",
+  "schemaVersion": 1
+}
+```
+
+Regenerate/retry payload:
+
+```json
+{
+  "messageType": "viz.regenerate",
+  "jobId": "job-id",
+  "slideId": "slide-id",
+  "userRequest": "제목을 조금 키워줘",
+  "isRetry": false,
+  "callbackBaseUrl": "https://main-backend.example",
+  "idempotencyKey": "uuid",
+  "schemaVersion": 1
+}
+```
+
+`isRetry=true`이면 `userRequest`는 생략한다. Cloud Tasks HTTP target은
+`oidc_token.service_account_email = WORKER_OIDC_SERVICE_ACCOUNT`,
+`audience = WORKER_URL`로 설정한다.
+
+## 상태 전이와 CAS
+
+- Generate 시작: `visualization_jobs.status=pending` 생성 후 enqueue.
+- Worker generate 처리 가능 상태: `pending`, `generating`.
+- Slide plan callback: slide rows를 `pending`으로 생성하고 `slide_plan_ready` SSE.
+- `slide_content_ready`: slide `generating`.
+- `slide_preview_ready`: slide `completed`, signed preview URL SSE.
+- `slide_preview_error`: Phase 1이면 slide `error`, Phase 2 재생성이면 이전 completed로 rollback.
+- `all_completed`: 성공 slide가 있으면 job `completed` 또는 `partial_error`, 전체 실패면 `error`.
+- Regenerate 시작: `completed -> regenerating` CAS와 quota 차감을 같은 transaction에서 처리.
+- Retry 시작: `error -> generating` CAS, quota 미차감.
+- `slide_regenerated`: slide `completed`, current fills/preview 갱신, 남은 error가 없으면 job 재평가.
+
+Stuck recovery cron은 `pending/generating/regenerating`이 일정 시간 이상 멈춘 경우 error 또는 rollback으로
+정리하고, 사용자 재생성 quota 보상까지 담당한다.
+
+## GCS와 Signed URL
+
+Worker가 직접 쓰는 canonical key:
+
+- `jobs/{jobId}/current.pptx`
+- `jobs/{jobId}/current.pdf`
+- `jobs/{jobId}/previews/slide-{slideOrder:02d}.jpg`
+
+Worker가 재생성 중 임시로 쓰는 staging key:
+
+- `jobs/{jobId}/attempts/{attemptId}/current.pptx`
+- `jobs/{jobId}/attempts/{attemptId}/current.pdf`
+- `jobs/{jobId}/attempts/{attemptId}/previews/slide-{slideOrder:02d}.jpg`
+- `jobs/{jobId}/attempts/{attemptId}/rollback/*`
+
+Main은 signed URL 발급 전용이다. Worker의 attempt key는 프론트 signed URL 대상이 아니며,
+Main은 callback payload의 canonical key만 사용자에게 노출한다.
+
+재생성 경로에서 Worker는 attempt 업로드 후 `slide_regenerated` callback이 2xx로 성공해야
+canonical promote를 수행한다. 따라서 Main은 `slide_regenerated` 처리와 SSE emit을 idempotent하게
+구성하고, promote 실패 재시도 중에는 이전 preview 유지 또는 pending 표시 정책을 정해야 한다.
+부분 promote/rollback 실패를 감지할 운영 알림과 수동 복구 절차도 필요하다.
+
+## 배포 전 확인
+
+- `uv run ruff check .`
+- `uv run pytest tests/test_features/test_visualization tests/test_pptx_worker -q`
+- Docker image build 및 `apps/pptx-worker/scripts/verify_runtime_image.sh`
+- `deploy/pptx-worker/README.md`의 Cloud Run/IAM/GCS/Secret verification
+- 최소 1개 템플릿의 `template.pptx`, `meta.json`, `thumbnail.jpg` GCS 업로드
+- Main Backend에서 실제 Cloud Tasks push smoke: generate 1건, regenerate 1건, export 1건
+
+## 운영 설정 요약
+
+- Secret Manager: `MAIN_BACKEND_API_KEY`, `OPENROUTER_API_KEY`
+- Worker env: `MAIN_BACKEND_URL`, `MAIN_BACKEND_TIMEOUT`, `OPENROUTER_BASE_URL`,
+  `LLM_MODEL_NAME`, `FILE_PROCESSOR_MODEL_NAME`, `ANTHROPIC_PPTX_SKILL_DIR`
+- Worker SA: Secret Accessor, bucket-level Storage Object Admin
+- Cloud Tasks SA: Cloud Run Invoker
+- Main Backend runtime principal: Cloud Tasks Enqueuer, Cloud Tasks SA actAs
+- GCS lifecycle: `jobs/*/attempts/**`와 `rollback/**` 보존 기간 설정

--- a/features/visualization/main_client.py
+++ b/features/visualization/main_client.py
@@ -40,7 +40,7 @@ _SLIDE_FIELD_MAP: dict[str, str] = {
     "updatedAt": "updated_at",
 }
 
-_BASE = "/api/internal/visualizations"
+_BASE = "/internal/visualizations"
 
 
 def _map_top_level(data: dict[str, Any], field_map: dict[str, str]) -> dict[str, Any]:
@@ -175,9 +175,6 @@ class VisualizationMainClient(BaseClient):
         schema_version: int = 1,
         current_fills: dict[str, Any] | None = None,
         gcs_preview_key: str | None = None,
-        preview_width: int | None = None,
-        preview_height: int | None = None,
-        preview_byte_size: int | None = None,
         message: str | None = None,
         retryable: bool | None = None,
     ) -> None:
@@ -185,7 +182,6 @@ class VisualizationMainClient(BaseClient):
 
         event: slide_content_ready | slide_content_error |
                slide_preview_ready | slide_preview_error | slide_regenerated
-        preview_width / preview_height / preview_byte_size: preview_ready 메타데이터
         current_fills 내부 키는 snake_case 그대로 전송 (§11.0.3).
         """
         body: dict[str, Any] = {
@@ -199,12 +195,6 @@ class VisualizationMainClient(BaseClient):
             body["currentFills"] = current_fills
         if gcs_preview_key is not None:
             body["gcsPreviewKey"] = gcs_preview_key
-        if preview_width is not None:
-            body["width"] = preview_width
-        if preview_height is not None:
-            body["height"] = preview_height
-        if preview_byte_size is not None:
-            body["byteSize"] = preview_byte_size
         if message is not None:
             body["message"] = message
         if retryable is not None:

--- a/specs/phase-1/02-main-backend-callback-client.md
+++ b/specs/phase-1/02-main-backend-callback-client.md
@@ -1,7 +1,7 @@
 # 메인 백엔드 콜백/컨텍스트 클라이언트 (워커 측)
 
 ## Purpose
-시각화 워커가 메인 백엔드의 `/api/internal/visualizations/...` 엔드포인트로 진행 이벤트를 콜백하고 작업 컨텍스트(포트폴리오 텍스트·slide_plan·slide 상태)를 조회하는 HTTP 클라이언트를 구축한다.
+시각화 워커가 메인 백엔드의 `/internal/visualizations/...` 엔드포인트로 진행 이벤트를 콜백하고 작업 컨텍스트(포트폴리오 텍스트·slide_plan·slide 상태)를 조회하는 HTTP 클라이언트를 구축한다.
 
 ## Requirements
 - slide-plan 제출, slide 레벨 이벤트(`slide_content_ready`/`slide_preview_ready`/`slide_*_error`/`slide_regenerated`), job 레벨 이벤트(`pipeline_stage_changed`/`all_completed`) 콜백 메서드를 제공한다.

--- a/specs/phase-1/06-visual-qa-fix-verify.md
+++ b/specs/phase-1/06-visual-qa-fix-verify.md
@@ -5,8 +5,10 @@
 
 ## Requirements
 - `VisualQA.check_slide()` 가 프리뷰 이미지를 LLM 비전에 넘겨 오버플로우/잘림·요소 겹침·미교체 안내문구·가독성·레이아웃 균형을 검사하고 통과/이슈 목록을 반환한다.
-- 통과 슬라이드는 GCS `jobs/{job_id}/previews/slide-{slide_order:02d}.jpg` 에 PUT 후 `slide_preview_ready`(gcsPreviewKey·width·height·byteSize) 콜백을 슬라이드별로 즉시 발신한다.
+- QA 대상 슬라이드는 제한된 동시성으로 병렬 검사하고, 한 슬라이드의 QA 예외나 preview 업로드 실패가 전체 Cloud Tasks retry 로 번지지 않도록 슬라이드별 `slide_preview_error` 로 격리한다.
+- 통과 슬라이드는 GCS `jobs/{job_id}/previews/slide-{slide_order:02d}.jpg` 에 PUT 후 `slide_preview_ready`(gcsPreviewKey) 콜백을 슬라이드별로 즉시 발신한다.
 - 이슈 슬라이드는 fix-and-verify 큐에 적재해 LLM 지시대로 XML 일괄 수정→pack 1회·PDF 변환 1회(배치)→영향 슬라이드만 재 QA 한다.
+- 자동 수정 후 산출물은 `pack -> validate -> repair -> repack -> validate` 경로를 통과해야 하며, 검증 실패 산출물은 업로드/ready 콜백으로 진행하지 않는다.
 - 최대 2회 시도에도 실패하면 해당 슬라이드 `slide_preview_error`(message·retryable) 콜백을 보낸다.
 - 렌더→시각 QA 검증을 최소 한 번 거치기 전에는 완료를 선언하지 않고, 재검증은 영향 받은 슬라이드만 검사한다(Anthropic 스킬 원칙).
 
@@ -16,5 +18,7 @@
 ## Verification
 - 오버플로우/미교체 안내문구가 있는 슬라이드 이미지를 QA 가 이슈로 분류하고, 정상 이미지는 통과로 분류하는지 검증한다.
 - 통과 슬라이드가 canonical key 로 GCS 업로드되고 `slide_preview_ready` 콜백이 슬라이드별로 발신되는지 확인한다.
+- 느린 QA/예외 슬라이드가 있어도 빠르게 통과한 슬라이드가 먼저 `slide_preview_ready` 로 공개되고, 예외는 해당 슬라이드 error 로 수렴하는지 확인한다.
+- preview 업로드 실패가 해당 슬라이드 `slide_preview_error` 로 격리되고 다른 통과 슬라이드는 계속 ready 처리되는지 확인한다.
 - 이슈 슬라이드가 1차 수정 후 통과하면 업로드되고, 2회 실패 시 `slide_preview_error`(retryable 포함) 콜백이 발신되는지 검증한다.
-- fix-and-verify 가 영향 슬라이드만 재 QA 하고 pack/PDF 변환을 배치 1회로 묶는지 확인한다.
+- fix-and-verify 가 영향 슬라이드만 재 QA 하고 pack/PDF 변환을 배치 1회로 묶으며, 수정 후 구조 검증 실패가 success 경로를 차단하는지 확인한다.

--- a/specs/phase-1/10-cloud-run-deployment-config.md
+++ b/specs/phase-1/10-cloud-run-deployment-config.md
@@ -6,6 +6,8 @@
 ## Requirements
 - Cloud Run Service 사양을 메모리 4GB(컨테이너 limit 5GB)·2 vCPU·`/tmp` 1GB+·`concurrency=1`·min-instances 0(민감 시 1)·max-instances 20(Cloud Tasks `maxConcurrentDispatches` 와 일치)·요청 timeout 1800s(=`dispatchDeadline` 상한)로 구성하고, `JAVA_TOOL_OPTIONS=-Xmx512m` 로 LibreOffice 내부 JVM 힙을 캡한다.
 - Dockerfile 을 ubuntu 22.04 기반으로 libreoffice-impress/core + poppler-utils + fonts-noto-cjk(+extra) + python + defusedxml/lxml/pillow/google-cloud-storage/google-cloud-tasks/fastapi/uvicorn/markitdown 으로 구성한다(§8.3.5).
+- 이미지 내부에 PPTX toolchain 호환 스크립트를 번들하고 `ANTHROPIC_PPTX_SKILL_DIR=/app/apps/pptx-worker/toolchain` 로 고정해 런타임 외부 볼륨 없이 `unpack`/`clean`/`pack`/`validate` 가 동작하게 한다.
+- Cloud Run 서비스에는 `MAIN_BACKEND_URL`, `MAIN_BACKEND_TIMEOUT`, `OPENROUTER_BASE_URL`, `LLM_MODEL_NAME`, `FILE_PROCESSOR_MODEL_NAME` 과 Secret Manager 기반 `MAIN_BACKEND_API_KEY`, `OPENROUTER_API_KEY` 를 연결한다.
 - 서비스를 require-authentication 으로 두고 OIDC 토큰 검증을 Cloud Run IAM 에 위임하며, Cloud Tasks 서비스 계정에 `roles/run.invoker` 를 부여한다.
 - 인터뷰 챗 서비스와 빌드/배포 단위를 분리하되 `common/` 패키지는 직접 import 로 재사용한다(ADR-0001).
 
@@ -14,5 +16,6 @@ Cloud Run Service 는 HTTP 엔드포인트를 노출해 Cloud Tasks push URL 로
 
 ## Verification
 - 배포된 서비스가 메모리 4GB/limit 5GB·2 vCPU·`/tmp` 1GB+·`concurrency=1`·timeout 1800s·max-instances 20 사양으로 기동하고, `JAVA_TOOL_OPTIONS=-Xmx512m` 가 적용되는지 확인한다.
-- 빌드된 이미지에서 soffice·pdftoppm·Noto CJK 폰트·markitdown·필수 Python 패키지가 모두 설치되어 있고 `common/` 패키지를 import 할 수 있는지 검증한다.
+- 빌드된 이미지에서 soffice·pdftoppm·Noto CJK 폰트·markitdown·필수 Python 패키지와 번들 PPTX toolchain 이 모두 설치되어 있고 `common/` 패키지를 import 할 수 있는지 검증한다.
+- Cloud Run YAML 에 필수 env/Secret Manager 참조가 빠짐없이 있으며 Secret 값이 저장소에 노출되지 않는지 확인한다.
 - `roles/run.invoker` 를 가진 Cloud Tasks SA 의 OIDC 호출만 통과하고, 권한 없는 호출은 IAM 단계에서 거부되는지 확인한다.

--- a/tasks/phase-1-pptx-worker/04-soffice-render.md
+++ b/tasks/phase-1-pptx-worker/04-soffice-render.md
@@ -22,7 +22,7 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 컨테이너에 libreoffice-impress·poppler-utils·Noto CJK 폰트 설치 (이미지 빌드는 1.10)
+- [x] 컨테이너에 libreoffice-impress·poppler-utils·Noto CJK 폰트 설치 (이미지 빌드는 1.10)
 
 ## 구현 체크리스트
 

--- a/tasks/phase-1-pptx-worker/06-visual-qa-fix-verify.md
+++ b/tasks/phase-1-pptx-worker/06-visual-qa-fix-verify.md
@@ -32,7 +32,7 @@ sprint: ""
 ## 구현 체크리스트
 
 - [x] `VisualQA.check_slide()` — 오버플로우/잘림·겹침·미교체 안내문구·가독성·균형 검사 → 통과/이슈 목록
-- [x] 통과 슬라이드: canonical key `previews/slide-{slide_order:02d}.jpg` PUT 후 `slide_preview_ready`(gcsPreviewKey·width·height·byteSize) 즉시 발신
+- [x] 통과 슬라이드: canonical key `previews/slide-{slide_order:02d}.jpg` PUT 후 `slide_preview_ready`(gcsPreviewKey) 즉시 발신
 - [x] 이슈 슬라이드: fix-and-verify 큐 → XML 일괄 수정 → pack 1회·PDF 변환 1회(배치) → 영향 슬라이드만 재 QA
 - [x] 최대 2회 실패 시 `slide_preview_error`(message·retryable) 발신
 - [x] 완료 전 최소 1회 시각 QA 강제, 재검증은 영향 슬라이드만

--- a/tasks/phase-1-pptx-worker/12-gcs-client.md
+++ b/tasks/phase-1-pptx-worker/12-gcs-client.md
@@ -32,10 +32,11 @@ sprint: ""
 
 ## Definition of Done
 
-- [x] GCS PUT/GET 이 IAM 직접 인증으로 동작 (signed URL 미경유)
+- [x] GCS PUT/GET 클라이언트가 IAM/ADC 기반 `google-cloud-storage` API 를 사용함 (signed URL 미경유)
 - [x] preview/PPTX/PDF 경로가 canonical 규칙 준수 확인
 - [x] 작업 종료 후 로컬 임시 파일 정리 확인
 
 ## 리스크 / 메모
 
 - 워커는 signed URL 발급 안 함 — `gcsPreviewKey` 만 콜백, 메인이 signed 변환 (1.06 참조).
+- 실제 GCP 버킷 IAM 권한 부여와 impersonation smoke 는 운영 단계에서 수행한다(1.21).

--- a/tasks/phase-1-pptx-worker/21-cloud-run-secrets-gcs-iam-operational-checks.md
+++ b/tasks/phase-1-pptx-worker/21-cloud-run-secrets-gcs-iam-operational-checks.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/10-cloud-run-deployment-config.md"
 depends_on: ["1.04", "1.10", "1.11", "1.12"]
 blocks: ["1.26"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-05-31"
 owner: ""
 sprint: ""
 ---
@@ -25,32 +26,40 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #236 본문과 기존 Cloud Run 배포 YAML 확인
-- [ ] Secret 값 없이 필요한 Secret 이름/용도만 문서화할 수 있는지 확인
-- [ ] 실제 GCP 프로젝트/서비스 계정 세부값을 공개 문서에 적지 않는 원칙 확인
+- [x] GitHub Issue #236 본문과 기존 Cloud Run 배포 YAML 확인
+- [x] Secret 값 없이 필요한 Secret 이름/용도만 문서화할 수 있는지 확인
+- [x] 실제 GCP 프로젝트/서비스 계정 세부값을 공개 문서에 적지 않는 원칙 확인
 
 ## 구현 체크리스트
 
-- [ ] Worker -> Main callback/context 조회에 필요한 `MAIN_BACKEND_URL`, `MAIN_BACKEND_API_KEY` 연결 방식 확인
-- [ ] LLM 호출에 필요한 `OPENROUTER_API_KEY` 및 모델 관련 환경변수 연결 방식 확인
-- [ ] PPTX toolchain 실행 경로에 필요한 환경변수 확인
-- [ ] Cloud Run YAML 또는 배포 문서에 Secret Manager 참조 방식 명시
-- [ ] Cloud Run require-authentication 모델 유지 여부 확인
-- [ ] Cloud Tasks 서비스 계정의 `roles/run.invoker` 부여 절차 명시
-- [ ] Worker 서비스 계정의 GCS 직접 R/W 권한 범위 명시
-- [ ] `folioo-visualizations` bucket template 읽기 권한 확인 절차 정리
-- [ ] `jobs/{job_id}/...` 산출물 쓰기/읽기 권한 확인 절차 정리
-- [ ] `tasks/phase-1-pptx-worker/12-gcs-client.md`의 IAM 확인 체크 상태를 실제 검증 결과와 맞춤
-- [ ] `soffice`, `pdftoppm`, Noto CJK 폰트, markitdown 설치 확인 절차의 보장 위치를 문서화
-- [ ] `tasks/phase-1-pptx-worker/04-soffice-render.md`의 컨테이너 도구 설치 확인 체크를 실제 검증 방법과 연결
+- [x] Worker -> Main callback/context 조회에 필요한 `MAIN_BACKEND_URL`, `MAIN_BACKEND_API_KEY` 연결 방식 확인
+- [x] LLM 호출에 필요한 `OPENROUTER_API_KEY` 및 모델 관련 환경변수 연결 방식 확인
+- [x] PPTX toolchain 실행 경로에 필요한 환경변수 확인
+- [x] Cloud Run YAML 또는 배포 문서에 Secret Manager 참조 방식 명시
+- [x] Cloud Run require-authentication 모델 유지 여부 확인
+- [x] Cloud Tasks 서비스 계정의 `roles/run.invoker` 부여 절차 명시
+- [x] Worker 서비스 계정의 GCS 직접 R/W 권한 범위 명시
+- [x] `folioo-visualizations` bucket template 읽기 권한 확인 절차 정리
+- [x] `jobs/{job_id}/...` 산출물 쓰기/읽기 권한 확인 절차 정리
+- [x] `tasks/phase-1-pptx-worker/12-gcs-client.md`의 IAM 확인 체크 상태를 실제 검증 결과와 맞춤
+- [x] `soffice`, `pdftoppm`, Noto CJK 폰트, markitdown 설치 확인 절차의 보장 위치를 문서화
+- [x] `tasks/phase-1-pptx-worker/04-soffice-render.md`의 컨테이너 도구 설치 확인 체크를 실제 검증 방법과 연결
 
 ## Definition of Done
 
-- [ ] Cloud Run 설정 또는 배포 문서에 필수 env/secret/IAM/GCS 항목 누락 없음
-- [ ] Secret 값이 저장소에 노출되지 않음
-- [ ] Cloud Tasks OIDC 인증과 Worker -> Main `X-API-Key` 인증 책임이 구분되어 있음
-- [ ] GCS IAM 직접 R/W 검증 절차가 task 문서와 일치
-- [ ] 컨테이너 도구 설치 확인 체크박스가 실제 검증 방법과 연결됨
+- [x] Cloud Run 설정 또는 배포 문서에 필수 env/secret/IAM/GCS 항목 누락 없음
+- [x] Secret 값이 저장소에 노출되지 않음
+- [x] Cloud Tasks OIDC 인증과 Worker -> Main `X-API-Key` 인증 책임이 구분되어 있음
+- [x] GCS IAM 직접 R/W 검증 절차가 task 문서와 일치
+- [x] 컨테이너 도구 설치 확인 체크박스가 실제 검증 방법과 연결됨
+
+## 구현 결과
+
+- `deploy/pptx-worker/cloud-run-service.yaml` 에 `MAIN_BACKEND_URL`, `MAIN_BACKEND_TIMEOUT`, `OPENROUTER_BASE_URL`, `LLM_MODEL_NAME`, `FILE_PROCESSOR_MODEL_NAME`, `MAIN_BACKEND_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_PPTX_SKILL_DIR` 를 명시했다.
+- `MAIN_BACKEND_API_KEY` 와 `OPENROUTER_API_KEY` 는 Secret Manager `secretKeyRef` 로만 연결하고 실제 값은 저장소에 두지 않는다.
+- PPTX toolchain 은 이미지 내부 `/app/apps/pptx-worker/toolchain` 으로 번들해 별도 Secret/volume 없이 runtime smoke 에서 `ensure_available()` 로 확인한다.
+- `deploy/pptx-worker/README.md` 에 API 활성화, Artifact Registry, 서비스 계정, Secret, GCS bucket/IAM, Cloud Tasks queue, Cloud Run deploy, 콘솔 체크리스트를 정리했다.
+- 실제 GCP IAM 부여와 버킷 객체 업로드는 운영자가 수행해야 하므로 `tasks/phase-1-pptx-worker/12-gcs-client.md` 의 IAM 확인 체크는 완료로 바꾸지 않았다.
 
 ## 리스크 / 메모
 

--- a/tasks/phase-1-pptx-worker/23-visual-qa-parallel-isolated-validated.md
+++ b/tasks/phase-1-pptx-worker/23-visual-qa-parallel-isolated-validated.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/06-visual-qa-fix-verify.md"
 depends_on: ["1.05", "1.06", "1.07"]
 blocks: ["1.25", "1.26"]
 estimate: "L"
-status: "todo"
+status: "done"
+completed_at: "2026-05-31"
 owner: ""
 sprint: ""
 ---
@@ -24,33 +25,40 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #238 본문과 현재 QA 순차 실행/예외 전파 경로 확인
-- [ ] LLM vision 호출 rate limit과 Cloud Run 리소스 기준의 동시성 제한 필요 여부 확인
-- [ ] 기존 `slide_preview_ready`, `slide_preview_error`, `all_completed` callback 계약 확인
+- [x] GitHub Issue #238 본문과 현재 QA 순차 실행/예외 전파 경로 확인
+- [x] LLM vision 호출 rate limit과 Cloud Run 리소스 기준의 동시성 제한 필요 여부 확인
+- [x] 기존 `slide_preview_ready`, `slide_preview_error`, `all_completed` callback 계약 확인
 
 ## 구현 체크리스트
 
-- [ ] 현재 `check_slide` 호출과 fix loop 실행 순서 분석
-- [ ] QA 대상 슬라이드를 병렬로 검사하도록 구조 개선
-- [ ] 필요한 경우 LLM rate limit과 Cloud Run 리소스를 고려한 동시성 제한 지점 추가
-- [ ] 빠르게 통과한 슬라이드는 다른 슬라이드 QA 완료를 기다리지 않고 preview 업로드/콜백 가능하게 정리
-- [ ] `check_slide` 예외를 해당 슬라이드의 QA 실패 결과로 변환
-- [ ] preview 업로드 실패를 해당 슬라이드의 `slide_preview_error`로 수렴
-- [ ] QA/fix 중 특정 슬라이드 실패가 전체 Cloud Tasks retry를 유발하지 않도록 정리
-- [ ] 전체 실패와 일부 실패의 job summary/errorCode가 기존 callback 계약과 맞는지 검증
-- [ ] 자동 수정 후 pack 산출물이 구조 검증을 통과하는지 확인하는 경로 추가/보강
-- [ ] 검증 실패 시 성공 preview/upload/callback으로 진행하지 않도록 차단
-- [ ] 영향 받은 슬라이드만 재 QA한다는 정책 유지
-- [ ] 최대 2회 실패 시 retryable 값과 message가 일관되게 전달되는지 확인
+- [x] 현재 `check_slide` 호출과 fix loop 실행 순서 분석
+- [x] QA 대상 슬라이드를 병렬로 검사하도록 구조 개선
+- [x] 필요한 경우 LLM rate limit과 Cloud Run 리소스를 고려한 동시성 제한 지점 추가
+- [x] 빠르게 통과한 슬라이드는 다른 슬라이드 QA 완료를 기다리지 않고 preview 업로드/콜백 가능하게 정리
+- [x] `check_slide` 예외를 해당 슬라이드의 QA 실패 결과로 변환
+- [x] preview 업로드 실패를 해당 슬라이드의 `slide_preview_error`로 수렴
+- [x] QA/fix 중 특정 슬라이드 실패가 전체 Cloud Tasks retry를 유발하지 않도록 정리
+- [x] 전체 실패와 일부 실패의 job summary/errorCode가 기존 callback 계약과 맞는지 검증
+- [x] 자동 수정 후 pack 산출물이 구조 검증을 통과하는지 확인하는 경로 추가/보강
+- [x] 검증 실패 시 성공 preview/upload/callback으로 진행하지 않도록 차단
+- [x] 영향 받은 슬라이드만 재 QA한다는 정책 유지
+- [x] 최대 2회 실패 시 retryable 값과 message가 일관되게 전달되는지 확인
 
 ## Definition of Done
 
-- [ ] QA 병렬 처리 테스트 통과
-- [ ] 슬라이드별 QA 예외 격리 테스트 통과
-- [ ] preview 업로드 실패의 슬라이드별 error 콜백 테스트 통과
-- [ ] fix-and-verify 후 구조 검증 실패 차단 테스트 통과
-- [ ] 전체 성공/일부 실패/전체 실패 summary가 기존 계약과 일치
-- [ ] `uv run ruff check .` 및 관련 worker visualization 테스트 통과
+- [x] QA 병렬 처리 테스트 통과
+- [x] 슬라이드별 QA 예외 격리 테스트 통과
+- [x] preview 업로드 실패의 슬라이드별 error 콜백 테스트 통과
+- [x] fix-and-verify 후 구조 검증 실패 차단 테스트 통과
+- [x] 전체 성공/일부 실패/전체 실패 summary가 기존 계약과 일치
+- [x] `uv run ruff check .` 및 관련 worker visualization 테스트 통과
+
+## 구현 결과
+
+- `VisualQAFixVerifyStep` 는 `max_qa_concurrency` 로 제한된 병렬 QA 를 수행하고 `asyncio.as_completed()` 결과 순서대로 통과 슬라이드 preview 를 공개한다.
+- `check_slide` 예외, preview 업로드 실패, fix 실패, 검증 실패, 렌더 실패는 해당 슬라이드 `slide_preview_error` 로 수렴한다.
+- 자동 수정 후에는 pack/validate/repair/repack/validate 경로를 통과한 산출물만 `fixed_pptx` 로 승격한다.
+- 관련 증거: GitHub PR #243, `tests/test_pptx_worker/test_visualization/test_qa.py`.
 
 ## 리스크 / 메모
 

--- a/tasks/phase-1-pptx-worker/26-spec-task-main-backend-handoff.md
+++ b/tasks/phase-1-pptx-worker/26-spec-task-main-backend-handoff.md
@@ -6,7 +6,8 @@ spec: "specs/phase-1/10-cloud-run-deployment-config.md"
 depends_on: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25"]
 blocks: []
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-05-31"
 owner: ""
 sprint: ""
 ---
@@ -27,45 +28,53 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] GitHub Issue #241 본문 확인
-- [ ] `docs/architecture/pptx-gen-plan-v6.md`, `specs/phase-1/*.md`, `tasks/phase-1-pptx-worker/*.md` 최신 상태 확인
-- [ ] Main Backend 저장소 또는 담당자에게 넘길 수 있는 공개 가능한 범위 확인
+- [x] GitHub Issue #241 본문 확인
+- [x] `docs/architecture/pptx-gen-plan-v6.md`, `specs/phase-1/*.md`, `tasks/phase-1-pptx-worker/*.md` 최신 상태 확인
+- [x] Main Backend 저장소 또는 담당자에게 넘길 수 있는 공개 가능한 범위 확인
 
 ## 구현 체크리스트
 
-- [ ] `tasks/phase-1-pptx-worker/*.md`의 체크박스와 실제 검증 결과 비교
-- [ ] GCS IAM 직접 R/W 권한 확인 항목의 완료/미완료 상태 정리
-- [ ] 컨테이너 도구 설치 확인 항목의 완료/미완료 상태 정리
-- [ ] template registration GCS publish 또는 운영 배포 단계가 DoD에 빠져 있는지 확인
-- [ ] spec과 task가 서로 다른 processable status를 설명하는 부분을 실제 코드/설계 기준으로 정리
-- [ ] 1.20 런타임 부팅/패키징 차단 해소 결과를 관련 task/spec에 반영
-- [ ] 1.21 배포 환경/Secret/GCS/IAM 정리 결과를 관련 task/spec에 반영
-- [ ] 1.22 Cloud Tasks in-flight 멱등 처리 결과를 관련 task/spec에 반영
-- [ ] 1.23 Visual QA 안정화 결과를 관련 task/spec에 반영
-- [ ] 1.24 생성 품질 계약 보강 결과를 관련 task/spec에 반영
-- [ ] 1.25 재생성 산출물 정합성 계약 결과를 관련 task/spec에 반영
-- [ ] Main Backend의 사용자 인증/소유권 검증 범위 정리
-- [ ] Main Backend의 Postgres DB 상태 전이 및 CAS 책임 정리
-- [ ] Main Backend의 Cloud Tasks enqueue 및 idempotency key 생성 책임 정리
-- [ ] Main Backend의 SSE snapshot/event fan-out 책임 정리
-- [ ] Main Backend의 signed URL 발급 책임 정리
-- [ ] Main Backend의 재생성 quota 차감/보상 책임 정리
-- [ ] stuck recovery cron 또는 복구 정책 정리
-- [ ] export 가능 여부 재검증 책임 정리
-- [ ] Worker callback 수신 API와 `X-API-Key` 검증 책임 정리
-- [ ] 배포 전 필수 smoke/test 명령 목록 정리
-- [ ] Secret 값 없이 필요한 Secret 이름/용도만 문서화
-- [ ] IAM 권한 확인 절차를 공개 가능한 수준으로 문서화
-- [ ] Worker-only 범위와 외부 저장소 범위를 분리해서 기록
-- [ ] 완료되지 않은 항목은 완료로 표시하지 않도록 전체 문서 재점검
+- [x] `tasks/phase-1-pptx-worker/*.md`의 체크박스와 실제 검증 결과 비교
+- [x] GCS IAM 직접 R/W 권한 확인 항목의 완료/미완료 상태 정리
+- [x] 컨테이너 도구 설치 확인 항목의 완료/미완료 상태 정리
+- [x] template registration GCS publish 또는 운영 배포 단계가 DoD에 빠져 있는지 확인
+- [x] spec과 task가 서로 다른 processable status를 설명하는 부분을 실제 코드/설계 기준으로 정리
+- [x] 1.20 런타임 부팅/패키징 차단 해소 결과를 관련 task/spec에 반영
+- [x] 1.21 배포 환경/Secret/GCS/IAM 정리 결과를 관련 task/spec에 반영
+- [x] 1.22 Cloud Tasks in-flight 멱등 처리 결과를 관련 task/spec에 반영
+- [x] 1.23 Visual QA 안정화 결과를 관련 task/spec에 반영
+- [x] 1.24 생성 품질 계약 보강 결과를 관련 task/spec에 반영
+- [x] 1.25 재생성 산출물 정합성 계약 결과를 관련 task/spec에 반영
+- [x] Main Backend의 사용자 인증/소유권 검증 범위 정리
+- [x] Main Backend의 Postgres DB 상태 전이 및 CAS 책임 정리
+- [x] Main Backend의 Cloud Tasks enqueue 및 idempotency key 생성 책임 정리
+- [x] Main Backend의 SSE snapshot/event fan-out 책임 정리
+- [x] Main Backend의 signed URL 발급 책임 정리
+- [x] Main Backend의 재생성 quota 차감/보상 책임 정리
+- [x] stuck recovery cron 또는 복구 정책 정리
+- [x] export 가능 여부 재검증 책임 정리
+- [x] Worker callback 수신 API와 `X-API-Key` 검증 책임 정리
+- [x] 배포 전 필수 smoke/test 명령 목록 정리
+- [x] Secret 값 없이 필요한 Secret 이름/용도만 문서화
+- [x] IAM 권한 확인 절차를 공개 가능한 수준으로 문서화
+- [x] Worker-only 범위와 외부 저장소 범위를 분리해서 기록
+- [x] 완료되지 않은 항목은 완료로 표시하지 않도록 전체 문서 재점검
 
 ## Definition of Done
 
-- [ ] spec/task 문서의 완료 표시가 실제 검증 상태와 일치
-- [ ] Worker repo 내 후속 수정 task(1.20~1.25)의 결과가 문서에 반영됨
-- [ ] Main Backend 후속 구현 목록이 독립적으로 실행 가능한 수준으로 정리됨
-- [ ] Secret 값, 서비스 계정 세부값 등 민감 정보가 문서에 노출되지 않음
-- [ ] 최종 문서만 보고 운영 전 남은 작업을 구분할 수 있음
+- [x] spec/task 문서의 완료 표시가 실제 검증 상태와 일치
+- [x] Worker repo 내 후속 수정 task(1.20~1.25)의 결과가 문서에 반영됨
+- [x] Main Backend 후속 구현 목록이 독립적으로 실행 가능한 수준으로 정리됨
+- [x] Secret 값, 서비스 계정 세부값 등 민감 정보가 문서에 노출되지 않음
+- [x] 최종 문서만 보고 운영 전 남은 작업을 구분할 수 있음
+
+## 구현 결과
+
+- Main Backend handoff 문서: [`docs/architecture/pptx-main-backend-handoff.md`](../../docs/architecture/pptx-main-backend-handoff.md)
+- GCP/운영 설정 문서: [`deploy/pptx-worker/README.md`](../../deploy/pptx-worker/README.md)
+- `specs/phase-1/06-visual-qa-fix-verify.md`, `specs/phase-1/10-cloud-run-deployment-config.md` 에 1.21/1.23 결과를 반영했다.
+- Task 1.23 은 PR #243 병합과 테스트 증거를 기준으로 완료 처리했다.
+- Task 1.12 의 실제 GCS IAM 확인 항목은 운영자가 GCP에서 검증해야 하므로 미완료 상태로 유지했다.
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_main_client.py
+++ b/tests/test_features/test_visualization/test_main_client.py
@@ -205,7 +205,7 @@ class TestSubmitSlidePlan:
             )
         mock_rwr.assert_called_once_with(
             "POST",
-            "/api/internal/visualizations/job-abc/slide-plan",
+            "/internal/visualizations/job-abc/slide-plan",
             json={
                 "totalSlides": 2,
                 "templateId": "blue",
@@ -320,7 +320,7 @@ class TestSendSlideEvent:
             )
         mock_rwr.assert_called_once_with(
             "POST",
-            "/api/internal/visualizations/job-1/slides/slide-2/events",
+            "/internal/visualizations/job-1/slides/slide-2/events",
             json={
                 "event": "slide_content_ready",
                 "slideOrder": 2,
@@ -332,7 +332,7 @@ class TestSendSlideEvent:
         )
 
     @pytest.mark.asyncio
-    async def test_slide_preview_ready_includes_gcs_key(self):
+    async def test_slide_preview_ready_includes_only_contract_fields(self):
         client = make_client()
         with patch.object(
             client, "_request_with_retry", new_callable=AsyncMock, return_value=None
@@ -345,16 +345,13 @@ class TestSendSlideEvent:
                 idempotency_key="idem-3",
                 occurred_at="2026-05-25T10:01:00Z",
                 gcs_preview_key="jobs/job-1/previews/slide-02.jpg",
-                preview_width=1280,
-                preview_height=720,
-                preview_byte_size=123456,
             )
         body = mock_rwr.call_args.kwargs["json"]
         assert body["event"] == "slide_preview_ready"
         assert body["gcsPreviewKey"] == "jobs/job-1/previews/slide-02.jpg"
-        assert body["width"] == 1280
-        assert body["height"] == 720
-        assert body["byteSize"] == 123456
+        assert "width" not in body
+        assert "height" not in body
+        assert "byteSize" not in body
         assert "currentFills" not in body
 
     @pytest.mark.asyncio
@@ -427,7 +424,7 @@ class TestSendJobEvent:
             )
         mock_rwr.assert_called_once_with(
             "POST",
-            "/api/internal/visualizations/job-1/events",
+            "/internal/visualizations/job-1/events",
             json={
                 "event": "pipeline_stage_changed",
                 "idempotencyKey": "idem-5",
@@ -658,7 +655,7 @@ class TestGetJobContext:
             return_value={"isSuccess": True, "result": {}},
         ) as mock_rwr:
             await client.get_job_context("job-xyz")
-        mock_rwr.assert_called_once_with("GET", "/api/internal/visualizations/job-xyz")
+        mock_rwr.assert_called_once_with("GET", "/internal/visualizations/job-xyz")
 
     @pytest.mark.asyncio
     async def test_non_dict_result_raises(self):
@@ -734,7 +731,7 @@ class TestGetSlideContext:
         ) as mock_rwr:
             await client.get_slide_context("job-xyz", "slide-abc")
         mock_rwr.assert_called_once_with(
-            "GET", "/api/internal/visualizations/job-xyz/slides/slide-abc"
+            "GET", "/internal/visualizations/job-xyz/slides/slide-abc"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
+++ b/tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
@@ -13,6 +13,7 @@ CLOUDBUILD_YAML = ROOT / "deploy" / "pptx-worker" / "cloudbuild.yaml"
 README = ROOT / "deploy" / "pptx-worker" / "README.md"
 VERIFY_SCRIPT = ROOT / "apps" / "pptx-worker" / "scripts" / "verify_runtime_image.sh"
 PYPROJECT = ROOT / "pyproject.toml"
+TOOLCHAIN_DIR = ROOT / "apps" / "pptx-worker" / "toolchain"
 
 
 def _load_service() -> dict:
@@ -48,16 +49,39 @@ def test_cloud_run_service_caps_java_heap_and_tmp_volume() -> None:
     """JVM 힙 캡과 /tmp 1Gi 메모리 볼륨을 서비스 사양에 고정한다."""
     service = _load_service()
     container = _container(service)
-    env = {item["name"]: item["value"] for item in container["env"]}
+    env = {item["name"]: item.get("value") for item in container["env"]}
     volume_mounts = {item["name"]: item["mountPath"] for item in container["volumeMounts"]}
     volumes = {item["name"]: item for item in service["spec"]["template"]["spec"]["volumes"]}
 
     assert env["JAVA_TOOL_OPTIONS"] == "-Xmx512m"
     assert env["PPTX_WORKER_RECYCLE_AFTER"] == "20"
+    assert env["ANTHROPIC_PPTX_SKILL_DIR"] == "/app/apps/pptx-worker/toolchain"
+    assert "PORT" not in env
     assert volume_mounts["pptx-worker-tmp"] == "/tmp"
     assert volumes["pptx-worker-tmp"]["emptyDir"] == {
         "medium": "Memory",
         "sizeLimit": "1Gi",
+    }
+
+
+def test_cloud_run_service_declares_required_runtime_env_and_secrets() -> None:
+    """워커 런타임 필수 env/Secret Manager 참조가 서비스 사양에 포함된다."""
+    service = _load_service()
+    env = {item["name"]: item for item in _container(service)["env"]}
+
+    assert env["GCS_BUCKET"]["value"] == "${GCS_BUCKET}"
+    assert env["MAIN_BACKEND_URL"]["value"] == "${MAIN_BACKEND_URL}"
+    assert env["MAIN_BACKEND_TIMEOUT"]["value"] == "30"
+    assert env["OPENROUTER_BASE_URL"]["value"] == "https://openrouter.ai/api/v1"
+    assert env["LLM_MODEL_NAME"]["value"] == "${LLM_MODEL_NAME}"
+    assert env["FILE_PROCESSOR_MODEL_NAME"]["value"] == "${FILE_PROCESSOR_MODEL_NAME}"
+    assert env["MAIN_BACKEND_API_KEY"]["valueFrom"]["secretKeyRef"] == {
+        "name": "${MAIN_BACKEND_API_KEY_SECRET}",
+        "key": "latest",
+    }
+    assert env["OPENROUTER_API_KEY"]["valueFrom"]["secretKeyRef"] == {
+        "name": "${OPENROUTER_API_KEY_SECRET}",
+        "key": "latest",
     }
 
 
@@ -79,6 +103,7 @@ def test_cloud_run_service_caps_java_heap_and_tmp_volume() -> None:
         "UV_PYTHON_INSTALL_DIR=/opt/uv-python",
         "PYTHONPATH=/app:/app/apps/pptx-worker",
         "JAVA_TOOL_OPTIONS=-Xmx512m",
+        "ANTHROPIC_PPTX_SKILL_DIR=/app/apps/pptx-worker/toolchain",
         "useradd --create-home --uid 10001 appuser",
         "chown -R appuser:appuser /app /opt/uv-python",
         "USER appuser",
@@ -101,6 +126,20 @@ def test_worker_dockerfile_excludes_unrelated_application_units() -> None:
 
     assert "COPY app/ ./app/" not in dockerfile
     assert "COPY features/ ./features/" not in dockerfile
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "scripts/office/unpack.py",
+        "scripts/office/pack.py",
+        "scripts/office/validate.py",
+        "scripts/clean.py",
+    ],
+)
+def test_worker_image_contains_bundled_pptx_toolchain_scripts(relative_path: str) -> None:
+    """Cloud Run 런타임이 외부 볼륨 없이 PPTX toolchain 을 찾을 수 있다."""
+    assert (TOOLCHAIN_DIR / relative_path).is_file()
 
 
 @pytest.mark.parametrize(
@@ -213,8 +252,8 @@ def test_deployment_readme_documents_required_auth_checks(expected: str) -> None
 @pytest.mark.parametrize(
     "expected",
     [
-        "이미지 build smoke는 `ANTHROPIC_PPTX_SKILL_DIR` 미설정 시 빠르게 실패하는 경로만",
-        "Secret/volume/env로 runtime에 주입",
+        "이미지 build smoke는 번들된 `ANTHROPIC_PPTX_SKILL_DIR`",
+        "`/app/apps/pptx-worker/toolchain`",
         "`PptxToolchain.ensure_available()`까지",
     ],
 )

--- a/tests/test_pptx_worker/test_visualization/test_qa.py
+++ b/tests/test_pptx_worker/test_visualization/test_qa.py
@@ -426,9 +426,9 @@ async def test_passed_slides_upload_preview_and_send_ready_callbacks(tmp_path: P
     assert all(event["event"] == "slide_preview_ready" for event in context.main_client.events)
     first_event = next(event for event in context.main_client.events if event["slide_order"] == 1)
     assert first_event["gcs_preview_key"] == "jobs/job-1/previews/slide-01.jpg"
-    assert first_event["preview_width"] == 801
-    assert first_event["preview_height"] == 451
-    assert first_event["preview_byte_size"] == len(context.slides[0].image_path.read_bytes())
+    assert "preview_width" not in first_event
+    assert "preview_height" not in first_event
+    assert "preview_byte_size" not in first_event
     assert context.toolchain.pack_calls == []
 
 

--- a/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
+++ b/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
@@ -117,6 +117,14 @@ def mock_gcs(tmp_path):
         client = GcsClient(bucket_name="folioo-visualizations")
         yield client, mock_bucket, mock_blob, tmp_path
 
+def test_gcs_client_uses_gcs_bucket_env_when_bucket_name_is_not_explicit(monkeypatch):
+    """기본 생성자는 Cloud Run GCS_BUCKET env 값을 버킷 이름으로 사용한다."""
+    monkeypatch.setenv("GCS_BUCKET", "folioo-498017-visualizations")
+    with patch("features.visualization.storage.gcs_client.storage.Client") as mock_client_cls:
+        GcsClient()
+
+    mock_client_cls.return_value.bucket.assert_called_once_with("folioo-498017-visualizations")
+
 
 def _use_distinct_blob_mocks(mock_bucket):
     """bucket.blob(key) 호출마다 key 별 Blob mock 을 반환한다."""


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 이슈 없음

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 메인 백엔드 dev 라우트 기준으로 PPTX 워커 internal callback 경로를 `/internal/visualizations`로 정리했습니다.
- `slide_preview_ready` 이벤트에서 서버 DTO에 없는 `width`, `height`, `byteSize` 전송을 제거했습니다.
- Cloud Run 환경에서 GCS 버킷을 `GCS_BUCKET` env로 주입받도록 수정했습니다.
- PPTX toolchain 스크립트를 워커 이미지에 번들하고 Cloud Run 런타임 env/Secret 설정을 보강했습니다.
- Main Backend 연동 책임과 운영 체크 항목을 handoff 문서와 phase task에 정리했습니다.

## 📸 스크린샷

- CLI 테스트 결과: `196 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- `deploy/pptx-worker/README.md`와 `templates/origin/`은 이번 PR에 포함하지 않았습니다.
- 실제 dev 환경의 GCS signed URL 실패는 Main Backend 런타임의 `GCS_BUCKET_NAME`, `GCS_SERVICE_ACCOUNT_KEY` 설정이 필요합니다.
- `docs/architecture/pptx-gen-plan-v6.md`에는 기존 `/api/internal` 계약 표현이 남아 있어, 큰 설계서 갱신은 별도 문서 정리 작업으로 분리하는 것을 권장합니다.

### 검증

```bash
uv run pytest tests/test_features/test_visualization/test_main_client.py \
  tests/test_pptx_worker/test_visualization/test_qa.py \
  tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py \
  tests/test_pptx_worker/test_deployment/test_cloud_run_deployment.py
```

```text
196 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * PPTX 문서 구조 검증 및 자동 복구 기능 추가
  * 슬라이드 미리보기 병렬 처리로 성능 개선
  * 슬라이드 단위 격리된 오류 처리 추가

* **개선 사항**
  * 미리보기 콜백 데이터 단순화로 효율성 향상
  * 프레젠테이션 구조 정리 및 검증 로직 강화

* **문서**
  * 배포 및 운영 가이드 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->