### PR TITLE
[PPTX] compile check와 v2 loader fail-fast 추가

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -34,6 +34,7 @@ from features.visualization.pptx import (
 )
 from features.visualization.qa import SlidePreview, VisualQA, VisualQAFixVerifyStep
 from features.visualization.storage.gcs_client import GcsClient, job_workdir, preview_key
+from features.visualization.templates import require_template_v2_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -550,7 +551,7 @@ class VisualizationTaskService:
                         "템플릿 파일을 가져오지 못했습니다.",
                         error_code="TEMPLATE_FETCH_FAILED",
                     ) from exc
-                template_metadata = _load_json_object(template_meta_path)
+                template_metadata = _load_template_metadata(template_meta_path)
 
                 try:
                     slide_plan = await asyncio.to_thread(
@@ -1084,6 +1085,18 @@ def _load_json_object(path: Path) -> dict[str, Any]:
     if not isinstance(loaded, dict):
         raise ValueError(f"JSON 최상위 값은 객체여야 합니다: {path}")
     return loaded
+
+
+def _load_template_metadata(path: Path) -> dict[str, Any]:
+    metadata = _load_json_object(path)
+    try:
+        require_template_v2_metadata(metadata)
+    except ValueError as exc:
+        raise _PipelineFatalError(
+            str(exc),
+            error_code="TEMPLATE_METADATA_SCHEMA_INVALID",
+        ) from exc
+    return metadata
 
 
 def _registered_slides_by_order(

--- a/features/visualization/agents/generation.py
+++ b/features/visualization/agents/generation.py
@@ -12,6 +12,18 @@ from langchain_core.messages import HumanMessage, SystemMessage
 
 from common.llm.client import get_llm_uncached
 from features.visualization.agents.schemas import FillPayloadOutput, SlidePlanOutput
+from features.visualization.templates import require_template_v2_metadata
+
+_FALLBACK_RUNTIME_CATEGORIES = (
+    "toc",
+    "overview",
+    "problem",
+    "process",
+    "outcome",
+    "chart",
+    "visual",
+    "text",
+)
 
 _PLAN_SYSTEM_PROMPT = """포트폴리오 PPT 구성을 설계하는 전문가입니다.
 응답은 반드시 JSON 객체 하나로만 작성하세요.
@@ -166,10 +178,13 @@ class SourceSlide:
     category: str
     description: str
     best_for: str
+    slide_filename_override: str = ""
 
     @property
     def slide_filename(self) -> str:
         """PPTX 내부 slide XML 파일명."""
+        if self.slide_filename_override:
+            return self.slide_filename_override
         return f"slide{self.slide_index + 1}.xml"
 
 
@@ -350,9 +365,21 @@ class LLMSlideChangeGenerator:
 
 def parse_template_metadata(metadata: Mapping[str, Any]) -> tuple[SourceSlide, ...]:
     """meta.json 객체에서 SourceSlide 목록을 추출한다."""
+    require_template_v2_metadata(metadata)
+
     raw_slides = metadata.get("slides")
-    if not isinstance(raw_slides, list):
-        raise ValueError("template meta.json 에 slides 배열이 필요합니다.")
+    if isinstance(raw_slides, list):
+        return _parse_source_slides(raw_slides)
+
+    raw_runtime_slides = metadata.get("runtime_slides")
+    if not isinstance(raw_runtime_slides, list):
+        raise ValueError("template meta.json 에 runtime_slides 배열이 필요합니다.")
+
+    return _parse_runtime_source_slides(raw_runtime_slides)
+
+
+def _parse_source_slides(raw_slides: list[Any]) -> tuple[SourceSlide, ...]:
+    """slides 배열에서 SourceSlide 목록을 추출한다."""
 
     slides: list[SourceSlide] = []
     for index, raw_slide in enumerate(raw_slides):
@@ -378,6 +405,76 @@ def parse_template_metadata(metadata: Mapping[str, Any]) -> tuple[SourceSlide, .
         )
 
     return tuple(slides)
+
+
+def _parse_runtime_source_slides(raw_slides: list[Any]) -> tuple[SourceSlide, ...]:
+    """v2 runtime_slides 배열에서 최소 SourceSlide 목록을 추출한다."""
+    slides: list[SourceSlide] = []
+    last_index = len(raw_slides) - 1
+    for index, raw_slide in enumerate(raw_slides):
+        if not isinstance(raw_slide, Mapping):
+            raise ValueError(f"runtime_slides[{index}] 항목은 객체여야 합니다.")
+        try:
+            slide_index = int(raw_slide["slide_index"])
+        except KeyError as exc:
+            raise ValueError(
+                f"runtime_slides[{index}] 필수 필드가 없습니다: {exc.args[0]}"
+            ) from exc
+
+        slide_number = slide_index + 1
+        slide_filename = _runtime_slide_filename(raw_slide, slide_number)
+        category = _metadata_text(raw_slide, "category") or _fallback_runtime_category(
+            index,
+            last_index,
+        )
+        slides.append(
+            SourceSlide(
+                slide_index=slide_index,
+                source_slide_id=(
+                    _metadata_text(raw_slide, "id")
+                    or _metadata_text(raw_slide, "source_slide_id")
+                    or f"slide{slide_number}"
+                ),
+                category=category,
+                description=(
+                    _metadata_text(raw_slide, "description") or f"Runtime slide {slide_number}"
+                ),
+                best_for=_metadata_text(raw_slide, "best_for") or category,
+                slide_filename_override=slide_filename,
+            )
+        )
+    return tuple(slides)
+
+
+def _metadata_text(metadata: Mapping[str, Any], field: str) -> str:
+    value = metadata.get(field)
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _runtime_slide_filename(metadata: Mapping[str, Any], slide_number: int) -> str:
+    slide_filename = _metadata_text(metadata, "slide_filename")
+    if slide_filename:
+        return _basename(slide_filename)
+
+    slide_part = _metadata_text(metadata, "slide_part")
+    if slide_part:
+        return _basename(slide_part)
+
+    return f"slide{slide_number}.xml"
+
+
+def _basename(path: str) -> str:
+    return path.replace("\\", "/").rstrip("/").rsplit("/", maxsplit=1)[-1]
+
+
+def _fallback_runtime_category(index: int, last_index: int) -> str:
+    if index == 0:
+        return "cover"
+    if index == last_index:
+        return "closing"
+    return _FALLBACK_RUNTIME_CATEGORIES[(index - 1) % len(_FALLBACK_RUNTIME_CATEGORIES)]
 
 
 def prefilter_source_slides(

--- a/features/visualization/templates/__init__.py
+++ b/features/visualization/templates/__init__.py
@@ -28,6 +28,7 @@ from .v2 import (
     json_normalized_equal,
     normalize_json,
     read_json_payload,
+    require_template_v2_metadata,
     write_json_payload,
 )
 from .validation import TemplateValidationResult, validate_template_directory
@@ -60,6 +61,7 @@ __all__ = [
     "load_category_schema",
     "normalize_json",
     "read_json_payload",
+    "require_template_v2_metadata",
     "validate_template_directory",
     "write_json_payload",
 ]

--- a/features/visualization/templates/compiler_v2.py
+++ b/features/visualization/templates/compiler_v2.py
@@ -46,6 +46,8 @@ def compile_template_v2(
     _validate_template_dir(root)
 
     target_dir = Path(output_dir) if output_dir is not None else root
+    if output_dir is not None:
+        _validate_output_dir(root, target_dir)
     source_extraction = extraction or extract_template_v2_from_pptx(root / TEMPLATE_PPTX_NAME)
     meta_path = target_dir / META_JSON_NAME
     reference_path = target_dir / REFERENCE_JSON_NAME
@@ -96,6 +98,16 @@ def _validate_template_dir(template_dir: Path) -> None:
     template_pptx = template_dir / TEMPLATE_PPTX_NAME
     if not template_pptx.is_file():
         raise ValueError(f"template.pptx 파일을 찾을 수 없습니다: {template_pptx}")
+
+
+def _validate_output_dir(template_dir: Path, output_dir: Path) -> None:
+    resolved_template_dir = template_dir.resolve()
+    resolved_output_dir = output_dir.resolve()
+    if resolved_output_dir == resolved_template_dir or resolved_template_dir in (
+        resolved_output_dir,
+        *resolved_output_dir.parents,
+    ):
+        raise ValueError("--out 출력 디렉터리는 원본 template dir 밖의 별도 디렉터리여야 합니다.")
 
 
 def _check_json_file(path: Path, expected_payload: dict, label: str) -> str | None:

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -93,6 +93,15 @@ def read_json_payload(path: Path | str) -> Any:
         raise ValueError(f"JSON 형식이 올바르지 않습니다: {source_path}") from exc
 
 
+def require_template_v2_metadata(metadata: Mapping[str, Any]) -> None:
+    """런타임에서 v2 template meta.json 만 허용한다."""
+    schema_version = metadata.get("schema_version")
+    if schema_version != SCHEMA_VERSION_V2:
+        raise ValueError(
+            f"template meta.json schema_version은 2여야 합니다. 현재 값: {schema_version!r}"
+        )
+
+
 def normalize_json(value: Any) -> Any:
     """JSON 값을 비교 가능한 canonical 구조로 정규화한다."""
     if isinstance(value, Mapping):

--- a/tasks/phase-2-pptx-template-quality/04-compile-template-cli-check-runtime-loader.md
+++ b/tasks/phase-2-pptx-template-quality/04-compile-template-cli-check-runtime-loader.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/01-pptx-template-v2-compiler.md"
 depends_on: ["2.03"]
 blocks: ["2.14", "2.16"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -22,23 +23,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 기존 generation pipeline 의 meta.json 로딩 지점 확인
-- [ ] `--out` 출력 디렉터리와 기본 템플릿 디렉터리 갱신 정책 확인
+- [x] 기존 generation pipeline 의 meta.json 로딩 지점 확인
+- [x] `--out` 출력 디렉터리와 기본 템플릿 디렉터리 갱신 정책 확인
 
 ## 구현 체크리스트
 
-- [ ] `compile_template.py` 기본 실행이 template dir 의 `meta.json`/`reference.json` 을 갱신하도록 연결
-- [ ] `--out` 실행은 별도 디렉터리에 산출물을 기록하고 원본 디렉터리를 변경하지 않도록 구현
-- [ ] `--check` 는 현재 산출물과 새 산출물의 normalized JSON 을 비교해 exit code 를 반환
-- [ ] 런타임 템플릿 로더에서 `schema_version == 2` 가 아니면 fail fast 하도록 변경
-- [ ] 기존 v1 meta 사용 경로가 실패 메시지를 명확히 내는지 테스트 추가
+- [x] `compile_template.py` 기본 실행이 template dir 의 `meta.json`/`reference.json` 을 갱신하도록 연결
+- [x] `--out` 실행은 별도 디렉터리에 산출물을 기록하고 원본 디렉터리를 변경하지 않도록 구현
+- [x] `--check` 는 현재 산출물과 새 산출물의 normalized JSON 을 비교해 exit code 를 반환
+- [x] 런타임 템플릿 로더에서 `schema_version == 2` 가 아니면 fail fast 하도록 변경
+- [x] 기존 v1 meta 사용 경로가 실패 메시지를 명확히 내는지 테스트 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] `docs/ppt-v3.pptx` 기반으로 신규 등록한 템플릿 디렉터리에서 산출물이 최신이면 `compile_template.py <template_dir> --check` 가 성공한다
-- [ ] 산출물이 다르면 `--check` 가 non-zero 로 실패한다
-- [ ] `schema_version` 누락 또는 2가 아닌 `meta.json` 은 런타임에서 즉시 실패한다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] `docs/ppt-v3.pptx` 기반으로 신규 등록한 템플릿 디렉터리에서 산출물이 최신이면 `compile_template.py <template_dir> --check` 가 성공한다
+- [x] 산출물이 다르면 `--check` 가 non-zero 로 실패한다
+- [x] `schema_version` 누락 또는 2가 아닌 `meta.json` 은 런타임에서 즉시 실패한다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -605,6 +605,125 @@ def test_parse_template_metadata_derives_slide_filenames() -> None:
     assert slides[-1].slide_filename == "slide7.xml"
 
 
+@pytest.mark.parametrize("metadata", [{"slides": []}, {"schema_version": 1, "slides": []}])
+def test_parse_template_metadata_rejects_non_v2_schema(metadata: dict[str, object]) -> None:
+    """schema_version 누락 또는 v2가 아닌 meta.json은 런타임에서 즉시 거부한다."""
+    with pytest.raises(ValueError, match="schema_version은 2"):
+        parse_template_metadata(metadata)
+
+
+def test_parse_template_metadata_supports_v2_runtime_slides() -> None:
+    """v2 compiler 산출물의 runtime_slides를 기본 SourceSlide 후보로 변환한다."""
+    slides = parse_template_metadata(
+        {
+            "schema_version": 2,
+            "template_id": "ppt-v3",
+            "runtime_slides": [
+                {
+                    "slide_index": 1,
+                    "slide_number": 2,
+                    "slide_filename": "slide2.xml",
+                    "slide_part": "ppt/slides/slide2.xml",
+                },
+                {
+                    "slide_index": 3,
+                    "slide_number": 4,
+                    "slide_filename": "slide4.xml",
+                    "slide_part": "ppt/slides/slide4.xml",
+                },
+            ],
+        }
+    )
+
+    assert [slide.source_slide_id for slide in slides] == ["slide2", "slide4"]
+    assert [slide.category for slide in slides] == ["cover", "closing"]
+    assert [slide.slide_filename for slide in slides] == ["slide2.xml", "slide4.xml"]
+
+
+def test_parse_template_metadata_prefers_runtime_slide_filename() -> None:
+    """runtime_slides는 slide_index 유도값 대신 compiler가 저장한 실제 slide part를 쓴다."""
+    slides = parse_template_metadata(
+        {
+            "schema_version": 2,
+            "template_id": "ppt-v3",
+            "runtime_slides": [
+                {
+                    "slide_index": 10,
+                    "slide_number": 11,
+                    "slide_filename": "slide2.xml",
+                    "slide_part": "ppt/slides/slide2.xml",
+                },
+                {
+                    "slide_index": 11,
+                    "slide_number": 12,
+                    "slide_part": "ppt/slides/slide99.xml",
+                },
+            ],
+        }
+    )
+
+    assert [slide.source_slide_id for slide in slides] == ["slide11", "slide12"]
+    assert [slide.slide_filename for slide in slides] == ["slide2.xml", "slide99.xml"]
+
+
+def test_slide_plan_generator_accepts_compiler_runtime_slides_only() -> None:
+    """compiler-shaped runtime_slides 만 있어도 fallback category로 7장 plan을 통과시킨다."""
+    llm = FakeLLM(
+        [
+            {
+                "total_slides": 7,
+                "slide_plan": [
+                    _plan_item(1, "slide2"),
+                    _plan_item(2, "slide4"),
+                    _plan_item(3, "slide6"),
+                    _plan_item(4, "slide8"),
+                    _plan_item(5, "slide10"),
+                    _plan_item(6, "slide12"),
+                    _plan_item(7, "slide14"),
+                ],
+            }
+        ]
+    )
+    generator = LLMSlidePlanGenerator(llm=llm)
+
+    plan = generator.create_plan(
+        portfolio_text="Folioo 프로젝트에서 전환율을 42% 개선했습니다.",
+        template_metadata={
+            "schema_version": 2,
+            "template_id": "ppt-v3",
+            "runtime_slides": [
+                {
+                    "slide_index": index,
+                    "slide_number": index + 1,
+                    "slide_filename": f"slide{index + 1}.xml",
+                    "slide_part": f"ppt/slides/slide{index + 1}.xml",
+                }
+                for index in (1, 3, 5, 7, 9, 11, 13)
+            ],
+        },
+    )
+
+    assert plan.total_slides == 7
+    assert [slide.category for slide in plan.selected_slides] == [
+        "cover",
+        "toc",
+        "overview",
+        "problem",
+        "process",
+        "outcome",
+        "closing",
+    ]
+    assert [slide.slide_filename for slide in plan.selected_slides] == [
+        "slide2.xml",
+        "slide4.xml",
+        "slide6.xml",
+        "slide8.xml",
+        "slide10.xml",
+        "slide12.xml",
+        "slide14.xml",
+    ]
+
+
 def _plan_item(order: int, source_slide_id: str) -> dict[str, object]:
     return {
         "order": order,
@@ -658,6 +777,7 @@ def _template_meta(
         for index, slide in enumerate(slides):
             slide["slide_index"] = index
     return {
+        "schema_version": 2,
         "template_id": "blue",
         "template_file": "template.pptx",
         "slides": slides,

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -416,6 +416,23 @@ def test_compile_template_cli_out_writes_separate_output_dir(tmp_path: Path) -> 
     assert not (template_dir / "reference.json").exists()
 
 
+def test_compile_template_cli_out_rejects_template_dir_descendant(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--out 은 원본 template dir 내부에 산출물을 쓰지 못한다."""
+    template_dir = _make_template_dir(tmp_path, "ppt-v3")
+    output_dir = template_dir / "compiled"
+
+    assert compile_template_main([str(template_dir), "--out", str(output_dir)]) == 1
+
+    captured = capsys.readouterr()
+    assert "--out 출력 디렉터리" in captured.err
+    assert not output_dir.exists()
+    assert not (template_dir / "meta.json").exists()
+    assert not (template_dir / "reference.json").exists()
+
+
 def test_compile_template_cli_check_uses_normalized_json(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -145,7 +145,12 @@ class FakeMainClient:
 class FakeStorage:
     """GCS 클라이언트 대역."""
 
-    def __init__(self) -> None:
+    def __init__(self, template_metadata: dict[str, Any] | None = None) -> None:
+        self.template_metadata = template_metadata or {
+            "schema_version": 2,
+            "template_id": "blue",
+            "runtime_slides": [],
+        }
         self.download_error: Exception | None = None
         self.attempt_pptx_error: Exception | None = None
         self.downloaded_pptx: list[tuple[str, Path]] = []
@@ -165,7 +170,7 @@ class FakeStorage:
     def download_template_meta(self, template_id: str, dest: Path) -> None:
         assert template_id == "blue"
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(json.dumps({"slides": []}), encoding="utf-8")
+        dest.write_text(json.dumps(self.template_metadata), encoding="utf-8")
 
     def download_pptx(self, job_id: str, dest: Path) -> None:
         if self.download_error is not None:
@@ -477,6 +482,21 @@ async def test_generate_pipeline_success_sends_callbacks_and_uploads_outputs() -
     assert context.storage.uploaded_pdf
     assert len(context.toolchain.pack_calls) == 1
     assert len(context.renderer.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_pipeline_rejects_non_v2_template_meta() -> None:
+    """schema_version 이 v2가 아닌 meta.json은 generation pipeline에서 즉시 실패한다."""
+    context = PipelineContext()
+    context.storage.template_metadata = {"schema_version": 1, "slides": []}
+
+    await context.service.generate(_task())
+
+    assert context.main_client.slide_plan_requests == []
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 0, "failed": 1}
+    assert context.main_client.job_events[-1]["error_code"] == "TEMPLATE_METADATA_SCHEMA_INVALID"
+    assert context.toolchain.unpack_calls == []
+    assert context.storage.uploaded_pptx == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #259

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 런타임에서 `meta.json.schema_version == 2`만 허용하도록 fail-fast 검증을 추가했습니다.
- v2 compiler 산출물처럼 `slides` 없이 `runtime_slides`만 있는 metadata도 slide plan 입력으로 변환합니다.
- `runtime_slides.slide_filename`/`slide_part`를 보존해 PPTX part 파일명이 presentation 순서와 달라도 downstream이 실제 slide XML을 선택합니다.
- `runtime_slides` fallback category를 표준 enum 기반으로 분산해 7장 이상 계획에서도 연속 category 검증을 통과하도록 했습니다.
- `compile_template_v2 --out`이 템플릿 디렉터리 자체 또는 하위 경로를 가리키면 즉시 거부합니다.
- pptx-worker generation pipeline에서도 schema mismatch를 `TEMPLATE_METADATA_SCHEMA_INVALID` fatal error로 분류합니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest -q` → `885 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 runtime_slides category fallback과 실제 slide_filename 보존 문제를 반영했습니다.
- 전체 테스트 병렬 실행 중 `/tmp/folioo-pptx-toolchain-*` 임시 디렉터리 검증 테스트가 서로 간섭해 실패했으나, 단독 재실행에서는 통과했습니다.