### PR TITLE
[PPTX] background/container shape 추론 추가

### DIFF
--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -23,6 +23,17 @@ _EXACT_MARKER_COLOR = "#FF0000"
 _REFERENCE_COLOR_FALLBACK = "#000000"
 _REFERENCE_MATCH_FAIL_SCORE = 0.3
 _REFERENCE_MATCH_LOW_CONFIDENCE_SCORE = 0.75
+_ITEM_BACKGROUND_MIN_SCORE = 0.72
+_ITEM_BACKGROUND_MIN_SLOT_COVERAGE = 0.75
+_ITEM_BACKGROUND_AMBIGUOUS_SLOT_COVERAGE = 0.45
+_ITEM_BACKGROUND_MAX_WIDTH_RATIO = 2.5
+_ITEM_BACKGROUND_MAX_HEIGHT_RATIO = 2.5
+_ITEM_BACKGROUND_MAX_AREA_RATIO = 5.0
+_CONTAINER_MIN_SLOT_COVERAGE = 0.85
+_CONTAINER_MIN_SLOT_COUNT = 2
+_CONTAINER_MIN_MAX_SLOT_AREA_RATIO = 3.0
+_CONTAINER_MIN_UNION_AREA_RATIO = 1.05
+_CONTAINER_MAX_UNION_AREA_RATIO = 8.0
 
 
 @dataclass(frozen=True)
@@ -56,6 +67,18 @@ class _TextShapeExtraction:
     line_count: int
     char_count: int
     output_text_color: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimeShapeGeometry:
+    """runtime slide의 무텍스트 shape geometry."""
+
+    shape_id: str
+    shape_name: str
+    x_emu: int
+    y_emu: int
+    w_emu: int
+    h_emu: int
 
 
 def count_pptx_slides(pptx_path: Path | str) -> int:
@@ -99,6 +122,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
     runtime_slides: list[dict] = []
     slide_pairs: list[dict] = []
     shape_matches: list[dict] = []
+    shape_inferences: list[dict] = []
     slots: list[dict] = []
     errors: list[str] = []
     warnings: list[str] = []
@@ -151,6 +175,13 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
             )
             slots.extend(marker_result.slots)
             errors.extend(marker_result.errors)
+            inferred_shapes, shape_warnings = _infer_runtime_shape_relationships(
+                marker_result.slots,
+                _extract_non_text_shapes_from_slide(root),
+                runtime_slide_number=slide_number,
+            )
+            shape_inferences.extend(inferred_shapes)
+            warnings.extend(shape_warnings)
             if not marker_result.slots and not marker_result.has_marker_candidate:
                 errors.append(
                     f"runtime slide {slide_number}에 정확한 #FF0000 editable marker가 없습니다."
@@ -183,6 +214,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
         layout_groups=(),
         slide_pairs=tuple(slide_pairs),
         shape_matches=tuple(shape_matches),
+        shape_inferences=tuple(shape_inferences),
         errors=tuple(errors),
         warnings=tuple(warnings),
     )
@@ -428,6 +460,370 @@ def _text_shape_from_shape(shape: Element) -> _TextShapeExtraction | None:
     )
 
 
+def _extract_non_text_shapes_from_slide(
+    slide_root: Element,
+) -> tuple[_RuntimeShapeGeometry, ...]:
+    shapes: list[_RuntimeShapeGeometry] = []
+    for shape in slide_root.findall(f".//{{{_PRESENTATION_NS}}}sp"):
+        if _shape_has_visible_text(shape):
+            continue
+        geometry = _runtime_shape_geometry_from_shape(shape)
+        if geometry is not None:
+            shapes.append(geometry)
+    return tuple(shapes)
+
+
+def _shape_has_visible_text(shape: Element) -> bool:
+    return any(
+        bool((text_node.text or "").strip())
+        for text_node in shape.findall(f".//{{{_DRAWINGML_NS}}}t")
+    )
+
+
+def _runtime_shape_geometry_from_shape(shape: Element) -> _RuntimeShapeGeometry | None:
+    coordinates = _coordinates(shape)
+    x_emu = coordinates["x_emu"]
+    y_emu = coordinates["y_emu"]
+    w_emu = coordinates["w_emu"]
+    h_emu = coordinates["h_emu"]
+    if x_emu is None or y_emu is None or w_emu is None or h_emu is None:
+        return None
+    if min(w_emu, h_emu) <= 0:
+        return None
+    return _RuntimeShapeGeometry(
+        shape_id=_shape_id(shape) or "",
+        shape_name=_shape_name(shape),
+        x_emu=x_emu,
+        y_emu=y_emu,
+        w_emu=w_emu,
+        h_emu=h_emu,
+    )
+
+
+def _infer_runtime_shape_relationships(
+    slots: tuple[dict, ...],
+    non_text_shapes: tuple[_RuntimeShapeGeometry, ...],
+    *,
+    runtime_slide_number: int,
+) -> tuple[list[dict], list[str]]:
+    text_slots = tuple(slot for slot in slots if _bbox_tuple(slot) is not None)
+    if not text_slots or not non_text_shapes:
+        return [], []
+
+    container_inferences = _infer_container_shape_inferences(
+        text_slots,
+        non_text_shapes,
+        runtime_slide_number=runtime_slide_number,
+    )
+    container_shape_ids = {
+        str(inference.get("shape_id"))
+        for inference in container_inferences
+        if inference.get("shape_id") is not None
+    }
+    item_inferences, item_warnings = _infer_item_background_inferences(
+        text_slots,
+        non_text_shapes,
+        excluded_shape_ids=container_shape_ids,
+        runtime_slide_number=runtime_slide_number,
+    )
+    return [*container_inferences, *item_inferences], item_warnings
+
+
+def _infer_container_shape_inferences(
+    slots: tuple[dict, ...],
+    non_text_shapes: tuple[_RuntimeShapeGeometry, ...],
+    *,
+    runtime_slide_number: int,
+) -> list[dict]:
+    inferences: list[dict] = []
+    for shape in non_text_shapes:
+        contained_slots = _container_contained_slots(slots, shape)
+        if len(contained_slots) < _CONTAINER_MIN_SLOT_COUNT:
+            continue
+
+        score = _container_shape_score(contained_slots, shape)
+        if score is None:
+            continue
+
+        inference = _shape_inference_base(
+            "container_shape",
+            shape,
+            runtime_slide_index=_runtime_slide_index(contained_slots),
+            runtime_slide_number=runtime_slide_number,
+        )
+        inference.update(
+            {
+                "contained_slot_ids": [
+                    str(slot.get("slot_id")) for slot in _sort_slots_by_position(contained_slots)
+                ],
+                "match_score": score,
+                "resize_linked": False,
+                "allowed_actions": [],
+            }
+        )
+        inferences.append(inference)
+    return inferences
+
+
+def _container_contained_slots(
+    slots: tuple[dict, ...],
+    shape: _RuntimeShapeGeometry,
+) -> tuple[dict, ...]:
+    contained: list[dict] = []
+    for slot in slots:
+        slot_box = _bbox_tuple(slot)
+        if slot_box is None:
+            continue
+        if _box_coverage(slot_box, _shape_bbox(shape)) >= _CONTAINER_MIN_SLOT_COVERAGE:
+            contained.append(slot)
+    return tuple(contained)
+
+
+def _container_shape_score(
+    contained_slots: tuple[dict, ...],
+    shape: _RuntimeShapeGeometry,
+) -> float | None:
+    shape_box = _shape_bbox(shape)
+    shape_area = _box_area(shape_box)
+    slot_boxes = tuple(box for slot in contained_slots if (box := _bbox_tuple(slot)) is not None)
+    if not slot_boxes:
+        return None
+
+    max_slot_area = max(_box_area(slot_box) for slot_box in slot_boxes)
+    if shape_area < max_slot_area * _CONTAINER_MIN_MAX_SLOT_AREA_RATIO:
+        return None
+
+    union_box = _union_bbox(slot_boxes)
+    if union_box is None:
+        return None
+    union_area = _box_area(union_box)
+    if union_area <= 0:
+        return None
+    if shape_area < union_area * _CONTAINER_MIN_UNION_AREA_RATIO:
+        return None
+    if shape_area > union_area * _CONTAINER_MAX_UNION_AREA_RATIO:
+        return None
+
+    coverage_sum = sum(_box_coverage(slot_box, shape_box) for slot_box in slot_boxes)
+    average_slot_coverage = coverage_sum / len(slot_boxes)
+    union_coverage = _box_coverage(union_box, shape_box)
+    return round((average_slot_coverage * 0.7) + (union_coverage * 0.3), 4)
+
+
+def _infer_item_background_inferences(
+    slots: tuple[dict, ...],
+    non_text_shapes: tuple[_RuntimeShapeGeometry, ...],
+    *,
+    excluded_shape_ids: set[str],
+    runtime_slide_number: int,
+) -> tuple[list[dict], list[str]]:
+    warnings: list[str] = []
+    inferences: list[dict] = []
+    candidates_by_slot_id: dict[str, list[tuple[float, _RuntimeShapeGeometry, dict]]] = {}
+
+    for shape in non_text_shapes:
+        if shape.shape_id in excluded_shape_ids:
+            continue
+
+        overlapping_slots = _background_overlapping_slots(slots, shape)
+        candidate_scores = [
+            (score, slot)
+            for slot in slots
+            if (score := _item_background_score(slot, shape)) >= _ITEM_BACKGROUND_MIN_SCORE
+        ]
+        if len(overlapping_slots) >= 2 and candidate_scores:
+            ambiguous_slots = _sort_slots_by_position(overlapping_slots)
+            inferences.append(
+                _ambiguous_item_background_inference(
+                    shape,
+                    ambiguous_slots,
+                    max(score for score, _slot in candidate_scores),
+                    runtime_slide_number=runtime_slide_number,
+                )
+            )
+            warnings.append(
+                "runtime slide "
+                f"{runtime_slide_number} shape {shape.shape_id}가 여러 text slot "
+                f"({_slot_id_list_text(ambiguous_slots)})과 겹쳐 item_background 연결을 "
+                "건너뜁니다."
+            )
+            continue
+
+        for score, slot in candidate_scores:
+            slot_id = str(slot.get("slot_id"))
+            candidates_by_slot_id.setdefault(slot_id, []).append((score, shape, slot))
+
+    pending_by_shape_id: dict[str, list[tuple[float, _RuntimeShapeGeometry, dict]]] = {}
+    for slot_id, candidates in candidates_by_slot_id.items():
+        del slot_id
+        candidates.sort(key=lambda item: (-item[0], _shape_id_sort_key(item[1].shape_id)))
+        score, shape, slot = candidates[0]
+        pending_by_shape_id.setdefault(shape.shape_id, []).append((score, shape, slot))
+
+    for shape_id, links in pending_by_shape_id.items():
+        if len(links) >= 2:
+            slots_for_shape = _sort_slots_by_position(tuple(slot for _score, _shape, slot in links))
+            best_score = max(score for score, _shape, _slot in links)
+            shape = links[0][1]
+            inferences.append(
+                _ambiguous_item_background_inference(
+                    shape,
+                    slots_for_shape,
+                    best_score,
+                    runtime_slide_number=runtime_slide_number,
+                )
+            )
+            warnings.append(
+                "runtime slide "
+                f"{runtime_slide_number} shape {shape_id}가 여러 text slot "
+                f"({_slot_id_list_text(slots_for_shape)})의 item_background 후보라 연결을 "
+                "건너뜁니다."
+            )
+            continue
+
+        score, shape, slot = links[0]
+        inference = _shape_inference_base(
+            "item_background",
+            shape,
+            runtime_slide_index=slot.get("slide_index"),
+            runtime_slide_number=runtime_slide_number,
+        )
+        inference.update(
+            {
+                "slot_id": slot.get("slot_id"),
+                "slot_shape_id": slot.get("shape_id"),
+                "match_score": round(score, 4),
+                "resize_linked": True,
+            }
+        )
+        inferences.append(inference)
+
+    return inferences, warnings
+
+
+def _background_overlapping_slots(
+    slots: tuple[dict, ...],
+    shape: _RuntimeShapeGeometry,
+) -> tuple[dict, ...]:
+    overlapping: list[dict] = []
+    shape_box = _shape_bbox(shape)
+    for slot in slots:
+        slot_box = _bbox_tuple(slot)
+        if slot_box is None:
+            continue
+        if _box_coverage(slot_box, shape_box) >= _ITEM_BACKGROUND_AMBIGUOUS_SLOT_COVERAGE:
+            overlapping.append(slot)
+    return tuple(overlapping)
+
+
+def _item_background_score(slot: dict, shape: _RuntimeShapeGeometry) -> float:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return 0.0
+
+    slot_x, slot_y, slot_w, slot_h = slot_box
+    shape_x, shape_y, shape_w, shape_h = _shape_bbox(shape)
+    if min(slot_w, slot_h, shape_w, shape_h) <= 0:
+        return 0.0
+
+    slot_area = _box_area(slot_box)
+    shape_area = _box_area(_shape_bbox(shape))
+    if slot_area <= 0 or shape_area <= 0:
+        return 0.0
+    if shape_w / slot_w > _ITEM_BACKGROUND_MAX_WIDTH_RATIO:
+        return 0.0
+    if shape_h / slot_h > _ITEM_BACKGROUND_MAX_HEIGHT_RATIO:
+        return 0.0
+    if shape_area / slot_area > _ITEM_BACKGROUND_MAX_AREA_RATIO:
+        return 0.0
+
+    slot_coverage = _box_coverage(slot_box, _shape_bbox(shape))
+    if slot_coverage < _ITEM_BACKGROUND_MIN_SLOT_COVERAGE:
+        return 0.0
+
+    center = _center_similarity(
+        slot_x,
+        slot_y,
+        slot_w,
+        slot_h,
+        shape_x,
+        shape_y,
+        shape_w,
+        shape_h,
+    )
+    size = (_axis_similarity(slot_w, shape_w) + _axis_similarity(slot_h, shape_h)) / 2
+    return (slot_coverage * 0.45) + (center * 0.35) + (size * 0.2)
+
+
+def _ambiguous_item_background_inference(
+    shape: _RuntimeShapeGeometry,
+    slots: tuple[dict, ...],
+    score: float,
+    *,
+    runtime_slide_number: int,
+) -> dict:
+    inference = _shape_inference_base(
+        "ambiguous_item_background",
+        shape,
+        runtime_slide_index=_runtime_slide_index(slots),
+        runtime_slide_number=runtime_slide_number,
+    )
+    inference.update(
+        {
+            "candidate_slot_ids": [str(slot.get("slot_id")) for slot in slots],
+            "match_score": round(score, 4),
+            "resize_linked": False,
+            "allowed_actions": [],
+        }
+    )
+    return inference
+
+
+def _shape_inference_base(
+    inference_type: str,
+    shape: _RuntimeShapeGeometry,
+    *,
+    runtime_slide_index: int | None,
+    runtime_slide_number: int,
+) -> dict:
+    return {
+        "inference_type": inference_type,
+        "runtime_slide_index": runtime_slide_index,
+        "runtime_slide_number": runtime_slide_number,
+        "shape_id": shape.shape_id,
+        "shape_name": shape.shape_name,
+        "x_emu": shape.x_emu,
+        "y_emu": shape.y_emu,
+        "w_emu": shape.w_emu,
+        "h_emu": shape.h_emu,
+    }
+
+
+def _runtime_slide_index(slots: tuple[dict, ...]) -> int | None:
+    if not slots:
+        return None
+    slide_index = slots[0].get("slide_index")
+    return (
+        slide_index if isinstance(slide_index, int) and not isinstance(slide_index, bool) else None
+    )
+
+
+def _sort_slots_by_position(slots: tuple[dict, ...]) -> tuple[dict, ...]:
+    return tuple(sorted(slots, key=_slot_position_sort_key))
+
+
+def _slot_position_sort_key(slot: dict) -> tuple[int, int, tuple[int, str]]:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return (10**18, 10**18, _shape_id_sort_key(str(slot.get("shape_id") or "")))
+    x_emu, y_emu, _w_emu, _h_emu = slot_box
+    return (y_emu, x_emu, _shape_id_sort_key(str(slot.get("shape_id") or "")))
+
+
+def _slot_id_list_text(slots: tuple[dict, ...]) -> str:
+    return ", ".join(str(slot.get("slot_id")) for slot in slots)
+
+
 def _match_reference_shapes(
     slots: tuple[dict, ...],
     example_shapes: tuple[_TextShapeExtraction, ...],
@@ -548,6 +944,46 @@ def _bbox_tuple(source: dict) -> tuple[int, int, int, int] | None:
     if any(isinstance(value, bool) or not isinstance(value, int) for value in values):
         return None
     return values
+
+
+def _shape_bbox(shape: _RuntimeShapeGeometry) -> tuple[int, int, int, int]:
+    return (shape.x_emu, shape.y_emu, shape.w_emu, shape.h_emu)
+
+
+def _box_area(box: tuple[int, int, int, int]) -> int:
+    _x, _y, width, height = box
+    return max(width, 0) * max(height, 0)
+
+
+def _box_coverage(
+    inner_box: tuple[int, int, int, int],
+    outer_box: tuple[int, int, int, int],
+) -> float:
+    inner_area = _box_area(inner_box)
+    if inner_area <= 0:
+        return 0.0
+    return _intersection_area(inner_box, outer_box) / inner_area
+
+
+def _intersection_area(
+    left_box: tuple[int, int, int, int],
+    right_box: tuple[int, int, int, int],
+) -> int:
+    left_x, left_y, left_w, left_h = left_box
+    right_x, right_y, right_w, right_h = right_box
+    overlap_w = max(0, min(left_x + left_w, right_x + right_w) - max(left_x, right_x))
+    overlap_h = max(0, min(left_y + left_h, right_y + right_h) - max(left_y, right_y))
+    return overlap_w * overlap_h
+
+
+def _union_bbox(boxes: tuple[tuple[int, int, int, int], ...]) -> tuple[int, int, int, int] | None:
+    if not boxes:
+        return None
+    min_x = min(box[0] for box in boxes)
+    min_y = min(box[1] for box in boxes)
+    max_x = max(box[0] + box[2] for box in boxes)
+    max_y = max(box[1] + box[3] for box in boxes)
+    return (min_x, min_y, max_x - min_x, max_y - min_y)
 
 
 def _intersection_over_union(

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -25,7 +25,7 @@ class TemplateV2Extraction:
     """v2 compiler 추출 결과.
 
     PPTX에서 추출한 runtime slide, editable marker slot, reference skeleton 정보를 담는다.
-    reference shape 매칭과 layout group 추론은 후속 task 가 이 구조를 확장한다.
+    reference shape 매칭과 layout group 추론 결과는 metadata/reference payload 로 분리된다.
     """
 
     runtime_slides: Sequence[Mapping[str, Any]] = ()
@@ -33,6 +33,7 @@ class TemplateV2Extraction:
     layout_groups: Sequence[Mapping[str, Any]] = ()
     slide_pairs: Sequence[Mapping[str, Any]] = ()
     shape_matches: Sequence[Mapping[str, Any]] = ()
+    shape_inferences: Sequence[Mapping[str, Any]] = ()
     errors: Sequence[str] = ()
     warnings: Sequence[str] = ()
 
@@ -57,7 +58,11 @@ def build_template_v2_payloads(
         "template_id": normalized_template_id,
         "runtime_slides": _json_array(source.runtime_slides, "runtime_slides"),
         "slots": _json_array(
-            _enrich_slot_descriptors(source.slots, source.shape_matches),
+            _enrich_slot_descriptors(
+                source.slots,
+                source.shape_matches,
+                source.shape_inferences,
+            ),
             "slots",
         ),
         "layout_groups": _json_array(source.layout_groups, "layout_groups"),
@@ -67,6 +72,7 @@ def build_template_v2_payloads(
         "template_id": normalized_template_id,
         "slide_pairs": _json_array(source.slide_pairs, "slide_pairs"),
         "shape_matches": _json_array(source.shape_matches, "shape_matches"),
+        "shape_inferences": _json_array(source.shape_inferences, "shape_inferences"),
     }
     return TemplateV2Payloads(metadata=metadata, reference=reference)
 
@@ -156,12 +162,15 @@ def _json_array(items: Sequence[Mapping[str, Any]], field_name: str) -> list[Any
 def _enrich_slot_descriptors(
     slots: Sequence[Mapping[str, Any]],
     shape_matches: Sequence[Mapping[str, Any]],
+    shape_inferences: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
     matches_by_slot_id = _shape_matches_by_slot_id(shape_matches)
+    item_backgrounds_by_slot_id = _item_backgrounds_by_slot_id(shape_inferences)
     return [
         _enrich_slot_descriptor(
             slot,
             matches_by_slot_id.get(str(slot.get("slot_id"))),
+            item_backgrounds_by_slot_id.get(str(slot.get("slot_id"))),
         )
         for slot in slots
     ]
@@ -181,9 +190,55 @@ def _shape_matches_by_slot_id(
     return matches_by_slot_id
 
 
+def _item_backgrounds_by_slot_id(
+    shape_inferences: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    candidates_by_slot_id: dict[str, list[Mapping[str, Any]]] = {}
+    for inference in shape_inferences:
+        if not isinstance(inference, Mapping):
+            continue
+        if inference.get("inference_type") != "item_background":
+            continue
+        if not _valid_item_background_inference(inference):
+            continue
+        slot_id = inference.get("slot_id")
+        if slot_id is None:
+            continue
+        candidates_by_slot_id.setdefault(str(slot_id), []).append(inference)
+    return {
+        slot_id: candidates[0]
+        for slot_id, candidates in candidates_by_slot_id.items()
+        if len(candidates) == 1
+    }
+
+
+def _valid_item_background_inference(inference: Mapping[str, Any]) -> bool:
+    if inference.get("resize_linked") is not True:
+        return False
+    if not str(inference.get("shape_id") or "").strip():
+        return False
+    if not all(_json_number(inference.get(field)) is not None for field in _ITEM_BACKGROUND_FIELDS):
+        return False
+    width = _json_number(inference.get("w_emu"))
+    height = _json_number(inference.get("h_emu"))
+    return width is not None and height is not None and width > 0 and height > 0
+
+
+_ITEM_BACKGROUND_FIELDS = (
+    "runtime_slide_index",
+    "runtime_slide_number",
+    "x_emu",
+    "y_emu",
+    "w_emu",
+    "h_emu",
+    "match_score",
+)
+
+
 def _enrich_slot_descriptor(
     slot: Mapping[str, Any],
     shape_match: Mapping[str, Any] | None,
+    item_background: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     enriched = dict(slot)
     if _is_editable_text_slot(enriched):
@@ -191,10 +246,33 @@ def _enrich_slot_descriptor(
             for field_name in _REFERENCE_SLOT_FIELDS:
                 if field_name in shape_match:
                     enriched[field_name] = shape_match[field_name]
+        if item_background is not None:
+            enriched["item_background"] = _slot_item_background(item_background)
         _apply_text_capacity_defaults(enriched)
     elif not _has_allowed_actions(enriched.get("allowed_actions")):
         enriched["allowed_actions"] = _infer_allowed_actions(enriched)
     return enriched
+
+
+def _slot_item_background(item_background: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "shape_id": item_background.get("shape_id"),
+        "shape_name": item_background.get("shape_name"),
+        "slide_index": item_background.get("runtime_slide_index"),
+        "slide_number": item_background.get("runtime_slide_number"),
+        "x_emu": item_background.get("x_emu"),
+        "y_emu": item_background.get("y_emu"),
+        "w_emu": item_background.get("w_emu"),
+        "h_emu": item_background.get("h_emu"),
+        "match_score": item_background.get("match_score"),
+        "resize_linked": item_background.get("resize_linked") is True,
+    }
+
+
+def _json_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return float(value)
 
 
 def _apply_text_capacity_defaults(slot: dict[str, Any]) -> None:

--- a/tasks/phase-2-pptx-template-quality/06-background-container-shape-inference.md
+++ b/tasks/phase-2-pptx-template-quality/06-background-container-shape-inference.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/02-pptx-slot-layout-group-inference.md"
 depends_on: ["2.05"]
 blocks: ["2.07"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -22,23 +23,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 작은 chip background 와 큰 카드 background fixture 구분
-- [ ] shape bbox overlap, containment, center distance 계산 유틸 위치 결정
+- [x] 작은 chip background 와 큰 카드 background fixture 구분
+- [x] shape bbox overlap, containment, center distance 계산 유틸 위치 결정
 
 ## 구현 체크리스트
 
-- [ ] 텍스트 없는 shape 중 text slot 을 감싸는 작은 후보를 `item_background` 로 score 계산
-- [ ] 동일 background 가 여러 slot 과 겹치는 ambiguous case 를 warning/fallback 으로 분리
-- [ ] 여러 text slot 을 담는 큰 shape 를 `container_shape` 로 분류
-- [ ] `container_shape` 는 참고 정보로만 기록하고 개별 resize 대상에서 제외
-- [ ] background/container 추론 단위 테스트와 origin fixture 기반 회귀 테스트 추가
+- [x] 텍스트 없는 shape 중 text slot 을 감싸는 작은 후보를 `item_background` 로 score 계산
+- [x] 동일 background 가 여러 slot 과 겹치는 ambiguous case 를 warning/fallback 으로 분리
+- [x] 여러 text slot 을 담는 큰 shape 를 `container_shape` 로 분류
+- [x] `container_shape` 는 참고 정보로만 기록하고 개별 resize 대상에서 제외
+- [x] background/container 추론 단위 테스트와 origin-style 합성 fixture 기반 회귀 테스트 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] chip text slot 이 1:1 `item_background` 와 연결된다
-- [ ] 큰 카드 배경은 `container_shape` 로 기록되고 resize linked 대상이 아니다
-- [ ] ambiguous background 후보는 억지로 연결되지 않고 warning 으로 남는다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] chip text slot 이 1:1 `item_background` 와 연결된다
+- [x] 큰 카드 배경은 `container_shape` 로 기록되고 resize linked 대상이 아니다
+- [x] ambiguous background 후보는 억지로 연결되지 않고 warning 으로 남는다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -45,6 +45,7 @@ def test_v2_payload_writer_generates_deterministic_skeleton(tmp_path: Path) -> N
 """
     expected_reference = """{
   "schema_version": 2,
+  "shape_inferences": [],
   "shape_matches": [],
   "slide_pairs": [],
   "template_id": "ppt-v3"
@@ -120,6 +121,156 @@ def test_v2_payload_writer_enriches_slot_capacity_deterministically() -> None:
     assert "role_hint" not in payloads.metadata["slots"][0]
 
 
+def test_v2_payload_writer_enriches_item_background_and_keeps_container_reference_only() -> None:
+    """item_background만 slot에 병합하고 container_shape는 reference 참고 정보로만 둔다."""
+    payloads = build_template_v2_payloads(
+        "ppt-v3",
+        extraction=TemplateV2Extraction(
+            slots=(
+                {
+                    "slot_id": "slide2_shape20",
+                    "shape_id": "20",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "OpenAI API",
+                    "marker_color": "#FF0000",
+                },
+                {
+                    "slot_id": "slide2_shape21",
+                    "shape_id": "21",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "FastAPI",
+                    "marker_color": "#FF0000",
+                },
+            ),
+            shape_inferences=(
+                {
+                    "inference_type": "item_background",
+                    "slot_id": "slide2_shape20",
+                    "slot_shape_id": "20",
+                    "runtime_slide_index": 1,
+                    "runtime_slide_number": 2,
+                    "shape_id": "19",
+                    "shape_name": "Chip background",
+                    "x_emu": 90,
+                    "y_emu": 190,
+                    "w_emu": 320,
+                    "h_emu": 420,
+                    "match_score": 0.98,
+                    "resize_linked": True,
+                },
+                {
+                    "inference_type": "container_shape",
+                    "runtime_slide_index": 1,
+                    "runtime_slide_number": 2,
+                    "shape_id": "18",
+                    "shape_name": "Card background",
+                    "x_emu": 50,
+                    "y_emu": 80,
+                    "w_emu": 900,
+                    "h_emu": 400,
+                    "contained_slot_ids": ["slide2_shape20", "slide2_shape21"],
+                    "match_score": 1.0,
+                    "resize_linked": False,
+                    "allowed_actions": [],
+                },
+            ),
+        ),
+    )
+
+    first_slot = payloads.metadata["slots"][0]
+    assert first_slot["item_background"] == {
+        "shape_id": "19",
+        "shape_name": "Chip background",
+        "slide_index": 1,
+        "slide_number": 2,
+        "x_emu": 90,
+        "y_emu": 190,
+        "w_emu": 320,
+        "h_emu": 420,
+        "match_score": 0.98,
+        "resize_linked": True,
+    }
+    assert "item_background" not in payloads.metadata["slots"][1]
+    assert payloads.reference["shape_inferences"][1]["inference_type"] == "container_shape"
+    assert payloads.reference["shape_inferences"][1]["resize_linked"] is False
+    assert payloads.reference["shape_inferences"][1]["allowed_actions"] == []
+
+
+def test_v2_payload_writer_ignores_invalid_or_duplicate_item_backgrounds() -> None:
+    """검증되지 않은 item_background는 slot 계약으로 승격하지 않는다."""
+    payloads = build_template_v2_payloads(
+        "ppt-v3",
+        extraction=TemplateV2Extraction(
+            slots=(
+                {
+                    "slot_id": "slide2_shape20",
+                    "shape_id": "20",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "OpenAI API",
+                },
+                {
+                    "slot_id": "slide2_shape21",
+                    "shape_id": "21",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "FastAPI",
+                },
+            ),
+            shape_inferences=(
+                {
+                    "inference_type": "item_background",
+                    "slot_id": "slide2_shape20",
+                    "runtime_slide_index": 1,
+                    "runtime_slide_number": 2,
+                    "shape_id": "19",
+                    "x_emu": 90,
+                    "y_emu": 190,
+                    "w_emu": 320,
+                    "h_emu": 120,
+                    "match_score": 0.98,
+                    "resize_linked": False,
+                },
+                {
+                    "inference_type": "item_background",
+                    "slot_id": "slide2_shape21",
+                    "runtime_slide_index": 1,
+                    "runtime_slide_number": 2,
+                    "shape_id": "22",
+                    "x_emu": 440,
+                    "y_emu": 190,
+                    "w_emu": 290,
+                    "h_emu": 120,
+                    "match_score": 0.95,
+                    "resize_linked": True,
+                },
+                {
+                    "inference_type": "item_background",
+                    "slot_id": "slide2_shape21",
+                    "runtime_slide_index": 1,
+                    "runtime_slide_number": 2,
+                    "shape_id": "23",
+                    "x_emu": 438,
+                    "y_emu": 188,
+                    "w_emu": 294,
+                    "h_emu": 124,
+                    "match_score": 0.96,
+                    "resize_linked": True,
+                },
+            ),
+        ),
+    )
+
+    assert all("item_background" not in slot for slot in payloads.metadata["slots"])
+    assert len(payloads.reference["shape_inferences"]) == 3
+
+
 def test_v2_payload_writer_preserves_non_text_allowed_action_defaults() -> None:
     """capacity 확장 후에도 chart/remove/decorative action 계약은 유지한다."""
     payloads = build_template_v2_payloads(
@@ -180,6 +331,7 @@ def test_compile_template_v2_writes_meta_and_reference_json(tmp_path: Path) -> N
         "template_id": "ppt-v3",
         "slide_pairs": [],
         "shape_matches": [],
+        "shape_inferences": [],
     }
 
 
@@ -480,6 +632,380 @@ def test_compile_template_v2_preserves_marker_soft_line_breaks(tmp_path: Path) -
     assert metadata["slots"][0]["placeholder_text"] == "첫 줄\n둘째 줄"
 
 
+def test_compile_template_v2_links_origin_style_chip_item_backgrounds(
+    tmp_path: Path,
+) -> None:
+    """origin 스타일 chip row에서 각 text slot을 1:1 item_background와 연결한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_without_text_xml(
+                            19,
+                            "OpenAI chip background",
+                            x=90,
+                            y=190,
+                            width=320,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            20,
+                            "OpenAI chip",
+                            (_run_xml("OpenAI API", color="FF0000"),),
+                            x=100,
+                            y=200,
+                            width=300,
+                            height=100,
+                        ),
+                        _shape_without_text_xml(
+                            21,
+                            "FastAPI chip background",
+                            x=440,
+                            y=190,
+                            width=290,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            22,
+                            "FastAPI chip",
+                            (_run_xml("FastAPI", color="FF0000"),),
+                            x=450,
+                            y=200,
+                            width=270,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "OpenAI example",
+                            (_run_xml("OpenAI API", color="123456"),),
+                            x=100,
+                            y=200,
+                            width=300,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            31,
+                            "FastAPI example",
+                            (_run_xml("FastAPI", color="123456"),),
+                            x=450,
+                            y=200,
+                            width=270,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    backgrounds_by_slot_id = {
+        slot["slot_id"]: slot["item_background"] for slot in metadata["slots"]
+    }
+    assert backgrounds_by_slot_id["slide2_shape20"]["shape_id"] == "19"
+    assert backgrounds_by_slot_id["slide2_shape22"]["shape_id"] == "21"
+    assert all(
+        background["resize_linked"] is True for background in backgrounds_by_slot_id.values()
+    )
+
+    reference = read_json_payload(result.reference_path)
+    item_inferences = [
+        inference
+        for inference in reference["shape_inferences"]
+        if inference["inference_type"] == "item_background"
+    ]
+    assert {inference["slot_id"] for inference in item_inferences} == {
+        "slide2_shape20",
+        "slide2_shape22",
+    }
+    assert {inference["shape_id"] for inference in item_inferences} == {"19", "21"}
+
+
+def test_compile_template_v2_records_large_card_as_container_shape(
+    tmp_path: Path,
+) -> None:
+    """여러 text slot을 담는 큰 배경은 container_shape로만 기록한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_without_text_xml(
+                            19,
+                            "Card background",
+                            x=50,
+                            y=50,
+                            width=500,
+                            height=220,
+                        ),
+                        _shape_xml(
+                            20,
+                            "Card title",
+                            (_run_xml("프로젝트명", color="FF0000"),),
+                            x=100,
+                            y=100,
+                            width=120,
+                            height=40,
+                        ),
+                        _shape_xml(
+                            21,
+                            "Card description",
+                            (_run_xml("프로젝트 설명", color="FF0000"),),
+                            x=100,
+                            y=170,
+                            width=200,
+                            height=40,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "Title example",
+                            (_run_xml("folioo", color="123456"),),
+                            x=100,
+                            y=100,
+                            width=120,
+                            height=40,
+                        ),
+                        _shape_xml(
+                            31,
+                            "Description example",
+                            (_run_xml("포트폴리오 생성", color="123456"),),
+                            x=100,
+                            y=170,
+                            width=200,
+                            height=40,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    assert all("item_background" not in slot for slot in metadata["slots"])
+
+    reference = read_json_payload(result.reference_path)
+    assert reference["shape_inferences"] == [
+        {
+            "allowed_actions": [],
+            "contained_slot_ids": ["slide2_shape20", "slide2_shape21"],
+            "h_emu": 220,
+            "inference_type": "container_shape",
+            "match_score": 1.0,
+            "resize_linked": False,
+            "runtime_slide_index": 1,
+            "runtime_slide_number": 2,
+            "shape_id": "19",
+            "shape_name": "Card background",
+            "w_emu": 500,
+            "x_emu": 50,
+            "y_emu": 50,
+        }
+    ]
+
+
+def test_compile_template_v2_ignores_slide_sized_background_as_container_shape(
+    tmp_path: Path,
+) -> None:
+    """슬라이드 전체 배경 수준의 과대 shape는 container_shape로 기록하지 않는다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_without_text_xml(
+                            19,
+                            "Slide background",
+                            x=0,
+                            y=0,
+                            width=2000,
+                            height=1000,
+                        ),
+                        _shape_xml(
+                            20,
+                            "Card title",
+                            (_run_xml("프로젝트명", color="FF0000"),),
+                            x=100,
+                            y=100,
+                            width=120,
+                            height=40,
+                        ),
+                        _shape_xml(
+                            21,
+                            "Card description",
+                            (_run_xml("프로젝트 설명", color="FF0000"),),
+                            x=100,
+                            y=170,
+                            width=200,
+                            height=40,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "Title example",
+                            (_run_xml("folioo", color="123456"),),
+                            x=100,
+                            y=100,
+                            width=120,
+                            height=40,
+                        ),
+                        _shape_xml(
+                            31,
+                            "Description example",
+                            (_run_xml("포트폴리오 생성", color="123456"),),
+                            x=100,
+                            y=170,
+                            width=200,
+                            height=40,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    reference = read_json_payload(result.reference_path)
+    assert reference["shape_inferences"] == []
+
+
+def test_compile_template_v2_warns_and_skips_ambiguous_item_background(
+    tmp_path: Path,
+) -> None:
+    """한 background가 여러 slot과 겹치면 억지로 item_background를 연결하지 않는다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_without_text_xml(
+                            19,
+                            "Ambiguous chip background",
+                            x=0,
+                            y=0,
+                            width=150,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            20,
+                            "First chip",
+                            (_run_xml("첫째", color="FF0000"),),
+                            x=10,
+                            y=0,
+                            width=100,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            21,
+                            "Second chip",
+                            (_run_xml("둘째", color="FF0000"),),
+                            x=80,
+                            y=0,
+                            width=100,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "First example",
+                            (_run_xml("첫째 예시", color="123456"),),
+                            x=10,
+                            y=0,
+                            width=100,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            31,
+                            "Second example",
+                            (_run_xml("둘째 예시", color="123456"),),
+                            x=80,
+                            y=0,
+                            width=100,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    assert any("여러 text slot" in warning for warning in result.warnings)
+    metadata = read_json_payload(result.meta_path)
+    assert all("item_background" not in slot for slot in metadata["slots"])
+
+    reference = read_json_payload(result.reference_path)
+    assert reference["shape_inferences"] == [
+        {
+            "allowed_actions": [],
+            "candidate_slot_ids": ["slide2_shape20", "slide2_shape21"],
+            "h_emu": 100,
+            "inference_type": "ambiguous_item_background",
+            "match_score": reference["shape_inferences"][0]["match_score"],
+            "resize_linked": False,
+            "runtime_slide_index": 1,
+            "runtime_slide_number": 2,
+            "shape_id": "19",
+            "shape_name": "Ambiguous chip background",
+            "w_emu": 150,
+            "x_emu": 0,
+            "y_emu": 0,
+        }
+    ]
+
+
 def test_compile_template_cli_help_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
     """compile_template.py --help 가 argparse help를 출력하고 0으로 종료한다."""
     with pytest.raises(SystemExit) as exc_info:
@@ -753,6 +1279,29 @@ def _shape_xml(
         "<p:txBody><a:bodyPr/><a:lstStyle/><a:p>"
         f"{''.join(runs_xml)}"
         "</a:p></p:txBody>"
+        "</p:sp>"
+    )
+
+
+def _shape_without_text_xml(
+    shape_id: int,
+    name: str,
+    *,
+    x: int = 0,
+    y: int = 0,
+    width: int = 100,
+    height: int = 100,
+) -> str:
+    return (
+        "<p:sp>"
+        "<p:nvSpPr>"
+        f'<p:cNvPr id="{shape_id}" name="{escape(name)}"/>'
+        "<p:cNvSpPr/><p:nvPr/>"
+        "</p:nvSpPr>"
+        "<p:spPr>"
+        f'<a:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm>'
+        '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+        "</p:spPr>"
         "</p:sp>"
     )
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #261

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- runtime slide의 무텍스트 shape를 bbox 기반으로 분석해 `item_background`, `container_shape`, `ambiguous_item_background`를 `reference.json.shape_inferences`에 기록합니다.
- 확정된 1:1 `item_background`만 `meta.json.slots[].item_background`로 병합하고, `container_shape`는 reference 참고 정보로만 유지합니다.
- 큰 카드 배경은 `resize_linked: false`, `allowed_actions: []`로 기록해 개별 resize 대상에서 제외합니다.
- 동일 background가 여러 slot과 겹치는 경우 slot에 연결하지 않고 warning과 ambiguous inference로 남깁니다.
- 과대 slide/background급 shape는 container로 기록하지 않도록 union bbox 대비 상한을 추가했습니다.
- 직접 주입된 `shape_inferences`에서 invalid/duplicate item_background가 slot 계약으로 승격되지 않도록 방어했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest -q` → `895 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 과대 container 배제와 invalid/duplicate item_background 방어를 반영했습니다.
- 실제 `templates/origin`은 아직 v1/legacy 자산이라, 회귀 테스트는 origin-style 합성 OOXML fixture로 고정했습니다.