### PR TITLE
[PPTX] LLM slot capacity hint 적용

### DIFF
--- a/features/visualization/agents/generation.py
+++ b/features/visualization/agents/generation.py
@@ -44,6 +44,8 @@ _FILL_SYSTEM_PROMPT = """PPTX 슬라이드 Slot 을 채우는 편집 데이터 �
 - required=false, editable=false, kind=decorative/background/layout slot 은 필수 채움 대상이 아닙니다.
 - 제공된 shape_id 만 key 로 사용하고, 각 slot 의 allowed_actions 범위 안에서만 action 을 선택하세요.
 - chart slot 은 action=chart 와 data.categories, data.series[].values 를 함께 제공하세요.
+- example_text 는 복사할 정답이 아니라 형식, 길이, 줄 수 참고용입니다.
+- placeholder_text, max_lines, nowrap, length_hint 를 우선해 slot 용량에 맞는 텍스트를 작성하세요.
 - 텍스트가 길면 먼저 폰트를 줄이되 원본의 60% 미만이나 10pt 미만으로 내리지 마세요.
 - 텍스트 요약이 필요하면 고유명사, 수치, 기술 스택, 성과 지표를 보존하세요.
 """
@@ -119,6 +121,10 @@ _METRIC_SLIDE_PATTERN = re.compile(
     r"chart|graph|metric|metrics|kpi|차트|그래프|지표|성과\s*지표|수치|통계|전환율|증감|비율",
     re.I,
 )
+_INLINE_LABEL_LAYOUT_TYPES = {"inline_label_group"}
+_INLINE_LABEL_FIT_POLICIES = {"resize_label", "inline_label_group"}
+_BASIC_TEXT_LAYOUT_TYPES = {"basic_text_area"}
+_BASIC_TEXT_FIT_POLICIES = {"basic_text_area", ""}
 
 
 class GenerationLLM(Protocol):
@@ -297,12 +303,13 @@ class LLMContentFillGenerator:
             return {}
 
         llm = self._llm or get_llm_uncached(temperature=0.1, timeout=120)
+        prompt_payload = _build_fill_prompt_payload(content_brief=content_brief, slots=slots)
         messages = [
             SystemMessage(content=_FILL_SYSTEM_PROMPT),
             HumanMessage(
                 content=(
                     "다음 슬라이드 요지와 Slot 정보를 보고 fills 를 작성하세요.\n"
-                    f"{json.dumps({'content_brief': content_brief, 'slots': list(slots)}, ensure_ascii=False, default=str)}"
+                    f"{json.dumps(prompt_payload, ensure_ascii=False, default=str)}"
                 )
             ),
         ]
@@ -536,6 +543,151 @@ def _build_plan_prompt(*, portfolio_text: str, source_slides: Sequence[SourceSli
         },
     }
     return json.dumps(payload, ensure_ascii=False)
+
+
+def _build_fill_prompt_payload(
+    *,
+    content_brief: str,
+    slots: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """LLM Call #2에 전달할 slot capacity 중심 payload를 구성한다."""
+    return {
+        "content_brief": content_brief,
+        "slot_guidance": {
+            "placeholder_text": "slot 의 의미를 알려주는 입력 힌트입니다.",
+            "example_text": "복사 대상이 아니라 형식, 길이, 줄 수 참고용입니다.",
+            "length_hint": "텍스트 생성 시 우선 준수해야 하는 길이 제약입니다.",
+        },
+        "slots": [_build_fill_slot_prompt_payload(slot) for slot in slots],
+    }
+
+
+def _build_fill_slot_prompt_payload(slot: Mapping[str, Any]) -> dict[str, Any]:
+    """원본 slot descriptor에 prompt용 capacity hint를 보강한다."""
+    prompt_slot = dict(slot)
+    if not _slot_uses_text_capacity(slot):
+        return prompt_slot
+
+    placeholder_text = _slot_text(slot, "placeholder_text") or _slot_text(slot, "current_text")
+    example_text = _slot_text(slot, "example_text")
+    example_line_count = _positive_int(slot.get("example_line_count")) or _line_count(example_text)
+    max_lines = (
+        _positive_int(slot.get("max_lines"))
+        or example_line_count
+        or _line_count(placeholder_text)
+        or 1
+    )
+    nowrap = slot.get("nowrap")
+    if not isinstance(nowrap, bool):
+        nowrap = max_lines == 1
+
+    prompt_slot["placeholder_text"] = placeholder_text or None
+    prompt_slot["example_text"] = example_text or None
+    prompt_slot["example_line_count"] = example_line_count
+    prompt_slot["max_lines"] = max_lines
+    prompt_slot["nowrap"] = nowrap
+    if _positive_int(slot.get("example_char_count")) is None and example_text:
+        prompt_slot["example_char_count"] = len(example_text.replace("\n", ""))
+    prompt_slot["length_hint"] = _slot_length_hint(
+        slot=slot,
+        example_text=example_text,
+        example_line_count=example_line_count,
+        max_lines=max_lines,
+        nowrap=nowrap,
+    )
+    return prompt_slot
+
+
+def _slot_uses_text_capacity(slot: Mapping[str, Any]) -> bool:
+    return _slot_is_editable(slot) and "text" in _allowed_actions_for_slot(slot)
+
+
+def _slot_length_hint(
+    *,
+    slot: Mapping[str, Any],
+    example_text: str,
+    example_line_count: int | None,
+    max_lines: int,
+    nowrap: bool,
+) -> str:
+    """layout 유형별 LLM 길이 지침을 생성한다."""
+    layout_type = _normalized_slot_text(slot, "layout_type")
+    layout_group_type = _normalized_slot_text(slot, "layout_group_type")
+    fit_policy = _normalized_slot_text(slot, "fit_policy")
+
+    if (
+        layout_type in _INLINE_LABEL_LAYOUT_TYPES
+        or layout_group_type in _INLINE_LABEL_LAYOUT_TYPES
+        or fit_policy in _INLINE_LABEL_FIT_POLICIES
+    ):
+        return _inline_label_length_hint(example_text=example_text, nowrap=nowrap)
+
+    if (
+        layout_type in _BASIC_TEXT_LAYOUT_TYPES
+        or layout_group_type in _BASIC_TEXT_LAYOUT_TYPES
+        or fit_policy in _BASIC_TEXT_FIT_POLICIES
+    ):
+        return _basic_text_area_length_hint(
+            example_text=example_text,
+            example_line_count=example_line_count,
+            max_lines=max_lines,
+            nowrap=nowrap,
+        )
+
+    return _fallback_length_hint(
+        example_text=example_text,
+        example_line_count=example_line_count,
+        max_lines=max_lines,
+        nowrap=nowrap,
+    )
+
+
+def _inline_label_length_hint(*, example_text: str, nowrap: bool) -> str:
+    example_clause = _example_length_clause(example_text)
+    nowrap_clause = " 줄바꿈하지 말고 한 줄로 유지하세요." if nowrap else ""
+    return (
+        "짧은 chip/label 문구로 작성하세요. "
+        f"{example_clause}공백이 포함되어도 단일 label 처럼 읽혀야 합니다.{nowrap_clause}"
+    )
+
+
+def _basic_text_area_length_hint(
+    *,
+    example_text: str,
+    example_line_count: int | None,
+    max_lines: int,
+    nowrap: bool,
+) -> str:
+    example_clause = _example_length_clause(example_text)
+    line_clause = f"최대 {max_lines}줄 안에서 작성하세요."
+    if example_line_count is not None:
+        line_clause = f"예시는 {example_line_count}줄이며, 최대 {max_lines}줄 안에서 작성하세요."
+    nowrap_clause = " 줄바꿈하지 말고 한 줄로 요약하세요." if nowrap else ""
+    return f"일반 텍스트 영역입니다. {example_clause}{line_clause}{nowrap_clause}"
+
+
+def _fallback_length_hint(
+    *,
+    example_text: str,
+    example_line_count: int | None,
+    max_lines: int,
+    nowrap: bool,
+) -> str:
+    if nowrap:
+        return f"{_example_length_clause(example_text)}최대 {max_lines}줄, 한 줄 문구로 작성하세요."
+    if example_line_count is not None:
+        return (
+            f"{_example_length_clause(example_text)}"
+            f"예시는 {example_line_count}줄이며, 최대 {max_lines}줄 안에서 작성하세요."
+        )
+    return f"{_example_length_clause(example_text)}최대 {max_lines}줄 안에서 작성하세요."
+
+
+def _example_length_clause(example_text: str) -> str:
+    if not example_text:
+        return "예시가 없으면 placeholder_text의 의미를 기준으로 간결하게 작성하세요. "
+    char_count = len(example_text.replace("\n", ""))
+    return f"example_text는 복사하지 말고 {char_count}자 안팎의 형식과 길이만 참고하세요. "
 
 
 def _parse_plan_payload(
@@ -810,6 +962,37 @@ def _has_visual_signal(text: str) -> bool:
             flags=re.IGNORECASE,
         )
     )
+
+
+def _slot_text(slot: Mapping[str, Any], field: str) -> str:
+    value = slot.get(field)
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalized_slot_text(slot: Mapping[str, Any], field: str) -> str:
+    return _slot_text(slot, field).casefold()
+
+
+def _line_count(text: str) -> int | None:
+    if not text:
+        return None
+    return max(1, len(text.splitlines()))
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
 
 
 def _guard_font_size(value: Any, base_font_size: Any) -> float:

--- a/tasks/phase-2-pptx-template-quality/08-llm-slot-capacity-hints.md
+++ b/tasks/phase-2-pptx-template-quality/08-llm-slot-capacity-hints.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/03-pptx-deterministic-text-fit-preflight.md"
 depends_on: ["1.05", "2.05"]
 blocks: ["2.09", "2.10"]
 estimate: "S"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -23,22 +24,22 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] `features/visualization/agents/generation.py` 의 Slot→Fill prompt 구성 확인
-- [ ] 기존 테스트에서 prompt snapshot 또는 fake LLM 입력 검증 방식 확인
+- [x] `features/visualization/agents/generation.py` 의 Slot→Fill prompt 구성 확인
+- [x] 기존 테스트에서 prompt snapshot 또는 fake LLM 입력 검증 방식 확인
 
 ## 구현 체크리스트
 
-- [ ] Slot prompt payload 에 `placeholder_text`, `example_text`, `example_line_count`, `max_lines`, `nowrap` 추가
-- [ ] length hint 문구를 `inline_label_group` 과 `basic_text_area` 에 맞게 생성
-- [ ] 예시 텍스트는 복사 대상이 아니라 형식/길이 참고임을 prompt 에 명시
-- [ ] role_hint 누락 시에도 placeholder/example 기반으로 prompt 가 생성되도록 테스트
+- [x] Slot prompt payload 에 `placeholder_text`, `example_text`, `example_line_count`, `max_lines`, `nowrap` 추가
+- [x] length hint 문구를 `inline_label_group` 과 `basic_text_area` 에 맞게 생성
+- [x] 예시 텍스트는 복사 대상이 아니라 형식/길이 참고임을 prompt 에 명시
+- [x] role_hint 누락 시에도 placeholder/example 기반으로 prompt 가 생성되도록 테스트
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] LLM Call #2 입력에 capacity hint 가 포함된다
-- [ ] `OpenAI API` 같은 짧은 chip 예시가 한 줄 label 의 길이 힌트로 전달된다
-- [ ] 기존 v1 slot payload 에서도 prompt 생성이 안전하게 fallback 한다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] LLM Call #2 입력에 capacity hint 가 포함된다
+- [x] `OpenAI API` 같은 짧은 chip 예시가 한 줄 label 의 길이 힌트로 전달된다
+- [x] 기존 v1 slot payload 에서도 prompt 생성이 안전하게 fallback 한다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -37,6 +37,11 @@ class FakeLLM:
         return LLMResponse(self.responses.pop(0))
 
 
+def _last_fill_prompt_payload(llm: FakeLLM) -> dict[str, object]:
+    """마지막 fill 생성 호출의 HumanMessage JSON payload를 반환한다."""
+    return json.loads(llm.messages[-1][1].content.rsplit("\n", maxsplit=1)[1])
+
+
 def test_slide_plan_generator_validates_required_rules() -> None:
     """cover/closing 포함, 7~12장, 연속 카테고리 회피 plan 을 생성한다."""
     llm = FakeLLM(
@@ -252,10 +257,122 @@ def test_content_fill_generator_does_not_require_optional_decorative_slot() -> N
 
     assert fills == {"2": {"action": "text", "text": "핵심 요약"}}
     system_prompt = llm.messages[0][0].content
-    prompt_payload = json.loads(llm.messages[0][1].content.rsplit("\n", maxsplit=1)[1])
+    prompt_payload = _last_fill_prompt_payload(llm)
     assert "required=false" in system_prompt
     assert "성과 지표" in system_prompt
     assert prompt_payload["slots"][1]["editable"] is False
+
+
+def test_content_fill_prompt_includes_capacity_hint_payload() -> None:
+    """LLM Call #2 payload에는 slot capacity hint와 예시 사용 안내가 포함된다."""
+    llm = FakeLLM([{"fills": {"26": {"action": "text", "text": "Folioo AI"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    generator.create_fills(
+        content_brief="프로젝트 이름을 작성",
+        slots=[
+            {
+                "shape_id": "26",
+                "kind": "text",
+                "editable": True,
+                "required": True,
+                "placeholder_text": "프로젝트명",
+                "example_text": "Folioo AI",
+                "example_char_count": 9,
+                "example_line_count": 1,
+                "max_lines": 1,
+                "nowrap": True,
+                "fit_policy": "basic_text_area",
+                "allowed_actions": ["text"],
+            }
+        ],
+    )
+
+    system_prompt = llm.messages[0][0].content
+    prompt_payload = _last_fill_prompt_payload(llm)
+    slot_payload = prompt_payload["slots"][0]
+    assert "example_text 는 복사할 정답이 아니라" in system_prompt
+    assert prompt_payload["slot_guidance"]["example_text"] == (
+        "복사 대상이 아니라 형식, 길이, 줄 수 참고용입니다."
+    )
+    assert slot_payload["placeholder_text"] == "프로젝트명"
+    assert slot_payload["example_text"] == "Folioo AI"
+    assert slot_payload["example_line_count"] == 1
+    assert slot_payload["max_lines"] == 1
+    assert slot_payload["nowrap"] is True
+    assert "length_hint" in slot_payload
+
+
+def test_content_fill_prompt_uses_inline_label_one_line_length_hint() -> None:
+    """짧은 chip 예시는 inline_label_group 한 줄 label 길이 힌트로 전달된다."""
+    llm = FakeLLM([{"fills": {"26": {"action": "text", "text": "OpenAI API"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    generator.create_fills(
+        content_brief="사용 기술을 chip 문구로 작성",
+        slots=[
+            {
+                "shape_id": "26",
+                "kind": "text",
+                "editable": True,
+                "required": True,
+                "placeholder_text": "사용 기술",
+                "example_text": "OpenAI API",
+                "example_line_count": 1,
+                "max_lines": 1,
+                "nowrap": True,
+                "layout_type": "inline_label_group",
+                "fit_policy": "resize_label",
+                "allowed_actions": ["text", "remove"],
+            }
+        ],
+    )
+
+    slot_payload = _last_fill_prompt_payload(llm)["slots"][0]
+    assert slot_payload["example_text"] == "OpenAI API"
+    assert slot_payload["length_hint"].startswith("짧은 chip/label 문구")
+    assert "한 줄" in slot_payload["length_hint"]
+    assert "줄바꿈하지 말고" in slot_payload["length_hint"]
+
+
+def test_content_fill_prompt_does_not_add_text_capacity_hint_to_chart_slot() -> None:
+    """chart slot 에는 text length hint를 붙여 action 계약을 흐리지 않는다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "8": {
+                        "action": "chart",
+                        "data": {
+                            "categories": ["전", "후"],
+                            "series": [{"name": "전환율", "values": [10, 42]}],
+                        },
+                    }
+                }
+            }
+        ]
+    )
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.create_fills(
+        content_brief="전환율 차트를 작성",
+        slots=[
+            {
+                "shape_id": "8",
+                "kind": "chart",
+                "editable": True,
+                "required": True,
+                "allowed_actions": ["chart"],
+            }
+        ],
+    )
+
+    assert fills["8"]["action"] == "chart"
+    slot_payload = _last_fill_prompt_payload(llm)["slots"][0]
+    assert slot_payload["allowed_actions"] == ["chart"]
+    assert "length_hint" not in slot_payload
+    assert "max_lines" not in slot_payload
+    assert "nowrap" not in slot_payload
 
 
 def test_content_fill_generator_accepts_v2_capacity_slot_without_role_hint() -> None:
@@ -287,11 +404,40 @@ def test_content_fill_generator_accepts_v2_capacity_slot_without_role_hint() -> 
     )
 
     assert fills == {"26": {"action": "text", "text": "OpenAI API"}}
-    prompt_payload = json.loads(llm.messages[0][1].content.rsplit("\n", maxsplit=1)[1])
+    prompt_payload = _last_fill_prompt_payload(llm)
     slot_payload = prompt_payload["slots"][0]
     assert "role_hint" not in slot_payload
     assert slot_payload["placeholder_text"] == "사용 기술"
     assert slot_payload["example_text"] == "OpenAI API"
+    assert "일반 텍스트 영역" in slot_payload["length_hint"]
+    assert "최대 1줄" in slot_payload["length_hint"]
+
+
+def test_content_fill_prompt_falls_back_for_legacy_slot_without_capacity_fields() -> None:
+    """legacy slot 에 capacity 필드가 없어도 prompt payload를 안전하게 만든다."""
+    llm = FakeLLM([{"fills": {"2": {"action": "text", "text": "Folioo AI"}}}])
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.create_fills(
+        content_brief="프로젝트명 작성",
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 20,
+                "kind": "text",
+                "current_text": "여기에 프로젝트명",
+            }
+        ],
+    )
+
+    assert fills == {"2": {"action": "text", "text": "Folioo AI"}}
+    slot_payload = _last_fill_prompt_payload(llm)["slots"][0]
+    assert slot_payload["placeholder_text"] == "여기에 프로젝트명"
+    assert slot_payload["example_text"] is None
+    assert slot_payload["example_line_count"] is None
+    assert slot_payload["max_lines"] == 1
+    assert slot_payload["nowrap"] is True
+    assert "placeholder_text" in slot_payload["length_hint"]
 
 
 def test_content_fill_generator_accepts_v2_capacity_remove_without_role_hint() -> None:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #263

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- LLM Call #2 Slot→Fill prompt payload에 `placeholder_text`, `example_text`, `example_line_count`, `max_lines`, `nowrap`, `length_hint`를 보강했습니다.
- `inline_label_group`/`resize_label` 계열은 한 줄 chip/label 길이 힌트를, `basic_text_area`는 max lines 중심 힌트를 생성합니다.
- system prompt와 payload guidance에 `example_text`는 복사 대상이 아니라 형식/길이/줄 수 참고용임을 명시했습니다.
- `role_hint`가 없어도 placeholder/example 기반 prompt 생성이 동작하도록 유지했습니다.
- legacy slot은 capacity 필드가 없어도 안전하게 fallback하고, chart slot에는 text length hint를 붙이지 않아 action 계약과 충돌하지 않게 했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run pytest -q` → `893 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 chart slot에 text capacity hint가 붙는 문제와 legacy `example_line_count` 의미 혼선을 반영했습니다.
- 실제 fit 계산과 layout action 생성은 후속 task 범위로 남겼습니다.