### PR TITLE
[PPTX] reference shape 매칭 추가

### DIFF
--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -20,6 +20,9 @@ _SLIDE_RELATIONSHIP_TYPE = (
 )
 _EXACT_MARKER_RGB = "FF0000"
 _EXACT_MARKER_COLOR = "#FF0000"
+_REFERENCE_COLOR_FALLBACK = "#000000"
+_REFERENCE_MATCH_FAIL_SCORE = 0.3
+_REFERENCE_MATCH_LOW_CONFIDENCE_SCORE = 0.75
 
 
 @dataclass(frozen=True)
@@ -37,6 +40,22 @@ class _MarkerShapeExtraction:
     slots: tuple[dict, ...]
     errors: tuple[str, ...]
     has_marker_candidate: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _TextShapeExtraction:
+    """예시 슬라이드 text shape 추출 결과."""
+
+    shape_id: str
+    shape_name: str
+    x_emu: int | None
+    y_emu: int | None
+    w_emu: int | None
+    h_emu: int | None
+    text: str
+    line_count: int
+    char_count: int
+    output_text_color: str | None
 
 
 def count_pptx_slides(pptx_path: Path | str) -> int:
@@ -79,6 +98,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
     slide_names = _ordered_slide_part_names(source)
     runtime_slides: list[dict] = []
     slide_pairs: list[dict] = []
+    shape_matches: list[dict] = []
     slots: list[dict] = []
     errors: list[str] = []
     warnings: list[str] = []
@@ -136,6 +156,24 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
                     f"runtime slide {slide_number}에 정확한 #FF0000 editable marker가 없습니다."
                 )
 
+            try:
+                example_xml = zf.read(example_name)
+            except KeyError as exc:
+                raise ValueError(f"PPTX 슬라이드 XML을 찾을 수 없습니다: {example_name}") from exc
+
+            example_root = _parse_xml(example_xml, f"{source}:{example_name}")
+            match_results = _match_reference_shapes(
+                marker_result.slots,
+                _extract_text_shapes_from_slide(example_root),
+                runtime_slide_number=slide_number,
+                example_slide_index=example_position,
+                example_slide_number=example_position + 1,
+                example_slide_part=example_name,
+            )
+            shape_matches.extend(match_results[0])
+            errors.extend(match_results[1])
+            warnings.extend(match_results[2])
+
     if not runtime_slides:
         errors.append("runtime 대상 슬라이드가 없습니다.")
 
@@ -144,7 +182,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
         slots=tuple(slots),
         layout_groups=(),
         slide_pairs=tuple(slide_pairs),
-        shape_matches=(),
+        shape_matches=tuple(shape_matches),
         errors=tuple(errors),
         warnings=tuple(warnings),
     )
@@ -336,6 +374,230 @@ def _marker_slot_from_shape(
         errors=(),
         has_marker_candidate=has_marker_candidate,
     )
+
+
+def _extract_text_shapes_from_slide(slide_root: Element) -> tuple[_TextShapeExtraction, ...]:
+    shapes: list[_TextShapeExtraction] = []
+    for shape in slide_root.findall(f".//{{{_PRESENTATION_NS}}}sp"):
+        extracted = _text_shape_from_shape(shape)
+        if extracted is not None:
+            shapes.append(extracted)
+    return tuple(shapes)
+
+
+def _text_shape_from_shape(shape: Element) -> _TextShapeExtraction | None:
+    tx_body = shape.find(f"{{{_PRESENTATION_NS}}}txBody")
+    if tx_body is None:
+        return None
+
+    paragraph_texts: list[str] = []
+    output_text_color: str | None = None
+    for paragraph in tx_body.findall(f"{{{_DRAWINGML_NS}}}p"):
+        parts: list[str] = []
+        for child in list(paragraph):
+            if child.tag == f"{{{_DRAWINGML_NS}}}br":
+                parts.append("\n")
+                continue
+            if child.tag != f"{{{_DRAWINGML_NS}}}r":
+                continue
+
+            run_text = _run_text(child)
+            parts.append(run_text)
+            if output_text_color is None and run_text.strip():
+                run_color = _run_srgb_color(child)
+                if run_color is not None:
+                    output_text_color = f"#{run_color}"
+        paragraph_texts.append("".join(parts))
+
+    text = "\n".join(paragraph_texts).strip()
+    if not text:
+        return None
+
+    coordinates = _coordinates(shape)
+    return _TextShapeExtraction(
+        shape_id=_shape_id(shape) or "",
+        shape_name=_shape_name(shape),
+        x_emu=coordinates["x_emu"],
+        y_emu=coordinates["y_emu"],
+        w_emu=coordinates["w_emu"],
+        h_emu=coordinates["h_emu"],
+        text=text,
+        line_count=len(text.splitlines()) or 1,
+        char_count=len(text.replace("\n", "")),
+        output_text_color=output_text_color,
+    )
+
+
+def _match_reference_shapes(
+    slots: tuple[dict, ...],
+    example_shapes: tuple[_TextShapeExtraction, ...],
+    *,
+    runtime_slide_number: int,
+    example_slide_index: int,
+    example_slide_number: int,
+    example_slide_part: str,
+) -> tuple[list[dict], list[str], list[str]]:
+    matches: list[dict] = []
+    errors: list[str] = []
+    warnings: list[str] = []
+    used_shape_ids: set[str] = set()
+
+    for slot in slots:
+        candidates = [
+            (_reference_match_score(slot, shape), shape)
+            for shape in example_shapes
+            if shape.shape_id not in used_shape_ids
+        ]
+        candidates.sort(key=lambda item: (-item[0], _shape_id_sort_key(item[1].shape_id)))
+        if not candidates:
+            errors.append(_reference_match_error(runtime_slide_number, slot))
+            continue
+
+        score, matched_shape = candidates[0]
+        if score < _REFERENCE_MATCH_FAIL_SCORE:
+            errors.append(_reference_match_error(runtime_slide_number, slot))
+            continue
+
+        used_shape_ids.add(matched_shape.shape_id)
+        confidence = "high" if score >= _REFERENCE_MATCH_LOW_CONFIDENCE_SCORE else "low"
+        if confidence == "low":
+            warnings.append(
+                "runtime slide "
+                f"{runtime_slide_number} slot {slot.get('slot_id')}의 example shape "
+                f"매칭 신뢰도가 낮습니다. (score: {score:.4f})"
+            )
+
+        output_text_color = matched_shape.output_text_color
+        if output_text_color is None:
+            output_text_color = _REFERENCE_COLOR_FALLBACK
+            warnings.append(
+                "runtime slide "
+                f"{runtime_slide_number} slot {slot.get('slot_id')}의 example shape "
+                f"{matched_shape.shape_id}에서 output_text_color를 찾지 못해 "
+                f"{_REFERENCE_COLOR_FALLBACK}을 사용합니다."
+            )
+
+        matches.append(
+            {
+                "slot_id": slot.get("slot_id"),
+                "runtime_slide_index": slot.get("slide_index"),
+                "runtime_slide_number": runtime_slide_number,
+                "runtime_shape_id": slot.get("shape_id"),
+                "example_slide_index": example_slide_index,
+                "example_slide_number": example_slide_number,
+                "example_slide_filename": Path(example_slide_part).name,
+                "example_slide_part": example_slide_part,
+                "example_shape_id": matched_shape.shape_id,
+                "example_shape_name": matched_shape.shape_name,
+                "example_text": matched_shape.text,
+                "example_char_count": matched_shape.char_count,
+                "example_line_count": matched_shape.line_count,
+                "output_text_color": output_text_color,
+                "match_score": round(score, 4),
+                "match_confidence": confidence,
+            }
+        )
+
+    return matches, errors, warnings
+
+
+def _reference_match_error(runtime_slide_number: int, slot: dict) -> str:
+    return (
+        "runtime slide "
+        f"{runtime_slide_number} slot {slot.get('slot_id')}의 example shape 매칭에 실패했습니다."
+    )
+
+
+def _reference_match_score(slot: dict, shape: _TextShapeExtraction) -> float:
+    slot_box = _bbox_tuple(slot)
+    shape_box = (shape.x_emu, shape.y_emu, shape.w_emu, shape.h_emu)
+    if slot_box is None or None in shape_box:
+        return 0.0
+
+    slot_x, slot_y, slot_w, slot_h = slot_box
+    shape_x, shape_y, shape_w, shape_h = shape_box
+    if shape_x is None or shape_y is None or shape_w is None or shape_h is None:
+        return 0.0
+    if min(slot_w, slot_h, shape_w, shape_h) <= 0:
+        return 0.0
+
+    overlap = _intersection_over_union(
+        slot_x, slot_y, slot_w, slot_h, shape_x, shape_y, shape_w, shape_h
+    )
+    center = _center_similarity(
+        slot_x,
+        slot_y,
+        slot_w,
+        slot_h,
+        shape_x,
+        shape_y,
+        shape_w,
+        shape_h,
+    )
+    size = (_axis_similarity(slot_w, shape_w) + _axis_similarity(slot_h, shape_h)) / 2
+    return (overlap * 0.5) + (center * 0.3) + (size * 0.2)
+
+
+def _bbox_tuple(source: dict) -> tuple[int, int, int, int] | None:
+    values = (
+        source.get("x_emu"),
+        source.get("y_emu"),
+        source.get("w_emu"),
+        source.get("h_emu"),
+    )
+    if any(isinstance(value, bool) or not isinstance(value, int) for value in values):
+        return None
+    return values
+
+
+def _intersection_over_union(
+    left_x: int,
+    left_y: int,
+    left_w: int,
+    left_h: int,
+    right_x: int,
+    right_y: int,
+    right_w: int,
+    right_h: int,
+) -> float:
+    overlap_w = max(0, min(left_x + left_w, right_x + right_w) - max(left_x, right_x))
+    overlap_h = max(0, min(left_y + left_h, right_y + right_h) - max(left_y, right_y))
+    intersection = overlap_w * overlap_h
+    union = (left_w * left_h) + (right_w * right_h) - intersection
+    if union <= 0:
+        return 0.0
+    return intersection / union
+
+
+def _center_similarity(
+    left_x: int,
+    left_y: int,
+    left_w: int,
+    left_h: int,
+    right_x: int,
+    right_y: int,
+    right_w: int,
+    right_h: int,
+) -> float:
+    left_center_x = left_x + left_w / 2
+    left_center_y = left_y + left_h / 2
+    right_center_x = right_x + right_w / 2
+    right_center_y = right_y + right_h / 2
+    distance = (
+        (left_center_x - right_center_x) ** 2 + (left_center_y - right_center_y) ** 2
+    ) ** 0.5
+    reference_distance = max((left_w**2 + left_h**2) ** 0.5, 1.0)
+    return max(0.0, 1 - (distance / reference_distance))
+
+
+def _axis_similarity(left: int, right: int) -> float:
+    return min(left, right) / max(left, right)
+
+
+def _shape_id_sort_key(shape_id: str) -> tuple[int, str]:
+    if shape_id.isdigit():
+        return (int(shape_id), shape_id)
+    return (10**9, shape_id)
 
 
 def _shape_id(shape: Element) -> str | None:

--- a/tasks/phase-2-pptx-template-quality/03-reference-shape-matching.md
+++ b/tasks/phase-2-pptx-template-quality/03-reference-shape-matching.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/01-pptx-template-v2-compiler.md"
 depends_on: ["2.02"]
 blocks: ["2.04", "2.05"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -22,23 +23,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] bbox center distance, overlap ratio, size similarity 계산 기준 정리
-- [ ] 예시 텍스트 색상과 줄 수를 검증할 fixture 슬라이드 준비
+- [x] bbox center distance, overlap ratio, size similarity 계산 기준 정리
+- [x] 예시 텍스트 색상과 줄 수를 검증할 fixture 슬라이드 준비
 
 ## 구현 체크리스트
 
-- [ ] runtime editable slot 과 example slide text shape 의 후보 score 계산 구현
-- [ ] `example_text`, `example_char_count`, `example_line_count`, `output_text_color` 추출
-- [ ] 매칭 실패와 낮은 신뢰도를 fail/warning 으로 분리
-- [ ] example slide 를 runtime 후보에서 제외한 `runtime_slides` 작성
-- [ ] `reference.json` 의 `slide_pairs`, `shape_matches` deterministic 생성 테스트 추가
+- [x] runtime editable slot 과 example slide text shape 의 후보 score 계산 구현
+- [x] `example_text`, `example_char_count`, `example_line_count`, `output_text_color` 추출
+- [x] 매칭 실패와 낮은 신뢰도를 fail/warning 으로 분리
+- [x] example slide 를 runtime 후보에서 제외한 `runtime_slides` 작성
+- [x] `reference.json` 의 `slide_pairs`, `shape_matches` deterministic 생성 테스트 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] 예시 슬라이드의 텍스트/줄 수/글자 수/output color 가 reference 로 기록된다
-- [ ] example slide 가 runtime 후보에 포함되지 않는다
-- [ ] editable slot 의 예시 shape 매칭 실패가 계약 오류로 보고된다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] 예시 슬라이드의 텍스트/줄 수/글자 수/output color 가 reference 로 기록된다
+- [x] example slide 가 runtime 후보에 포함되지 않는다
+- [x] editable slot 의 예시 shape 매칭 실패가 계약 오류로 보고된다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -141,6 +141,26 @@ def test_compile_template_v2_extracts_only_exact_red_marker_slots(tmp_path: Path
     ]
     assert reference["slide_pairs"][0]["runtime_slide_number"] == 2
     assert reference["slide_pairs"][0]["example_slide_number"] == 3
+    assert reference["shape_matches"] == [
+        {
+            "example_char_count": 8,
+            "example_line_count": 1,
+            "example_shape_id": "30",
+            "example_shape_name": "Example text",
+            "example_slide_filename": "slide3.xml",
+            "example_slide_index": 2,
+            "example_slide_number": 3,
+            "example_slide_part": "ppt/slides/slide3.xml",
+            "example_text": "실제 프로젝트명",
+            "match_confidence": "high",
+            "match_score": 1.0,
+            "output_text_color": "#123456",
+            "runtime_shape_id": "10",
+            "runtime_slide_index": 1,
+            "runtime_slide_number": 2,
+            "slot_id": "slide2_shape10",
+        }
+    ]
 
     assert len(metadata["slots"]) == 1
     slot = metadata["slots"][0]
@@ -196,6 +216,136 @@ def test_compile_template_v2_reports_mixed_color_run_as_contract_error(
     assert result.updated is False
     assert not (template_dir / "meta.json").exists()
     assert any("non-red run이 섞여 있습니다" in error for error in result.errors)
+
+
+def test_compile_template_v2_reports_reference_match_failure(tmp_path: Path) -> None:
+    """editable slot의 예시 shape 매칭 실패는 계약 오류로 보고한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                _shape_xml(20, "Marker", (_run_xml("경험명", color="FF0000"),)),
+            ),
+            _slide_xml(
+                3,
+                _shape_xml(
+                    30,
+                    "Far example",
+                    (_run_xml("너무 먼 예시", color="123456"),),
+                    x=1000,
+                    y=1000,
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is False
+    assert result.updated is False
+    assert not (template_dir / "reference.json").exists()
+    assert any("example shape 매칭에 실패했습니다" in error for error in result.errors)
+
+
+def test_compile_template_v2_warns_on_low_confidence_reference_match(
+    tmp_path: Path,
+) -> None:
+    """낮은 신뢰도의 example shape 매칭은 warning으로 남기고 reference에는 기록한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                _shape_xml(20, "Marker", (_run_xml("경험명", color="FF0000"),)),
+            ),
+            _slide_xml(
+                3,
+                _shape_xml(
+                    30,
+                    "Shifted example",
+                    (_run_xml("살짝 밀린 예시", color="123456"),),
+                    x=50,
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    assert any("매칭 신뢰도가 낮습니다" in warning for warning in result.warnings)
+    reference = read_json_payload(result.reference_path)
+    assert reference["shape_matches"][0]["match_confidence"] == "low"
+    assert reference["shape_matches"][0]["example_text"] == "살짝 밀린 예시"
+
+
+def test_compile_template_v2_falls_back_when_reference_color_missing(
+    tmp_path: Path,
+) -> None:
+    """example run 색상을 못 가져오면 검정 fallback과 warning을 기록한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                _shape_xml(20, "Marker", (_run_xml("경험명", color="FF0000"),)),
+            ),
+            _slide_xml(
+                3,
+                _shape_xml(30, "Uncolored example", (_run_xml("색상 없는 예시"),)),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    assert any("output_text_color를 찾지 못해 #000000" in warning for warning in result.warnings)
+    reference = read_json_payload(result.reference_path)
+    assert reference["shape_matches"][0]["output_text_color"] == "#000000"
+
+
+def test_compile_template_v2_does_not_overtrust_large_containing_example_shape(
+    tmp_path: Path,
+) -> None:
+    """slot을 포함하는 큰 example shape는 high confidence로 보지 않는다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                _shape_xml(20, "Marker", (_run_xml("경험명", color="FF0000"),)),
+            ),
+            _slide_xml(
+                3,
+                _shape_xml(
+                    30,
+                    "Huge example",
+                    (_run_xml("큰 예시", color="123456"),),
+                    x=-450,
+                    y=-450,
+                    width=1000,
+                    height=1000,
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    reference = read_json_payload(result.reference_path)
+    assert reference["shape_matches"][0]["match_confidence"] == "low"
+    assert reference["shape_matches"][0]["match_score"] < 0.75
 
 
 def test_compile_template_v2_preserves_marker_soft_line_breaks(tmp_path: Path) -> None:
@@ -362,7 +512,18 @@ def _valid_v2_slide_xmls() -> tuple[str, ...]:
                 )
             ),
         ),
-        _slide_xml(3, _shape_xml(30, "Example text", (_run_xml("실제 프로젝트명"),))),
+        _slide_xml(
+            3,
+            _shape_xml(
+                30,
+                "Example text",
+                (_run_xml("실제 프로젝트명", color="123456"),),
+                x=100,
+                y=200,
+                width=300,
+                height=400,
+            ),
+        ),
     )
 
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #258

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- runtime editable slot과 example slide text shape를 bbox 기반 score로 매칭합니다.
- `reference.json.shape_matches`에 example text, char/line count, output text color, match score/confidence를 기록합니다.
- example shape 매칭 실패는 계약 오류로 보고하고 낮은 confidence는 warning으로 남깁니다.
- example run 색상을 못 가져오면 `#000000` fallback과 warning을 기록합니다.
- IoU 기반 overlap score를 사용해 지나치게 큰 example shape가 high confidence로 잡히지 않도록 했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest -q` → `878 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 output_text_color fallback과 bbox score 과신 방지 지적을 반영했습니다.
- `compile_template.py templates/origin --check`는 기존 origin 템플릿의 2.02 mixed-color 오류와 2.03 low-confidence warning을 함께 보고합니다.