### PR TITLE
[PPTX] slide pair marker 추출 추가

### DIFF
--- a/features/visualization/templates/__init__.py
+++ b/features/visualization/templates/__init__.py
@@ -12,7 +12,12 @@ from .builder import (
 )
 from .categories import CategoryDefinition, CategorySchema, load_category_schema
 from .compiler_v2 import TemplateV2CompileResult, compile_template_v2
-from .pptx import SlideText, count_pptx_slides, extract_slide_texts
+from .pptx import (
+    SlideText,
+    count_pptx_slides,
+    extract_slide_texts,
+    extract_template_v2_from_pptx,
+)
 from .v2 import (
     SCHEMA_VERSION_V2,
     TemplateV2Extraction,
@@ -49,6 +54,7 @@ __all__ = [
     "compile_template_v2",
     "count_pptx_slides",
     "extract_slide_texts",
+    "extract_template_v2_from_pptx",
     "json_file_normalized_equal",
     "json_normalized_equal",
     "load_category_schema",

--- a/features/visualization/templates/compiler_v2.py
+++ b/features/visualization/templates/compiler_v2.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from .pptx import extract_template_v2_from_pptx
 from .v2 import (
     META_JSON_NAME,
     REFERENCE_JSON_NAME,
@@ -45,9 +46,20 @@ def compile_template_v2(
     _validate_template_dir(root)
 
     target_dir = Path(output_dir) if output_dir is not None else root
-    payloads = build_template_v2_payloads(root.name, extraction=extraction)
+    source_extraction = extraction or extract_template_v2_from_pptx(root / TEMPLATE_PPTX_NAME)
     meta_path = target_dir / META_JSON_NAME
     reference_path = target_dir / REFERENCE_JSON_NAME
+    if source_extraction.errors:
+        return TemplateV2CompileResult(
+            meta_path=meta_path,
+            reference_path=reference_path,
+            checked=check,
+            updated=False,
+            errors=tuple(source_extraction.errors),
+            warnings=tuple(source_extraction.warnings),
+        )
+
+    payloads = build_template_v2_payloads(root.name, extraction=source_extraction)
 
     if check:
         errors = tuple(
@@ -64,6 +76,7 @@ def compile_template_v2(
             checked=True,
             updated=False,
             errors=errors,
+            warnings=tuple(source_extraction.warnings),
         )
 
     write_json_payload(meta_path, payloads.metadata)
@@ -73,6 +86,7 @@ def compile_template_v2(
         reference_path=reference_path,
         checked=False,
         updated=True,
+        warnings=tuple(source_extraction.warnings),
     )
 
 

--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -9,6 +9,8 @@ from xml.etree.ElementTree import Element, ParseError
 from defusedxml import ElementTree
 from defusedxml.common import DefusedXmlException
 
+from .v2 import TemplateV2Extraction
+
 _PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
 _DRAWINGML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
 _REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
@@ -16,6 +18,8 @@ _PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/rela
 _SLIDE_RELATIONSHIP_TYPE = (
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
 )
+_EXACT_MARKER_RGB = "FF0000"
+_EXACT_MARKER_COLOR = "#FF0000"
 
 
 @dataclass(frozen=True)
@@ -24,6 +28,15 @@ class SlideText:
 
     slide_index: int
     text: str
+
+
+@dataclass(frozen=True, slots=True)
+class _MarkerShapeExtraction:
+    """단일 runtime slide의 marker shape 추출 결과."""
+
+    slots: tuple[dict, ...]
+    errors: tuple[str, ...]
+    has_marker_candidate: bool
 
 
 def count_pptx_slides(pptx_path: Path | str) -> int:
@@ -53,6 +66,88 @@ def extract_slide_texts(pptx_path: Path | str) -> tuple[SlideText, ...]:
             slide_texts.append(SlideText(slide_index=index, text="\n".join(texts)))
 
     return tuple(slide_texts)
+
+
+def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction:
+    """PPTX convention에서 v2 runtime slide pair와 marker slot을 추출한다.
+
+    1-based 짝수 슬라이드를 runtime 유형 슬라이드로 보고, 바로 뒤 1-based 홀수
+    슬라이드를 example slide로 매칭한다. 첫 안내 슬라이드나 example slide의 red text는
+    runtime editable slot 후보로 보지 않는다.
+    """
+    source = Path(pptx_path)
+    slide_names = _ordered_slide_part_names(source)
+    runtime_slides: list[dict] = []
+    slide_pairs: list[dict] = []
+    slots: list[dict] = []
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    with _open_pptx(source) as zf:
+        for slide_position, slide_name in enumerate(slide_names):
+            slide_number = slide_position + 1
+            if slide_number % 2 != 0:
+                continue
+
+            example_position = slide_position + 1
+            if example_position >= len(slide_names):
+                errors.append(
+                    f"runtime slide {slide_number}의 example slide pair를 찾을 수 없습니다."
+                )
+                continue
+
+            example_name = slide_names[example_position]
+            runtime_slide = {
+                "slide_index": slide_position,
+                "slide_number": slide_number,
+                "slide_filename": Path(slide_name).name,
+                "slide_part": slide_name,
+            }
+            runtime_slides.append(runtime_slide)
+            slide_pairs.append(
+                {
+                    "runtime_slide_index": slide_position,
+                    "runtime_slide_number": slide_number,
+                    "runtime_slide_filename": Path(slide_name).name,
+                    "runtime_slide_part": slide_name,
+                    "example_slide_index": example_position,
+                    "example_slide_number": example_position + 1,
+                    "example_slide_filename": Path(example_name).name,
+                    "example_slide_part": example_name,
+                }
+            )
+
+            try:
+                slide_xml = zf.read(slide_name)
+            except KeyError as exc:
+                raise ValueError(f"PPTX 슬라이드 XML을 찾을 수 없습니다: {slide_name}") from exc
+
+            root = _parse_xml(slide_xml, f"{source}:{slide_name}")
+            marker_result = _extract_marker_slots_from_slide(
+                root,
+                slide_index=slide_position,
+                slide_number=slide_number,
+                slide_part=slide_name,
+            )
+            slots.extend(marker_result.slots)
+            errors.extend(marker_result.errors)
+            if not marker_result.slots and not marker_result.has_marker_candidate:
+                errors.append(
+                    f"runtime slide {slide_number}에 정확한 #FF0000 editable marker가 없습니다."
+                )
+
+    if not runtime_slides:
+        errors.append("runtime 대상 슬라이드가 없습니다.")
+
+    return TemplateV2Extraction(
+        runtime_slides=tuple(runtime_slides),
+        slots=tuple(slots),
+        layout_groups=(),
+        slide_pairs=tuple(slide_pairs),
+        shape_matches=(),
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
 
 
 def _ordered_slide_part_names(pptx_path: Path) -> tuple[str, ...]:
@@ -121,6 +216,198 @@ def _resolve_slide_part_name(target: str, names: set[str]) -> str:
     if slide_name not in names:
         raise ValueError(f"PPTX 슬라이드 XML을 찾을 수 없습니다: {slide_name}")
     return slide_name
+
+
+def _extract_marker_slots_from_slide(
+    slide_root: Element,
+    *,
+    slide_index: int,
+    slide_number: int,
+    slide_part: str,
+) -> _MarkerShapeExtraction:
+    slots: list[dict] = []
+    errors: list[str] = []
+    has_marker_candidate = False
+
+    for shape in slide_root.findall(f".//{{{_PRESENTATION_NS}}}sp"):
+        result = _marker_slot_from_shape(
+            shape,
+            slide_index=slide_index,
+            slide_number=slide_number,
+            slide_part=slide_part,
+        )
+        if result is None:
+            continue
+
+        has_marker_candidate = has_marker_candidate or result.has_marker_candidate
+        slots.extend(result.slots)
+        errors.extend(result.errors)
+
+    return _MarkerShapeExtraction(
+        slots=tuple(slots),
+        errors=tuple(errors),
+        has_marker_candidate=has_marker_candidate,
+    )
+
+
+def _marker_slot_from_shape(
+    shape: Element,
+    *,
+    slide_index: int,
+    slide_number: int,
+    slide_part: str,
+) -> _MarkerShapeExtraction | None:
+    tx_body = shape.find(f"{{{_PRESENTATION_NS}}}txBody")
+    if tx_body is None:
+        return None
+
+    red_text_parts: list[str] = []
+    non_red_text_parts: list[str] = []
+    red_font_size_pt: float | None = None
+
+    for paragraph_index, paragraph in enumerate(tx_body.findall(f"{{{_DRAWINGML_NS}}}p")):
+        if paragraph_index > 0 and red_text_parts and red_text_parts[-1] != "\n":
+            red_text_parts.append("\n")
+
+        for child in list(paragraph):
+            if child.tag == f"{{{_DRAWINGML_NS}}}br":
+                if red_text_parts and not non_red_text_parts and red_text_parts[-1] != "\n":
+                    red_text_parts.append("\n")
+                continue
+
+            if child.tag != f"{{{_DRAWINGML_NS}}}r":
+                continue
+
+            run_text = _run_text(child)
+            if not run_text:
+                continue
+
+            color = _run_srgb_color(child)
+            if color == _EXACT_MARKER_RGB:
+                red_text_parts.append(run_text)
+                if red_font_size_pt is None:
+                    red_font_size_pt = _run_font_size_pt(child)
+            elif run_text.strip():
+                non_red_text_parts.append(run_text)
+
+    if not red_text_parts and not non_red_text_parts:
+        return None
+
+    shape_id = _shape_id(shape) or ""
+    shape_name = _shape_name(shape)
+    has_marker_candidate = bool(red_text_parts)
+    if red_text_parts and non_red_text_parts:
+        return _MarkerShapeExtraction(
+            slots=(),
+            errors=(
+                "runtime slide "
+                f"{slide_number} shape {shape_id or '(unknown)'}에 "
+                "#FF0000 marker와 non-red run이 섞여 있습니다.",
+            ),
+            has_marker_candidate=True,
+        )
+
+    if not red_text_parts:
+        return _MarkerShapeExtraction(slots=(), errors=(), has_marker_candidate=False)
+
+    placeholder_text = "".join(red_text_parts).strip()
+    if not placeholder_text:
+        return _MarkerShapeExtraction(slots=(), errors=(), has_marker_candidate=False)
+
+    slot = {
+        "slot_id": f"slide{slide_number}_shape{shape_id}",
+        "slide_index": slide_index,
+        "slide_number": slide_number,
+        "slide_filename": Path(slide_part).name,
+        "slide_part": slide_part,
+        "shape_id": shape_id,
+        "shape_name": shape_name,
+        **_coordinates(shape),
+        "placeholder_text": placeholder_text,
+        "marker_color": _EXACT_MARKER_COLOR,
+        "font_size_pt": red_font_size_pt,
+        "kind": "text",
+        "editable": True,
+        "required": True,
+        "allowed_actions": ["text"],
+    }
+    return _MarkerShapeExtraction(
+        slots=(slot,),
+        errors=(),
+        has_marker_candidate=has_marker_candidate,
+    )
+
+
+def _shape_id(shape: Element) -> str | None:
+    cnv_pr = _cnv_pr(shape)
+    return cnv_pr.attrib.get("id") if cnv_pr is not None else None
+
+
+def _shape_name(shape: Element) -> str:
+    cnv_pr = _cnv_pr(shape)
+    return cnv_pr.attrib.get("name", "") if cnv_pr is not None else ""
+
+
+def _cnv_pr(shape: Element) -> Element | None:
+    return shape.find(
+        f"{{{_PRESENTATION_NS}}}nvSpPr/{{{_PRESENTATION_NS}}}cNvPr",
+    )
+
+
+def _coordinates(shape: Element) -> dict[str, int | None]:
+    xfrm = shape.find(
+        f"{{{_PRESENTATION_NS}}}spPr/{{{_DRAWINGML_NS}}}xfrm",
+    )
+    off = xfrm.find(f"{{{_DRAWINGML_NS}}}off") if xfrm is not None else None
+    ext = xfrm.find(f"{{{_DRAWINGML_NS}}}ext") if xfrm is not None else None
+    return {
+        "x_emu": _int_attr(off, "x"),
+        "y_emu": _int_attr(off, "y"),
+        "w_emu": _int_attr(ext, "cx"),
+        "h_emu": _int_attr(ext, "cy"),
+    }
+
+
+def _run_text(run: Element) -> str:
+    return "".join(text_node.text or "" for text_node in run.findall(f".//{{{_DRAWINGML_NS}}}t"))
+
+
+def _run_srgb_color(run: Element) -> str | None:
+    color = run.find(
+        f"{{{_DRAWINGML_NS}}}rPr/{{{_DRAWINGML_NS}}}solidFill/{{{_DRAWINGML_NS}}}srgbClr"
+    )
+    if color is None:
+        return None
+    if list(color):
+        return None
+
+    raw_value = color.attrib.get("val")
+    if raw_value is None:
+        return None
+    return raw_value.upper()
+
+
+def _run_font_size_pt(run: Element) -> float | None:
+    run_props = run.find(f"{{{_DRAWINGML_NS}}}rPr")
+    if run_props is None:
+        return None
+
+    size = run_props.attrib.get("sz")
+    if size is None:
+        return None
+    try:
+        return int(size) / 100
+    except ValueError:
+        return None
+
+
+def _int_attr(element: Element | None, attr_name: str) -> int | None:
+    if element is None:
+        return None
+    value = element.attrib.get(attr_name)
+    if value is None:
+        return None
+    return int(value)
 
 
 def _is_slide_part_name(part_name: str) -> bool:

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -16,8 +16,8 @@ TEMPLATE_PPTX_NAME = "template.pptx"
 class TemplateV2Extraction:
     """v2 compiler 추출 결과.
 
-    Task 2.01 단계에서는 빈 추출 결과를 안정적으로 직렬화하는 기반만 제공한다.
-    slide pair, marker, reference shape 매칭은 후속 task 가 이 구조를 채운다.
+    PPTX에서 추출한 runtime slide, editable marker slot, reference skeleton 정보를 담는다.
+    reference shape 매칭과 layout group 추론은 후속 task 가 이 구조를 확장한다.
     """
 
     runtime_slides: Sequence[Mapping[str, Any]] = ()
@@ -25,6 +25,8 @@ class TemplateV2Extraction:
     layout_groups: Sequence[Mapping[str, Any]] = ()
     slide_pairs: Sequence[Mapping[str, Any]] = ()
     shape_matches: Sequence[Mapping[str, Any]] = ()
+    errors: Sequence[str] = ()
+    warnings: Sequence[str] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tasks/phase-2-pptx-template-quality/02-pptx-slide-pair-marker-extraction.md
+++ b/tasks/phase-2-pptx-template-quality/02-pptx-slide-pair-marker-extraction.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/01-pptx-template-v2-compiler.md"
 depends_on: ["1.03", "2.01"]
 blocks: ["2.03"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -23,23 +24,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] `docs/architecture/pptx-template-quality-roadmap.md` 의 짝수/홀수 convention 확인
-- [ ] 샘플 PPTX에서 빨간 marker, non-red text, mixed run fixture 후보 확보
+- [x] `docs/architecture/pptx-template-quality-roadmap.md` 의 짝수/홀수 convention 확인
+- [x] 샘플 PPTX에서 빨간 marker, non-red text, mixed run fixture 후보 확보
 
 ## 구현 체크리스트
 
-- [ ] PPTX package 에서 slide XML 순서와 runtime/example pair 를 계산하는 추출기 추가
-- [ ] 텍스트 shape 의 run color 를 정확한 RGB `#FF0000` 기준으로 판별
-- [ ] `#FF0000` marker shape 만 editable slot 으로 만들고 non-red text 는 제외
-- [ ] red/non-red mixed run 을 계약 위반으로 수집하는 오류 모델 추가
-- [ ] marker slot 에 shape id, bbox, font size, `marker_color`, `placeholder_text` 를 기록
+- [x] PPTX package 에서 slide XML 순서와 runtime/example pair 를 계산하는 추출기 추가
+- [x] 텍스트 shape 의 run color 를 정확한 RGB `#FF0000` 기준으로 판별
+- [x] `#FF0000` marker shape 만 editable slot 으로 만들고 non-red text 는 제외
+- [x] red/non-red mixed run 을 계약 위반으로 수집하는 오류 모델 추가
+- [x] marker slot 에 shape id, bbox, font size, `marker_color`, `placeholder_text` 를 기록
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] 유형 슬라이드의 빨간 텍스트만 editable slot 으로 추출된다
-- [ ] non-red 텍스트는 slot 에 들어가지 않는다
-- [ ] mixed-color run fixture 가 fail 대상 오류로 보고된다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] 유형 슬라이드의 빨간 텍스트만 editable slot 으로 추출된다
+- [x] non-red 텍스트는 slot 에 들어가지 않는다
+- [x] mixed-color run fixture 가 fail 대상 오류로 보고된다
 
 ## 리스크 / 메모
 

--- a/tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md
+++ b/tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md
@@ -43,6 +43,7 @@ sprint: ""
 
 - [ ] `docs/ppt-v3.pptx` 기반 `templates/ppt-v3/` 신규 등록 템플릿을 acceptance fixture 로 유지할지, 별도 운영 자산으로 둘지 사용자 확인을 받는다.
 - [ ] 정상 acceptance deck 이 runtime/example pair, 정확한 `#FF0000` marker, non-red fixed text, chip group, metric slot 을 포함하는지 사용자 확인을 받는다.
+- [ ] `docs/ppt-v3.pptx` 또는 운영 acceptance deck 에서 fixed label 과 editable marker 가 한 텍스트 shape 안에 섞인 mixed-color run 을 분리할지 사용자 확인을 받는다. (2.02 compiler 는 mixed-color run 을 계약 위반으로 실패 처리한다.)
 - [x] mixed-color run, `#FE0000`/theme red, 예시 pair 누락 같은 negative case 는 정상 deck 과 분리한 invalid fixture 로 둔다.
 - [ ] `compile_template.py --strict` 를 CI 필수 게이트로 승격할 rollout 시점을 사용자 확인을 받는다.
 - [ ] Main backend 계약 변경이 불가피한 상황이 발견되면 변경 사유와 대안을 사용자에게 최종 확인받는다.

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -1,20 +1,32 @@
 """PPTX 템플릿 v2 compiler 기반 테스트."""
 
 import json
+import zipfile
 from pathlib import Path
+from xml.sax.saxutils import escape
 
 import pytest
 
 from features.visualization.templates import (
+    TemplateV2Extraction,
     build_template_v2_payloads,
     canonical_json_text,
     compile_template_v2,
+    extract_template_v2_from_pptx,
     json_normalized_equal,
     read_json_payload,
     write_json_payload,
 )
 from scripts.templates.compile_template import main as compile_template_main
 from scripts.templates.compile_template import parse_args
+
+_PRESENTATION_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+_DRAWINGML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_PACKAGE_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+_SLIDE_RELATIONSHIP_TYPE = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
+)
 
 
 def test_v2_payload_writer_generates_deterministic_skeleton(tmp_path: Path) -> None:
@@ -57,7 +69,7 @@ def test_compile_template_v2_writes_meta_and_reference_json(tmp_path: Path) -> N
     """v2 compiler는 template_id 정책에 맞춰 meta/reference skeleton을 생성한다."""
     template_dir = _make_template_dir(tmp_path, "ppt-v3")
 
-    result = compile_template_v2(template_dir)
+    result = compile_template_v2(template_dir, extraction=TemplateV2Extraction())
 
     assert result.ok is True
     assert result.updated is True
@@ -76,6 +88,144 @@ def test_compile_template_v2_writes_meta_and_reference_json(tmp_path: Path) -> N
         "slide_pairs": [],
         "shape_matches": [],
     }
+
+
+def test_extract_template_v2_from_pptx_uses_even_runtime_odd_example_pairs(
+    tmp_path: Path,
+) -> None:
+    """1-based 짝수 슬라이드만 runtime 후보로 삼고 바로 뒤 홀수 슬라이드를 example로 묶는다."""
+    pptx_path = tmp_path / "template.pptx"
+    _make_template_pptx(pptx_path, _valid_v2_slide_xmls())
+
+    extraction = extract_template_v2_from_pptx(pptx_path)
+
+    assert extraction.errors == ()
+    assert extraction.runtime_slides == (
+        {
+            "slide_index": 1,
+            "slide_number": 2,
+            "slide_filename": "slide2.xml",
+            "slide_part": "ppt/slides/slide2.xml",
+        },
+    )
+    assert extraction.slide_pairs == (
+        {
+            "runtime_slide_index": 1,
+            "runtime_slide_number": 2,
+            "runtime_slide_filename": "slide2.xml",
+            "runtime_slide_part": "ppt/slides/slide2.xml",
+            "example_slide_index": 2,
+            "example_slide_number": 3,
+            "example_slide_filename": "slide3.xml",
+            "example_slide_part": "ppt/slides/slide3.xml",
+        },
+    )
+
+
+def test_compile_template_v2_extracts_only_exact_red_marker_slots(tmp_path: Path) -> None:
+    """정확한 #FF0000 텍스트 shape만 editable slot으로 만들고 non-red text는 제외한다."""
+    template_dir = _make_template_dir(tmp_path, "ppt-v3")
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    reference = read_json_payload(result.reference_path)
+    assert metadata["runtime_slides"] == [
+        {
+            "slide_filename": "slide2.xml",
+            "slide_index": 1,
+            "slide_number": 2,
+            "slide_part": "ppt/slides/slide2.xml",
+        }
+    ]
+    assert reference["slide_pairs"][0]["runtime_slide_number"] == 2
+    assert reference["slide_pairs"][0]["example_slide_number"] == 3
+
+    assert len(metadata["slots"]) == 1
+    slot = metadata["slots"][0]
+    assert slot == {
+        "allowed_actions": ["text"],
+        "editable": True,
+        "font_size_pt": 18.0,
+        "h_emu": 400,
+        "kind": "text",
+        "marker_color": "#FF0000",
+        "placeholder_text": "프로젝트명",
+        "required": True,
+        "shape_id": "10",
+        "shape_name": "Exact red marker",
+        "slide_filename": "slide2.xml",
+        "slide_index": 1,
+        "slide_number": 2,
+        "slide_part": "ppt/slides/slide2.xml",
+        "slot_id": "slide2_shape10",
+        "w_emu": 300,
+        "x_emu": 100,
+        "y_emu": 200,
+    }
+
+
+def test_compile_template_v2_reports_mixed_color_run_as_contract_error(
+    tmp_path: Path,
+) -> None:
+    """red/non-red mixed run은 보정하지 않고 fail 대상 오류로 보고한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                _shape_xml(
+                    20,
+                    "Mixed marker",
+                    (
+                        _run_xml("경험명", color="FF0000"),
+                        _run_xml(" - 고정 문구", color=None),
+                    ),
+                ),
+            ),
+            _slide_xml(3, _shape_xml(30, "Example", (_run_xml("경험명 예시"),))),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is False
+    assert result.updated is False
+    assert not (template_dir / "meta.json").exists()
+    assert any("non-red run이 섞여 있습니다" in error for error in result.errors)
+
+
+def test_compile_template_v2_preserves_marker_soft_line_breaks(tmp_path: Path) -> None:
+    """marker shape 내부 soft line break는 placeholder_text에 줄바꿈으로 남긴다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                _shape_xml(
+                    20,
+                    "Multiline marker",
+                    (
+                        _run_xml("첫 줄", color="FF0000"),
+                        _break_xml(),
+                        _run_xml("둘째 줄", color="FF0000"),
+                    ),
+                ),
+            ),
+            _slide_xml(3, _shape_xml(30, "Example", (_run_xml("예시"),))),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    assert metadata["slots"][0]["placeholder_text"] == "첫 줄\n둘째 줄"
 
 
 def test_compile_template_cli_help_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
@@ -125,12 +275,13 @@ def test_compile_template_cli_check_uses_normalized_json(
     assert compile_template_main([str(template_dir)]) == 0
     capsys.readouterr()
 
+    current_meta = read_json_payload(template_dir / "meta.json")
     reordered_meta = {
-        "template_id": "ppt-v3",
-        "slots": [],
-        "schema_version": 2,
-        "runtime_slides": [],
-        "layout_groups": [],
+        "template_id": current_meta["template_id"],
+        "slots": current_meta["slots"],
+        "schema_version": current_meta["schema_version"],
+        "runtime_slides": current_meta["runtime_slides"],
+        "layout_groups": current_meta["layout_groups"],
     }
     (template_dir / "meta.json").write_text(
         json.dumps(reordered_meta, ensure_ascii=False, indent=2) + "\n",
@@ -152,9 +303,198 @@ def test_compile_template_cli_check_uses_normalized_json(
     assert "최신 v2 산출물과 다릅니다" in captured.err
 
 
-def _make_template_dir(tmp_path: Path, template_id: str) -> Path:
+def _make_template_dir(
+    tmp_path: Path,
+    template_id: str,
+    *,
+    slide_xmls: tuple[str, ...] | None = None,
+) -> Path:
     """테스트용 템플릿 디렉터리를 만든다."""
     template_dir = tmp_path / template_id
     template_dir.mkdir()
-    (template_dir / "template.pptx").write_bytes(b"pptx")
+    _make_template_pptx(template_dir / "template.pptx", slide_xmls or _valid_v2_slide_xmls())
     return template_dir
+
+
+def _valid_v2_slide_xmls() -> tuple[str, ...]:
+    """기본 v2 compiler 테스트용 slide pair fixture를 만든다."""
+    return (
+        _slide_xml(1, ""),
+        _slide_xml(
+            2,
+            "".join(
+                (
+                    _shape_xml(
+                        10,
+                        "Exact red marker",
+                        (_run_xml("프로젝트명", color="FF0000", font_size=1800),),
+                        x=100,
+                        y=200,
+                        width=300,
+                        height=400,
+                    ),
+                    _shape_xml(
+                        11,
+                        "Fixed non red",
+                        (_run_xml("고정 문구", color="222222"),),
+                    ),
+                    _shape_xml(
+                        12,
+                        "Almost red",
+                        (_run_xml("거의 빨강", color="FE0000"),),
+                    ),
+                    _shape_xml(
+                        13,
+                        "Theme red",
+                        (_run_xml("테마 빨강", scheme_color="accent2"),),
+                    ),
+                    _shape_xml(
+                        14,
+                        "Shaded exact red",
+                        (
+                            _run_xml(
+                                "음영 빨강",
+                                color="FF0000",
+                                color_transform_xml='<a:shade val="50000"/>',
+                            ),
+                        ),
+                    ),
+                )
+            ),
+        ),
+        _slide_xml(3, _shape_xml(30, "Example text", (_run_xml("실제 프로젝트명"),))),
+    )
+
+
+def _make_template_pptx(path: Path, slide_xmls: tuple[str, ...]) -> None:
+    """테스트용 최소 PPTX 패키지를 생성한다."""
+    slide_count = len(slide_xmls)
+    entries: dict[str, str] = {
+        "[Content_Types].xml": _content_types(slide_count),
+        "_rels/.rels": (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}">'
+            '<Relationship Id="rId1" '
+            'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+            'Target="ppt/presentation.xml"/>'
+            "</Relationships>"
+        ),
+        "ppt/presentation.xml": _presentation(slide_count),
+        "ppt/_rels/presentation.xml.rels": _presentation_rels(slide_count),
+    }
+    for index, slide_xml in enumerate(slide_xmls, start=1):
+        entries[f"ppt/slides/slide{index}.xml"] = slide_xml
+        entries[f"ppt/slides/_rels/slide{index}.xml.rels"] = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}"/>'
+        )
+
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+
+
+def _content_types(slide_count: int) -> str:
+    overrides = [
+        '<Override PartName="/ppt/presentation.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>'
+    ]
+    overrides.extend(
+        f'<Override PartName="/ppt/slides/slide{index}.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>'
+        for index in range(1, slide_count + 1)
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+        '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+        '<Default Extension="xml" ContentType="application/xml"/>'
+        f"{''.join(overrides)}</Types>"
+    )
+
+
+def _presentation(slide_count: int) -> str:
+    slide_ids = "".join(
+        f'<p:sldId id="{255 + index}" r:id="rId{index}"/>' for index in range(1, slide_count + 1)
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<p:presentation xmlns:p="{_PRESENTATION_NS}" xmlns:r="{_RELATIONSHIPS_NS}">'
+        f"<p:sldIdLst>{slide_ids}</p:sldIdLst>"
+        "</p:presentation>"
+    )
+
+
+def _presentation_rels(slide_count: int) -> str:
+    relationships = "".join(
+        f'<Relationship Id="rId{index}" Type="{_SLIDE_RELATIONSHIP_TYPE}" '
+        f'Target="slides/slide{index}.xml"/>'
+        for index in range(1, slide_count + 1)
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}">{relationships}</Relationships>'
+    )
+
+
+def _slide_xml(index: int, shapes_xml: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<p:sld xmlns:p="{_PRESENTATION_NS}" xmlns:a="{_DRAWINGML_NS}" '
+        f'xmlns:r="{_RELATIONSHIPS_NS}">'
+        "<p:cSld><p:spTree>"
+        f'<p:nvGrpSpPr><p:cNvPr id="{index}" name=""/><p:cNvGrpSpPr/><p:nvPr/>'
+        "</p:nvGrpSpPr><p:grpSpPr/>"
+        f"{shapes_xml}"
+        "</p:spTree></p:cSld></p:sld>"
+    )
+
+
+def _shape_xml(
+    shape_id: int,
+    name: str,
+    runs_xml: tuple[str, ...],
+    *,
+    x: int = 0,
+    y: int = 0,
+    width: int = 100,
+    height: int = 100,
+) -> str:
+    return (
+        "<p:sp>"
+        "<p:nvSpPr>"
+        f'<p:cNvPr id="{shape_id}" name="{escape(name)}"/>'
+        '<p:cNvSpPr txBox="1"/><p:nvPr/>'
+        "</p:nvSpPr>"
+        "<p:spPr>"
+        f'<a:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm>'
+        '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+        "</p:spPr>"
+        "<p:txBody><a:bodyPr/><a:lstStyle/><a:p>"
+        f"{''.join(runs_xml)}"
+        "</a:p></p:txBody>"
+        "</p:sp>"
+    )
+
+
+def _run_xml(
+    text: str,
+    *,
+    color: str | None = None,
+    scheme_color: str | None = None,
+    color_transform_xml: str = "",
+    font_size: int = 1200,
+) -> str:
+    if color is not None:
+        fill_xml = (
+            f'<a:solidFill><a:srgbClr val="{color}">{color_transform_xml}</a:srgbClr></a:solidFill>'
+        )
+    elif scheme_color is not None:
+        fill_xml = f'<a:solidFill><a:schemeClr val="{scheme_color}"/></a:solidFill>'
+    else:
+        fill_xml = ""
+    return f'<a:r><a:rPr sz="{font_size}">{fill_xml}</a:rPr><a:t>{escape(text)}</a:t></a:r>'
+
+
+def _break_xml() -> str:
+    return "<a:br/>"


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #257

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [x] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `template.pptx`의 slide order를 기준으로 1-based 짝수 runtime / 바로 뒤 홀수 example slide pair를 추출합니다.
- runtime slide의 정확한 `#FF0000` `srgbClr` 텍스트 shape만 editable slot으로 직렬화합니다.
- non-red, `#FE0000`, theme/scheme red, tint/shade red는 marker에서 제외하고 red/non-red mixed run은 계약 위반 오류로 보고합니다.
- marker slot에 shape id, bbox, font size, marker color, placeholder text를 기록하고 soft line break를 보존합니다.
- 실제 `templates/origin/template.pptx`의 mixed-color run 분리 여부를 2.18 사용자 확인사항으로 누적했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest -q` → `874 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 tint/shade red 제외와 soft line break 보존 지적을 반영했습니다.
- `compile_template.py templates/origin --check`는 기존 origin 템플릿의 mixed-color run을 계약 위반으로 보고합니다. 이는 2.02의 의도된 실패 경로입니다.