### PR TITLE
[PPTX] slot capacity 계약 확장

### DIFF
--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -367,7 +367,7 @@ def _marker_slot_from_shape(
         "kind": "text",
         "editable": True,
         "required": True,
-        "allowed_actions": ["text"],
+        "allowed_actions": ["text", "remove"],
     }
     return _MarkerShapeExtraction(
         slots=(slot,),

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -10,6 +10,14 @@ SCHEMA_VERSION_V2 = 2
 META_JSON_NAME = "meta.json"
 REFERENCE_JSON_NAME = "reference.json"
 TEMPLATE_PPTX_NAME = "template.pptx"
+_DEFAULT_TEXT_MIN_FONT_PT = 10.0
+_DEFAULT_TEXT_FIT_POLICY = "basic_text_area"
+_REFERENCE_SLOT_FIELDS = (
+    "example_text",
+    "example_char_count",
+    "example_line_count",
+    "output_text_color",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,7 +56,10 @@ def build_template_v2_payloads(
         "schema_version": SCHEMA_VERSION_V2,
         "template_id": normalized_template_id,
         "runtime_slides": _json_array(source.runtime_slides, "runtime_slides"),
-        "slots": _json_array(source.slots, "slots"),
+        "slots": _json_array(
+            _enrich_slot_descriptors(source.slots, source.shape_matches),
+            "slots",
+        ),
         "layout_groups": _json_array(source.layout_groups, "layout_groups"),
     }
     reference = {
@@ -131,3 +142,141 @@ def _json_array(items: Sequence[Mapping[str, Any]], field_name: str) -> list[Any
     if not isinstance(normalized, list):
         raise ValueError(f"{field_name} 값은 배열이어야 합니다.")
     return normalized
+
+
+def _enrich_slot_descriptors(
+    slots: Sequence[Mapping[str, Any]],
+    shape_matches: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    matches_by_slot_id = _shape_matches_by_slot_id(shape_matches)
+    return [
+        _enrich_slot_descriptor(
+            slot,
+            matches_by_slot_id.get(str(slot.get("slot_id"))),
+        )
+        for slot in slots
+    ]
+
+
+def _shape_matches_by_slot_id(
+    shape_matches: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    matches_by_slot_id: dict[str, Mapping[str, Any]] = {}
+    for match in shape_matches:
+        if not isinstance(match, Mapping):
+            continue
+        slot_id = match.get("slot_id")
+        if slot_id is None:
+            continue
+        matches_by_slot_id[str(slot_id)] = match
+    return matches_by_slot_id
+
+
+def _enrich_slot_descriptor(
+    slot: Mapping[str, Any],
+    shape_match: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    enriched = dict(slot)
+    if _is_editable_text_slot(enriched):
+        if shape_match is not None:
+            for field_name in _REFERENCE_SLOT_FIELDS:
+                if field_name in shape_match:
+                    enriched[field_name] = shape_match[field_name]
+        _apply_text_capacity_defaults(enriched)
+    elif not _has_allowed_actions(enriched.get("allowed_actions")):
+        enriched["allowed_actions"] = _infer_allowed_actions(enriched)
+    return enriched
+
+
+def _apply_text_capacity_defaults(slot: dict[str, Any]) -> None:
+    if not _has_allowed_actions(slot.get("allowed_actions")):
+        slot["allowed_actions"] = _infer_allowed_actions(slot)
+
+    if _positive_float(slot.get("min_font_pt")) is None:
+        slot["min_font_pt"] = _infer_min_font_pt(slot)
+    if _positive_float(slot.get("max_font_pt")) is None:
+        slot["max_font_pt"] = _infer_max_font_pt(slot)
+    if _positive_int(slot.get("max_lines")) is None:
+        slot["max_lines"] = _infer_max_lines(slot)
+    if not isinstance(slot.get("nowrap"), bool):
+        slot["nowrap"] = _positive_int(slot.get("max_lines")) == 1
+    if not str(slot.get("fit_policy") or "").strip():
+        slot["fit_policy"] = _DEFAULT_TEXT_FIT_POLICY
+
+
+def _is_editable_text_slot(slot: Mapping[str, Any]) -> bool:
+    if slot.get("editable") is False:
+        return False
+    return str(slot.get("kind") or "text").casefold() == "text"
+
+
+def _has_allowed_actions(value: Any) -> bool:
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return bool(value)
+    return False
+
+
+def _infer_allowed_actions(slot: Mapping[str, Any]) -> list[str]:
+    if slot.get("editable") is False:
+        return []
+
+    kind = str(slot.get("kind") or "text").casefold()
+    if kind == "chart":
+        return ["chart"]
+    if kind in {"decorative", "background", "layout", "non_editable"}:
+        return []
+    return ["text", "remove"]
+
+
+def _infer_min_font_pt(slot: Mapping[str, Any]) -> float:
+    font_size_pt = _positive_float(slot.get("font_size_pt"))
+    if font_size_pt is None:
+        return _DEFAULT_TEXT_MIN_FONT_PT
+    return _round_pt(max(_DEFAULT_TEXT_MIN_FONT_PT, font_size_pt * 0.6))
+
+
+def _infer_max_font_pt(slot: Mapping[str, Any]) -> float:
+    font_size_pt = _positive_float(slot.get("font_size_pt"))
+    min_font_pt = _positive_float(slot.get("min_font_pt")) or _infer_min_font_pt(slot)
+    if font_size_pt is None:
+        return min_font_pt
+    return _round_pt(max(font_size_pt, min_font_pt))
+
+
+def _infer_max_lines(slot: Mapping[str, Any]) -> int:
+    example_line_count = _positive_int(slot.get("example_line_count"))
+    if example_line_count is not None:
+        return example_line_count
+
+    placeholder_text = str(slot.get("placeholder_text") or "")
+    if not placeholder_text:
+        return 1
+    return max(1, len(placeholder_text.splitlines()))
+
+
+def _positive_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def _round_pt(value: float) -> float:
+    return round(value, 2)

--- a/tasks/phase-2-pptx-template-quality/05-slot-capacity-contract-enrichment.md
+++ b/tasks/phase-2-pptx-template-quality/05-slot-capacity-contract-enrichment.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/02-pptx-slot-layout-group-inference.md"
 depends_on: ["2.03"]
 blocks: ["2.06", "2.08"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -22,23 +23,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] v2 slot descriptor 필드 목록과 기본값 정책 확인
-- [ ] 기존 LLM Slot descriptor 소비 코드가 unknown field 를 처리하는 방식 확인
+- [x] v2 slot descriptor 필드 목록과 기본값 정책 확인
+- [x] 기존 LLM Slot descriptor 소비 코드가 unknown field 를 처리하는 방식 확인
 
 ## 구현 체크리스트
 
-- [ ] slot 에 `example_text`, `example_char_count`, `example_line_count`, `output_text_color` 병합
-- [ ] `min_font_pt`, `max_font_pt`, `max_lines`, `nowrap`, `fit_policy`, `allowed_actions` 기본 추론 추가
-- [ ] `role_hint` 는 optional 로만 기록하고 누락 가능성을 테스트
-- [ ] v2 slot descriptor serialization 테스트 추가
-- [ ] 기존 `text`/`remove`/`chart` fill action 계약과 충돌하지 않는지 확인
+- [x] slot 에 `example_text`, `example_char_count`, `example_line_count`, `output_text_color` 병합
+- [x] `min_font_pt`, `max_font_pt`, `max_lines`, `nowrap`, `fit_policy`, `allowed_actions` 기본 추론 추가
+- [x] `role_hint` 는 optional 로만 기록하고 누락 가능성을 테스트
+- [x] v2 slot descriptor serialization 테스트 추가
+- [x] 기존 `text`/`remove`/`chart` fill action 계약과 충돌하지 않는지 확인
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] v2 `meta.json` 의 editable slot 이 capacity 필드를 포함한다
-- [ ] `role_hint` 가 없어도 slot payload 와 prompt 생성이 실패하지 않는다
-- [ ] 기존 `currentFills` 구조가 slot capacity 확장으로 변경되지 않는다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] v2 `meta.json` 의 editable slot 이 capacity 필드를 포함한다
+- [x] `role_hint` 가 없어도 slot payload 와 prompt 생성이 실패하지 않는다
+- [x] 기존 `currentFills` 구조가 slot capacity 확장으로 변경되지 않는다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -258,6 +258,73 @@ def test_content_fill_generator_does_not_require_optional_decorative_slot() -> N
     assert prompt_payload["slots"][1]["editable"] is False
 
 
+def test_content_fill_generator_accepts_v2_capacity_slot_without_role_hint() -> None:
+    """role_hint 없는 v2 capacity slot 도 prompt payload 와 fill 검증에서 그대로 통과한다."""
+    llm = FakeLLM([{"fills": {"26": {"action": "text", "text": "OpenAI API"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.create_fills(
+        content_brief="사용 기술을 간결하게 작성",
+        slots=[
+            {
+                "shape_id": "26",
+                "kind": "text",
+                "editable": True,
+                "required": True,
+                "placeholder_text": "사용 기술",
+                "example_text": "OpenAI API",
+                "example_char_count": 10,
+                "example_line_count": 1,
+                "output_text_color": "#000000",
+                "min_font_pt": 10.0,
+                "max_font_pt": 10.0,
+                "max_lines": 1,
+                "nowrap": True,
+                "fit_policy": "basic_text_area",
+                "allowed_actions": ["text", "remove"],
+            },
+        ],
+    )
+
+    assert fills == {"26": {"action": "text", "text": "OpenAI API"}}
+    prompt_payload = json.loads(llm.messages[0][1].content.rsplit("\n", maxsplit=1)[1])
+    slot_payload = prompt_payload["slots"][0]
+    assert "role_hint" not in slot_payload
+    assert slot_payload["placeholder_text"] == "사용 기술"
+    assert slot_payload["example_text"] == "OpenAI API"
+
+
+def test_content_fill_generator_accepts_v2_capacity_remove_without_role_hint() -> None:
+    """role_hint 없는 v2 capacity slot 에서 remove action 도 계약대로 허용한다."""
+    llm = FakeLLM([{"fills": {"26": {"action": "remove"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.create_fills(
+        content_brief="사용 기술이 없으면 제거",
+        slots=[
+            {
+                "shape_id": "26",
+                "kind": "text",
+                "editable": True,
+                "required": False,
+                "placeholder_text": "사용 기술",
+                "example_text": "OpenAI API",
+                "example_char_count": 10,
+                "example_line_count": 1,
+                "output_text_color": "#000000",
+                "min_font_pt": 10.0,
+                "max_font_pt": 10.0,
+                "max_lines": 1,
+                "nowrap": True,
+                "fit_policy": "basic_text_area",
+                "allowed_actions": ["text", "remove"],
+            },
+        ],
+    )
+
+    assert fills == {"26": {"action": "remove"}}
+
+
 def test_content_fill_generator_rejects_fill_for_non_editable_slot() -> None:
     """LLM 이 비편집 slot 을 채우려 하면 적용 전에 거부한다."""
     llm = FakeLLM(

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -55,6 +55,99 @@ def test_v2_payload_writer_generates_deterministic_skeleton(tmp_path: Path) -> N
     assert canonical_json_text(payloads.metadata) == expected_meta
 
 
+def test_v2_payload_writer_enriches_slot_capacity_deterministically() -> None:
+    """reference match를 slot capacity 필드로 병합해 deterministic 하게 직렬화한다."""
+    payloads = build_template_v2_payloads(
+        "ppt-v3",
+        extraction=TemplateV2Extraction(
+            slots=(
+                {
+                    "slot_id": "slide2_shape26",
+                    "shape_id": "26",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "marker_color": "#FF0000",
+                    "placeholder_text": "사용 기술",
+                    "font_size_pt": 10.0,
+                },
+            ),
+            shape_matches=(
+                {
+                    "slot_id": "slide2_shape26",
+                    "example_text": "OpenAI API",
+                    "example_char_count": 10,
+                    "example_line_count": 1,
+                    "output_text_color": "#000000",
+                },
+            ),
+        ),
+    )
+
+    expected_meta = """{
+  "layout_groups": [],
+  "runtime_slides": [],
+  "schema_version": 2,
+  "slots": [
+    {
+      "allowed_actions": [
+        "text",
+        "remove"
+      ],
+      "editable": true,
+      "example_char_count": 10,
+      "example_line_count": 1,
+      "example_text": "OpenAI API",
+      "fit_policy": "basic_text_area",
+      "font_size_pt": 10.0,
+      "kind": "text",
+      "marker_color": "#FF0000",
+      "max_font_pt": 10.0,
+      "max_lines": 1,
+      "min_font_pt": 10.0,
+      "nowrap": true,
+      "output_text_color": "#000000",
+      "placeholder_text": "사용 기술",
+      "required": true,
+      "shape_id": "26",
+      "slot_id": "slide2_shape26"
+    }
+  ],
+  "template_id": "ppt-v3"
+}
+"""
+    assert canonical_json_text(payloads.metadata) == expected_meta
+    assert "role_hint" not in payloads.metadata["slots"][0]
+
+
+def test_v2_payload_writer_preserves_non_text_allowed_action_defaults() -> None:
+    """capacity 확장 후에도 chart/remove/decorative action 계약은 유지한다."""
+    payloads = build_template_v2_payloads(
+        "ppt-v3",
+        extraction=TemplateV2Extraction(
+            slots=(
+                {
+                    "slot_id": "chart_slot",
+                    "shape_id": "8",
+                    "kind": "chart",
+                    "editable": True,
+                    "required": True,
+                },
+                {
+                    "slot_id": "decorative_slot",
+                    "shape_id": "9",
+                    "kind": "decorative",
+                    "editable": False,
+                    "required": False,
+                },
+            )
+        ),
+    )
+
+    assert payloads.metadata["slots"][0]["allowed_actions"] == ["chart"]
+    assert payloads.metadata["slots"][1]["allowed_actions"] == []
+
+
 def test_json_normalized_equal_ignores_key_order_and_detects_semantic_changes() -> None:
     """JSON normalize 비교는 key 순서 차이만 무시하고 의미 차이는 감지한다."""
     left = {"b": 1, "a": [{"z": "value", "y": 2}]}
@@ -165,12 +258,21 @@ def test_compile_template_v2_extracts_only_exact_red_marker_slots(tmp_path: Path
     assert len(metadata["slots"]) == 1
     slot = metadata["slots"][0]
     assert slot == {
-        "allowed_actions": ["text"],
+        "allowed_actions": ["text", "remove"],
         "editable": True,
+        "example_char_count": 8,
+        "example_line_count": 1,
+        "example_text": "실제 프로젝트명",
+        "fit_policy": "basic_text_area",
         "font_size_pt": 18.0,
         "h_emu": 400,
         "kind": "text",
         "marker_color": "#FF0000",
+        "max_font_pt": 18.0,
+        "max_lines": 1,
+        "min_font_pt": 10.8,
+        "nowrap": True,
+        "output_text_color": "#123456",
         "placeholder_text": "프로젝트명",
         "required": True,
         "shape_id": "10",


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #260

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `reference.json.shape_matches`의 example text, char/line count, output text color를 `meta.json.slots`로 병합합니다.
- editable text slot에 `min_font_pt`, `max_font_pt`, `max_lines`, `nowrap`, `fit_policy`, `allowed_actions` capacity 기본값을 채웁니다.
- v2 capacity slot은 `role_hint` 없이도 prompt payload와 fill 검증을 통과하도록 유지했습니다.
- text slot 기본 action 계약을 `text/remove`로 맞추고, chart/decorative slot의 action 계약도 보존합니다.
- PPTX marker slot extractor가 text/remove allowed_actions를 직접 내보내도록 정렬했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest -q` → `882 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 text slot의 `remove` action 계약 누락을 반영했습니다.
- 전체 테스트 병렬 실행 중 `/tmp/folioo-pptx-toolchain-*` 임시 디렉터리 검증 테스트가 서로 간섭해 실패했으나, 단독 재실행에서는 통과했습니다.