### PR TITLE
[PPTX] 템플릿 v2 JSON 계약 기반 추가

### DIFF
--- a/deploy/pptx-worker/README.md
+++ b/deploy/pptx-worker/README.md
@@ -34,10 +34,10 @@ docker run --rm \
   apps/pptx-worker/scripts/verify_runtime_image.sh
 ```
 
-이미지 build smoke는 `ANTHROPIC_PPTX_SKILL_DIR` 미설정 시 빠르게 실패하는 경로만
-검증한다. 실제 skill directory를 Secret/volume/env로 runtime에 주입하는 배포에서는
-동일한 스크립트를 runtime 환경에서 실행해 `PptxToolchain.ensure_available()`까지
-확인한다.
+이미지 build smoke는 번들된 `ANTHROPIC_PPTX_SKILL_DIR` 을 기준으로
+`/app/apps/pptx-worker/toolchain` 경로를 검증하고, 환경변수 미설정 시 빠르게 실패하는
+경로도 함께 확인한다. 동일한 스크립트를 runtime 환경에서 실행해
+`PptxToolchain.ensure_available()`까지 확인한다.
 
 ## Deploy
 

--- a/docs/architecture/ooxml-editing.md
+++ b/docs/architecture/ooxml-editing.md
@@ -217,65 +217,65 @@ class SlideEditor:
     def _replace_text(self, sp_element, fill):
         """
         텍스트 교체 - 원본 서식 완전 보존
-        
+
         - 첫 <a:r>의 <a:rPr>을 기준 서식으로 보존
         - 기존 <a:p> 모두 제거 후 새로 생성
         - 여러 항목은 개별 <a:p>로 분리
         - 공백 보존: xml:space="preserve"
         """
-        
+
         txBody = sp_element.getElementsByTagNameNS(
             self.DRAWINGML_NS, "txBody"
         )[0]
-        
+
         # 기준 서식 추출
         base_pPr = self._extract_paragraph_props(txBody)
         base_rPr = self._extract_run_props(txBody)
-        
+
         # 폰트 크기 오버라이드
         if fill.get("font_size_override"):
             size_val = str(int(fill["font_size_override"] * 100))
             base_rPr.setAttribute("sz", size_val)
-        
+
         # 제목이면 굵게
         if fill.get("is_title"):
             base_rPr.setAttribute("b", "1")
-        
+
         # 기존 <a:p> 모두 제거
         existing_paragraphs = txBody.getElementsByTagNameNS(
             self.DRAWINGML_NS, "p"
         )
         for p in list(existing_paragraphs):
             txBody.removeChild(p)
-        
+
         # 새 텍스트를 줄바꿈 기준으로 <a:p> 분리
         lines = fill["text"].split("\n")
         doc = sp_element.ownerDocument
-        
+
         for line in lines:
             new_p = doc.createElementNS(self.DRAWINGML_NS, "a:p")
-            
+
             if base_pPr:
                 new_p.appendChild(base_pPr.cloneNode(deep=True))
-            
+
             new_r = doc.createElementNS(self.DRAWINGML_NS, "a:r")
             new_r.appendChild(base_rPr.cloneNode(deep=True))
-            
+
             new_t = doc.createElementNS(self.DRAWINGML_NS, "a:t")
             if line.startswith(" ") or line.endswith(" ") or "\t" in line:
                 new_t.setAttribute("xml:space", "preserve")
-            
+
             new_t.appendChild(doc.createTextNode(line))
             new_r.appendChild(new_t)
             new_p.appendChild(new_r)
             txBody.appendChild(new_p)
-    
+
     def _extract_paragraph_props(self, txBody):
         pPr_list = txBody.getElementsByTagNameNS(self.DRAWINGML_NS, "pPr")
         if pPr_list:
             return pPr_list[0].cloneNode(deep=True)
         return None
-    
+
     def _extract_run_props(self, txBody):
         rPr_list = txBody.getElementsByTagNameNS(self.DRAWINGML_NS, "rPr")
         if rPr_list:

--- a/docs/architecture/qa-and-guardrails.md
+++ b/docs/architecture/qa-and-guardrails.md
@@ -68,10 +68,10 @@ Anthropic PPTX 스킬의 핵심 프로세스 중 하나. 자동으로 결과물�
 
 ```python
 class VisualQA:
-    
-    def check_slide(self, slide_image_path: str, 
+
+    def check_slide(self, slide_image_path: str,
                     expected_content: dict) -> dict:
-        
+
         prompt = f"""이 PPT 슬라이드 이미지를 검사해줘.
 
 체크리스트:
@@ -87,7 +87,7 @@ class VisualQA:
 - 채워진 주요 텍스트: {expected_content.get('texts_summary', 'N/A')[:200]}...
 
 이슈가 있으면 목록으로, 없으면 "통과"로 답해줘."""
-        
+
         result = call_llm_with_image(prompt, slide_image_path)
         return parse_qa_result(result)
 ```

--- a/features/visualization/templates/__init__.py
+++ b/features/visualization/templates/__init__.py
@@ -11,7 +11,20 @@ from .builder import (
     build_template_metadata,
 )
 from .categories import CategoryDefinition, CategorySchema, load_category_schema
+from .compiler_v2 import TemplateV2CompileResult, compile_template_v2
 from .pptx import SlideText, count_pptx_slides, extract_slide_texts
+from .v2 import (
+    SCHEMA_VERSION_V2,
+    TemplateV2Extraction,
+    TemplateV2Payloads,
+    build_template_v2_payloads,
+    canonical_json_text,
+    json_file_normalized_equal,
+    json_normalized_equal,
+    normalize_json,
+    read_json_payload,
+    write_json_payload,
+)
 from .validation import TemplateValidationResult, validate_template_directory
 
 __all__ = [
@@ -21,14 +34,26 @@ __all__ = [
     "CategorySchema",
     "LlmSlideDraftGenerator",
     "MarkitdownSlideTextExtractor",
+    "SCHEMA_VERSION_V2",
     "SlideDraft",
     "SlideDraftInput",
     "SlideText",
     "TemplateValidationResult",
+    "TemplateV2CompileResult",
+    "TemplateV2Extraction",
+    "TemplateV2Payloads",
     "TextExtractionResult",
+    "build_template_v2_payloads",
     "build_template_metadata",
+    "canonical_json_text",
+    "compile_template_v2",
     "count_pptx_slides",
     "extract_slide_texts",
+    "json_file_normalized_equal",
+    "json_normalized_equal",
     "load_category_schema",
+    "normalize_json",
+    "read_json_payload",
     "validate_template_directory",
+    "write_json_payload",
 ]

--- a/features/visualization/templates/compiler_v2.py
+++ b/features/visualization/templates/compiler_v2.py
@@ -1,0 +1,93 @@
+"""PPTX 템플릿 v2 metadata/reference 컴파일러 기반."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .v2 import (
+    META_JSON_NAME,
+    REFERENCE_JSON_NAME,
+    TEMPLATE_PPTX_NAME,
+    TemplateV2Extraction,
+    build_template_v2_payloads,
+    json_file_normalized_equal,
+    write_json_payload,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateV2CompileResult:
+    """v2 compiler 실행 결과."""
+
+    meta_path: Path
+    reference_path: Path
+    checked: bool
+    updated: bool
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        """오류가 없으면 True."""
+        return not self.errors
+
+
+def compile_template_v2(
+    template_dir: Path | str,
+    *,
+    output_dir: Path | str | None = None,
+    check: bool = False,
+    strict: bool = False,
+    extraction: TemplateV2Extraction | None = None,
+) -> TemplateV2CompileResult:
+    """템플릿 디렉터리에서 v2 meta/reference JSON 을 생성하거나 최신성을 확인한다."""
+    del strict
+    root = Path(template_dir)
+    _validate_template_dir(root)
+
+    target_dir = Path(output_dir) if output_dir is not None else root
+    payloads = build_template_v2_payloads(root.name, extraction=extraction)
+    meta_path = target_dir / META_JSON_NAME
+    reference_path = target_dir / REFERENCE_JSON_NAME
+
+    if check:
+        errors = tuple(
+            error
+            for error in (
+                _check_json_file(meta_path, payloads.metadata, META_JSON_NAME),
+                _check_json_file(reference_path, payloads.reference, REFERENCE_JSON_NAME),
+            )
+            if error is not None
+        )
+        return TemplateV2CompileResult(
+            meta_path=meta_path,
+            reference_path=reference_path,
+            checked=True,
+            updated=False,
+            errors=errors,
+        )
+
+    write_json_payload(meta_path, payloads.metadata)
+    write_json_payload(reference_path, payloads.reference)
+    return TemplateV2CompileResult(
+        meta_path=meta_path,
+        reference_path=reference_path,
+        checked=False,
+        updated=True,
+    )
+
+
+def _validate_template_dir(template_dir: Path) -> None:
+    if not template_dir.is_dir():
+        raise ValueError(f"템플릿 디렉터리를 찾을 수 없습니다: {template_dir}")
+    template_pptx = template_dir / TEMPLATE_PPTX_NAME
+    if not template_pptx.is_file():
+        raise ValueError(f"template.pptx 파일을 찾을 수 없습니다: {template_pptx}")
+
+
+def _check_json_file(path: Path, expected_payload: dict, label: str) -> str | None:
+    try:
+        if json_file_normalized_equal(path, expected_payload):
+            return None
+    except ValueError as exc:
+        return f"{label} normalize 비교 실패: {exc}"
+    return f"{label}이 최신 v2 산출물과 다릅니다: {path}"

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -1,0 +1,131 @@
+"""PPTX 템플릿 v2 metadata/reference JSON 계약."""
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION_V2 = 2
+META_JSON_NAME = "meta.json"
+REFERENCE_JSON_NAME = "reference.json"
+TEMPLATE_PPTX_NAME = "template.pptx"
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateV2Extraction:
+    """v2 compiler 추출 결과.
+
+    Task 2.01 단계에서는 빈 추출 결과를 안정적으로 직렬화하는 기반만 제공한다.
+    slide pair, marker, reference shape 매칭은 후속 task 가 이 구조를 채운다.
+    """
+
+    runtime_slides: Sequence[Mapping[str, Any]] = ()
+    slots: Sequence[Mapping[str, Any]] = ()
+    layout_groups: Sequence[Mapping[str, Any]] = ()
+    slide_pairs: Sequence[Mapping[str, Any]] = ()
+    shape_matches: Sequence[Mapping[str, Any]] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateV2Payloads:
+    """v2 metadata/reference payload 묶음."""
+
+    metadata: dict[str, Any]
+    reference: dict[str, Any]
+
+
+def build_template_v2_payloads(
+    template_id: str,
+    extraction: TemplateV2Extraction | None = None,
+) -> TemplateV2Payloads:
+    """template_id 와 추출 결과로 v2 meta/reference payload 를 만든다."""
+    normalized_template_id = _normalize_template_id(template_id)
+    source = extraction or TemplateV2Extraction()
+    metadata = {
+        "schema_version": SCHEMA_VERSION_V2,
+        "template_id": normalized_template_id,
+        "runtime_slides": _json_array(source.runtime_slides, "runtime_slides"),
+        "slots": _json_array(source.slots, "slots"),
+        "layout_groups": _json_array(source.layout_groups, "layout_groups"),
+    }
+    reference = {
+        "schema_version": SCHEMA_VERSION_V2,
+        "template_id": normalized_template_id,
+        "slide_pairs": _json_array(source.slide_pairs, "slide_pairs"),
+        "shape_matches": _json_array(source.shape_matches, "shape_matches"),
+    }
+    return TemplateV2Payloads(metadata=metadata, reference=reference)
+
+
+def canonical_json_text(payload: Any) -> str:
+    """payload 를 deterministic JSON 문자열로 직렬화한다."""
+    return (
+        json.dumps(
+            normalize_json(payload),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+
+
+def write_json_payload(path: Path | str, payload: Any) -> Path:
+    """payload 를 sort-key JSON 파일로 작성한다."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(canonical_json_text(payload), encoding="utf-8")
+    return output_path
+
+
+def read_json_payload(path: Path | str) -> Any:
+    """JSON 파일을 읽어 Python 값으로 반환한다."""
+    source_path = Path(path)
+    try:
+        return json.loads(source_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"JSON 파일을 읽을 수 없습니다: {source_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"JSON 형식이 올바르지 않습니다: {source_path}") from exc
+
+
+def normalize_json(value: Any) -> Any:
+    """JSON 값을 비교 가능한 canonical 구조로 정규화한다."""
+    if isinstance(value, Mapping):
+        normalized_items = []
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"JSON 객체 key는 문자열이어야 합니다: {key!r}")
+            normalized_items.append((key, normalize_json(item)))
+        return {key: item for key, item in sorted(normalized_items)}
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [normalize_json(item) for item in value]
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    raise ValueError(f"JSON으로 직렬화할 수 없는 값입니다: {type(value).__name__}")
+
+
+def json_normalized_equal(left: Any, right: Any) -> bool:
+    """두 JSON payload 의 의미가 같은지 비교한다."""
+    return normalize_json(left) == normalize_json(right)
+
+
+def json_file_normalized_equal(path: Path | str, expected_payload: Any) -> bool:
+    """JSON 파일과 예상 payload 를 normalize 비교한다."""
+    return json_normalized_equal(read_json_payload(path), expected_payload)
+
+
+def _normalize_template_id(template_id: str) -> str:
+    normalized = template_id.strip()
+    if not normalized:
+        raise ValueError("template_id는 비어 있을 수 없습니다.")
+    return normalized
+
+
+def _json_array(items: Sequence[Mapping[str, Any]], field_name: str) -> list[Any]:
+    normalized = normalize_json(list(items))
+    if not isinstance(normalized, list):
+        raise ValueError(f"{field_name} 값은 배열이어야 합니다.")
+    return normalized

--- a/scripts/templates/compile_template.py
+++ b/scripts/templates/compile_template.py
@@ -1,0 +1,67 @@
+"""PPTX 템플릿 v2 metadata/reference compiler CLI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI 인자를 파싱한다."""
+    parser = argparse.ArgumentParser(
+        description="template.pptx에서 v2 meta.json/reference.json skeleton을 생성합니다."
+    )
+    parser.add_argument("template_dir", type=Path, help="template.pptx가 있는 템플릿 디렉터리")
+    parser.add_argument("--out", type=Path, help="meta.json/reference.json을 쓸 별도 출력 디렉터리")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="현재 JSON 파일과 새 산출물을 normalize 비교하고 파일은 쓰지 않습니다.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="품질 warning을 실패로 승격합니다. 후속 validator 연동을 위한 옵션입니다.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """스크립트 실행 진입점."""
+    from features.visualization.templates import compile_template_v2
+
+    args = parse_args(argv)
+    try:
+        result = compile_template_v2(
+            args.template_dir,
+            output_dir=args.out,
+            check=args.check,
+            strict=args.strict,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    for warning in result.warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+    for error in result.errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+
+    if not result.ok:
+        return 1
+
+    if result.checked:
+        print("v2 템플릿 JSON 최신성 확인 완료")
+    else:
+        print("v2 템플릿 JSON 생성 완료")
+        print(f"- meta: {result.meta_path}")
+        print(f"- reference: {result.reference_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/phase-2-pptx-template-quality/01-v2-metadata-models-json-io.md
+++ b/tasks/phase-2-pptx-template-quality/01-v2-metadata-models-json-io.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/01-pptx-template-v2-compiler.md"
 depends_on: ["1.08"]
 blocks: ["2.02"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -21,23 +22,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 현재 `features/visualization/templates/` 모듈 구조와 `build_meta.py` 출력 계약 확인
-- [ ] 기존 `templates/origin/` 은 개선 전 버전으로 보고, `docs/ppt-v3.pptx` 를 `templates/ppt-v3/` 신규 등록 입력 자산으로 확인
+- [x] 현재 `features/visualization/templates/` 모듈 구조와 `build_meta.py` 출력 계약 확인
+- [x] 기존 `templates/origin/` 은 개선 전 버전으로 보고, `docs/ppt-v3.pptx` 를 `templates/ppt-v3/` 신규 등록 입력 자산으로 확인
 
 ## 구현 체크리스트
 
-- [ ] `features/visualization/templates/` 에 v2 metadata/reference dataclass 또는 TypedDict 모델 추가
-- [ ] `schema_version: 2`, `template_id`, `runtime_slides`, `slots`, `layout_groups` 기본 payload 생성기 추가
-- [ ] `reference.json` 기본 payload와 JSON normalize/sort-key writer 추가
-- [ ] `scripts/templates/compile_template.py` CLI 골격과 `template_dir`, `--out`, `--check`, `--strict` 인자 파싱 추가
-- [ ] `tests/test_features/test_visualization/test_template_v2_compiler.py` 에 JSON writer와 CLI 골격 단위 테스트 추가
+- [x] `features/visualization/templates/` 에 v2 metadata/reference dataclass 또는 TypedDict 모델 추가
+- [x] `schema_version: 2`, `template_id`, `runtime_slides`, `slots`, `layout_groups` 기본 payload 생성기 추가
+- [x] `reference.json` 기본 payload와 JSON normalize/sort-key writer 추가
+- [x] `scripts/templates/compile_template.py` CLI 골격과 `template_dir`, `--out`, `--check`, `--strict` 인자 파싱 추가
+- [x] `tests/test_features/test_visualization/test_template_v2_compiler.py` 에 JSON writer와 CLI 골격 단위 테스트 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] `compile_template.py --help` 가 동작한다
-- [ ] 빈 추출 결과에서도 v2 JSON skeleton 이 deterministic 하게 생성된다
-- [ ] JSON normalize 비교 유틸리티가 key 순서 차이를 무시하고 의미 차이는 감지한다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] `compile_template.py --help` 가 동작한다
+- [x] 빈 추출 결과에서도 v2 JSON skeleton 이 deterministic 하게 생성된다
+- [x] JSON normalize 비교 유틸리티가 key 순서 차이를 무시하고 의미 차이는 감지한다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_main_client.py
+++ b/tests/test_features/test_visualization/test_main_client.py
@@ -730,9 +730,7 @@ class TestGetSlideContext:
             return_value={"isSuccess": True, "result": {}},
         ) as mock_rwr:
             await client.get_slide_context("job-xyz", "slide-abc")
-        mock_rwr.assert_called_once_with(
-            "GET", "/internal/visualizations/job-xyz/slides/slide-abc"
-        )
+        mock_rwr.assert_called_once_with("GET", "/internal/visualizations/job-xyz/slides/slide-abc")
 
     @pytest.mark.asyncio
     async def test_non_dict_result_raises(self):

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -1,0 +1,160 @@
+"""PPTX 템플릿 v2 compiler 기반 테스트."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from features.visualization.templates import (
+    build_template_v2_payloads,
+    canonical_json_text,
+    compile_template_v2,
+    json_normalized_equal,
+    read_json_payload,
+    write_json_payload,
+)
+from scripts.templates.compile_template import main as compile_template_main
+from scripts.templates.compile_template import parse_args
+
+
+def test_v2_payload_writer_generates_deterministic_skeleton(tmp_path: Path) -> None:
+    """빈 추출 결과에서도 v2 meta/reference skeleton을 deterministic 하게 쓴다."""
+    payloads = build_template_v2_payloads("ppt-v3")
+    meta_path = write_json_payload(tmp_path / "meta.json", payloads.metadata)
+    reference_path = write_json_payload(tmp_path / "reference.json", payloads.reference)
+
+    expected_meta = """{
+  "layout_groups": [],
+  "runtime_slides": [],
+  "schema_version": 2,
+  "slots": [],
+  "template_id": "ppt-v3"
+}
+"""
+    expected_reference = """{
+  "schema_version": 2,
+  "shape_matches": [],
+  "slide_pairs": [],
+  "template_id": "ppt-v3"
+}
+"""
+    assert meta_path.read_text(encoding="utf-8") == expected_meta
+    assert reference_path.read_text(encoding="utf-8") == expected_reference
+    assert canonical_json_text(payloads.metadata) == expected_meta
+
+
+def test_json_normalized_equal_ignores_key_order_and_detects_semantic_changes() -> None:
+    """JSON normalize 비교는 key 순서 차이만 무시하고 의미 차이는 감지한다."""
+    left = {"b": 1, "a": [{"z": "value", "y": 2}]}
+    right = {"a": [{"y": 2, "z": "value"}], "b": 1}
+    changed = {"a": [{"y": 3, "z": "value"}], "b": 1}
+
+    assert json_normalized_equal(left, right) is True
+    assert json_normalized_equal(left, changed) is False
+
+
+def test_compile_template_v2_writes_meta_and_reference_json(tmp_path: Path) -> None:
+    """v2 compiler는 template_id 정책에 맞춰 meta/reference skeleton을 생성한다."""
+    template_dir = _make_template_dir(tmp_path, "ppt-v3")
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    assert result.updated is True
+    assert result.meta_path == template_dir / "meta.json"
+    assert result.reference_path == template_dir / "reference.json"
+    assert read_json_payload(result.meta_path) == {
+        "schema_version": 2,
+        "template_id": "ppt-v3",
+        "runtime_slides": [],
+        "slots": [],
+        "layout_groups": [],
+    }
+    assert read_json_payload(result.reference_path) == {
+        "schema_version": 2,
+        "template_id": "ppt-v3",
+        "slide_pairs": [],
+        "shape_matches": [],
+    }
+
+
+def test_compile_template_cli_help_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    """compile_template.py --help 가 argparse help를 출력하고 0으로 종료한다."""
+    with pytest.raises(SystemExit) as exc_info:
+        compile_template_main(["--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "template_dir" in captured.out
+    assert "--check" in captured.out
+    assert "--strict" in captured.out
+
+
+def test_compile_template_cli_supports_out_check_and_strict_args(tmp_path: Path) -> None:
+    """CLI 골격은 template_dir, --out, --check, --strict 인자를 파싱한다."""
+    template_dir = _make_template_dir(tmp_path, "ppt-v3")
+    output_dir = tmp_path / "compiled"
+
+    args = parse_args([str(template_dir), "--out", str(output_dir), "--check", "--strict"])
+
+    assert args.template_dir == template_dir
+    assert args.out == output_dir
+    assert args.check is True
+    assert args.strict is True
+
+
+def test_compile_template_cli_out_writes_separate_output_dir(tmp_path: Path) -> None:
+    """--out 실행은 입력 템플릿 디렉터리 대신 지정한 출력 디렉터리에 쓴다."""
+    template_dir = _make_template_dir(tmp_path, "ppt-v3")
+    output_dir = tmp_path / "compiled"
+
+    assert compile_template_main([str(template_dir), "--out", str(output_dir), "--strict"]) == 0
+
+    assert (output_dir / "meta.json").is_file()
+    assert (output_dir / "reference.json").is_file()
+    assert not (template_dir / "meta.json").exists()
+    assert not (template_dir / "reference.json").exists()
+
+
+def test_compile_template_cli_check_uses_normalized_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--check 는 key 순서 차이를 무시하고 의미 차이가 있으면 non-zero를 반환한다."""
+    template_dir = _make_template_dir(tmp_path, "ppt-v3")
+    assert compile_template_main([str(template_dir)]) == 0
+    capsys.readouterr()
+
+    reordered_meta = {
+        "template_id": "ppt-v3",
+        "slots": [],
+        "schema_version": 2,
+        "runtime_slides": [],
+        "layout_groups": [],
+    }
+    (template_dir / "meta.json").write_text(
+        json.dumps(reordered_meta, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    assert compile_template_main([str(template_dir), "--check"]) == 0
+    capsys.readouterr()
+
+    reordered_meta["template_id"] = "changed"
+    (template_dir / "meta.json").write_text(
+        json.dumps(reordered_meta, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    assert compile_template_main([str(template_dir), "--check"]) == 1
+    captured = capsys.readouterr()
+    assert "meta.json" in captured.err
+    assert "최신 v2 산출물과 다릅니다" in captured.err
+
+
+def _make_template_dir(tmp_path: Path, template_id: str) -> Path:
+    """테스트용 템플릿 디렉터리를 만든다."""
+    template_dir = tmp_path / template_id
+    template_dir.mkdir()
+    (template_dir / "template.pptx").write_bytes(b"pptx")
+    return template_dir

--- a/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
+++ b/tests/test_pptx_worker/test_visualization/test_storage/test_gcs_client.py
@@ -117,6 +117,7 @@ def mock_gcs(tmp_path):
         client = GcsClient(bucket_name="folioo-visualizations")
         yield client, mock_bucket, mock_blob, tmp_path
 
+
 def test_gcs_client_uses_gcs_bucket_env_when_bucket_name_is_not_explicit(monkeypatch):
     """기본 생성자는 Cloud Run GCS_BUCKET env 값을 버킷 이름으로 사용한다."""
     monkeypatch.setenv("GCS_BUCKET", "folioo-498017-visualizations")


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #256

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [x] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PPTX 템플릿 v2 `meta.json` / `reference.json` skeleton payload 모델을 추가했습니다.
- `schema_version: 2`, `template_id`, `runtime_slides`, `slots`, `layout_groups`, `slide_pairs`, `shape_matches` 기본 계약을 deterministic JSON으로 생성하도록 했습니다.
- JSON normalize 비교 유틸리티를 추가해 key 순서 차이는 무시하고 의미 차이는 감지하도록 했습니다.
- `scripts/templates/compile_template.py` CLI 골격을 추가하고 `template_dir`, `--out`, `--check`, `--strict` 인자를 지원했습니다.
- 기존 v1 `build_meta.py` 책임은 유지하고 v2 compiler 기반을 별도 모듈로 분리했습니다.
- 배포 README의 PPTX worker runtime smoke 범위를 현재 Dockerfile/Cloud Run env와 맞게 보강했습니다.
- repo-wide pre-commit 통과를 위해 기존 문서/테스트 파일의 포맷과 trailing whitespace를 정리했습니다.
- Task 2.01 문서를 완료 상태로 갱신했습니다.

## 📸 스크린샷

- CLI 검증 결과로 대체
  - `uv run ruff check .` 통과
  - `uv run ruff format --check .` 통과 (`198 files already formatted`)
  - `uv run pytest` 통과 (`870 passed`)
  - `uv run pre-commit run --all-files` 통과

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- `/review` 서브에이전트 리뷰 2회 결과 주요 이슈 없음으로 확인했습니다.
- `--strict`는 후속 validator/compiler 연동을 위한 CLI 옵션으로 보존하며, 현재 Task 2.01 범위에서는 no-op입니다.
- slide pair 추출, `#FF0000` marker 추출, reference shape 매칭, runtime fail-fast는 후속 task 범위로 남겼습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 템플릿 v2 컴파일 시스템 추가 - 메타데이터 및 참조 JSON 생성 및 검증 기능
  * 템플릿 컴파일 CLI 도구 추가 - 커맨드라인에서 템플릿 빌드 및 검증 가능
  * JSON 정규화 및 비교 유틸리티 추가 - 구조 변경 감지

* **Documentation**
  * 템플릿 빌드 프로세스 설명 개선

* **Tests**
  * 템플릿 컴파일러 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->