### PR TITLE
[PPTX] 워커 생성 태스크 ID 숫자 계약 적용

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -56,8 +56,8 @@ class GenerateVisualizationTask:
 
     message_type: Literal["viz.generate"]
     job_id: str
-    portfolio_id: str
-    user_id: str
+    portfolio_id: int
+    user_id: int
     template_id: str
     idempotency_key: str
     callback_base_url: str

--- a/apps/pptx-worker/pptx_worker/api/tasks.py
+++ b/apps/pptx-worker/pptx_worker/api/tasks.py
@@ -97,8 +97,8 @@ class GeneratePushPayload(_BasePushPayload):
     """초기 생성 push payload."""
 
     message_type: Literal["viz.generate"] = Field(alias="messageType")
-    portfolio_id: str = Field(alias="portfolioId", min_length=1)
-    user_id: str = Field(alias="userId", min_length=1)
+    portfolio_id: int = Field(alias="portfolioId", ge=1)
+    user_id: int = Field(alias="userId", ge=1)
     template_id: str = Field(alias="templateId", min_length=1)
 
     def to_task(self) -> GenerateVisualizationTask:

--- a/docs/architecture/pptx-main-backend-handoff.md
+++ b/docs/architecture/pptx-main-backend-handoff.md
@@ -61,8 +61,8 @@ Generate payload:
 {
   "messageType": "viz.generate",
   "jobId": "job-id",
-  "portfolioId": "portfolio-id",
-  "userId": "user-id",
+  "portfolioId": 84,
+  "userId": 69,
   "templateId": "template-id",
   "callbackBaseUrl": "https://main-backend.example",
   "idempotencyKey": "uuid",

--- a/tests/test_pptx_worker/test_app/test_tasks.py
+++ b/tests/test_pptx_worker/test_app/test_tasks.py
@@ -138,8 +138,8 @@ def generate_payload(**overrides: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "messageType": "viz.generate",
         "jobId": "job-1",
-        "portfolioId": "portfolio-1",
-        "userId": "user-1",
+        "portfolioId": 84,
+        "userId": 69,
         "templateId": "blue",
         "idempotencyKey": "idem-generate",
         "callbackBaseUrl": "http://main.local",
@@ -176,7 +176,8 @@ def test_generate_push_parses_payload_delegates_and_returns_200(worker_client):
     task = service.generate_calls[0]
     assert task.message_type == "viz.generate"
     assert task.job_id == "job-1"
-    assert task.portfolio_id == "portfolio-1"
+    assert task.portfolio_id == 84
+    assert task.user_id == 69
     assert task.template_id == "blue"
     assert task.callback_base_url == "http://main.local"
     assert main_client.closed is True

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -889,8 +889,8 @@ def _task() -> GenerateVisualizationTask:
     return GenerateVisualizationTask(
         message_type="viz.generate",
         job_id="job-1",
-        portfolio_id="portfolio-1",
-        user_id="user-1",
+        portfolio_id=84,
+        user_id=69,
         template_id="blue",
         idempotency_key="task-key",
         callback_base_url="http://main.local",


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 이슈 없음

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- Cloud Tasks generate payload의 `portfolioId`, `userId`를 문자열이 아닌 숫자 ID로 받도록 워커 스키마를 수정했습니다.
- `GenerateVisualizationTask` 내부 타입도 숫자 ID 계약에 맞췄습니다.
- generate task API 테스트와 generation pipeline fixture를 숫자 ID 기준으로 갱신했습니다.
- Main Backend handoff 문서의 generate payload 예시를 숫자 ID 기준으로 정리했습니다.

## 📸 스크린샷

- CLI 테스트 결과: `33 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 실제 dev Cloud Tasks enqueue에서 `portfolioId`, `userId`가 number로 전달되어 워커 FastAPI 검증이 422를 반환하던 문제를 맞춘 변경입니다.
- `messageType`, `jobId`, `templateId`, `callbackBaseUrl`, `idempotencyKey`, `schemaVersion` 계약은 기존과 동일합니다.

### 검증

```bash
uv run pytest tests/test_pptx_worker/test_app/test_tasks.py \
  tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
```

```text
33 passed
```
