### PR TITLE
[PPTX] inline_label_group 추론 추가

### DIFF
--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -34,6 +34,15 @@ _CONTAINER_MIN_SLOT_COUNT = 2
 _CONTAINER_MIN_MAX_SLOT_AREA_RATIO = 3.0
 _CONTAINER_MIN_UNION_AREA_RATIO = 1.05
 _CONTAINER_MAX_UNION_AREA_RATIO = 8.0
+_INLINE_LABEL_GROUP_MIN_ITEMS = 3
+_INLINE_LABEL_GROUP_MAX_PLACEHOLDER_CHARS = 28
+_INLINE_LABEL_GROUP_MIN_HEIGHT_SIMILARITY = 0.65
+_INLINE_LABEL_GROUP_MAX_WIDTH_RATIO = 5.0
+_INLINE_LABEL_GROUP_CENTER_Y_TOLERANCE_RATIO = 0.35
+_INLINE_LABEL_GROUP_MAX_GAP_HEIGHT_RATIO = 2.0
+_INLINE_LABEL_GROUP_MAX_GAP_WIDTH_RATIO = 0.75
+_INLINE_LABEL_GROUP_MAX_GAP_VARIANCE_RATIO = 3.0
+_INLINE_LABEL_GROUP_MIN_BACKGROUND_ITEMS = 2
 
 
 @dataclass(frozen=True)
@@ -123,6 +132,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
     slide_pairs: list[dict] = []
     shape_matches: list[dict] = []
     shape_inferences: list[dict] = []
+    layout_groups: list[dict] = []
     slots: list[dict] = []
     errors: list[str] = []
     warnings: list[str] = []
@@ -182,6 +192,13 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
             )
             shape_inferences.extend(inferred_shapes)
             warnings.extend(shape_warnings)
+            inferred_groups, group_warnings = _infer_inline_label_groups(
+                marker_result.slots,
+                inferred_shapes,
+                runtime_slide_number=slide_number,
+            )
+            layout_groups.extend(inferred_groups)
+            warnings.extend(group_warnings)
             if not marker_result.slots and not marker_result.has_marker_candidate:
                 errors.append(
                     f"runtime slide {slide_number}에 정확한 #FF0000 editable marker가 없습니다."
@@ -211,7 +228,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
     return TemplateV2Extraction(
         runtime_slides=tuple(runtime_slides),
         slots=tuple(slots),
-        layout_groups=(),
+        layout_groups=tuple(layout_groups),
         slide_pairs=tuple(slide_pairs),
         shape_matches=tuple(shape_matches),
         shape_inferences=tuple(shape_inferences),
@@ -777,6 +794,252 @@ def _ambiguous_item_background_inference(
         }
     )
     return inference
+
+
+def _infer_inline_label_groups(
+    slots: tuple[dict, ...],
+    shape_inferences: list[dict],
+    *,
+    runtime_slide_number: int,
+) -> tuple[list[dict], list[str]]:
+    """반복되는 짧은 slot row를 inline label group으로 추론한다."""
+    candidate_slots = tuple(slot for slot in slots if _inline_label_slot_candidate(slot))
+    if len(candidate_slots) < _INLINE_LABEL_GROUP_MIN_ITEMS:
+        return [], []
+
+    item_backgrounds_by_slot_id = _item_background_inferences_by_slot_id(shape_inferences)
+    groups: list[dict] = []
+    warnings: list[str] = []
+    for row in _cluster_inline_label_rows(candidate_slots):
+        group = _inline_label_group_from_row(
+            row,
+            item_backgrounds_by_slot_id,
+            runtime_slide_number=runtime_slide_number,
+            group_index=len(groups) + 1,
+        )
+        if group is None:
+            if len(row) >= _INLINE_LABEL_GROUP_MIN_ITEMS:
+                warnings.append(
+                    "runtime slide "
+                    f"{runtime_slide_number}의 inline_label_group 후보 "
+                    f"({_slot_id_list_text(_sort_slots_by_position(row))})는 "
+                    "정렬, gap, background 신뢰도가 부족해 basic_text_area로 둡니다."
+                )
+            continue
+        groups.append(group)
+    return groups, warnings
+
+
+def _inline_label_slot_candidate(slot: dict) -> bool:
+    if slot.get("editable") is False:
+        return False
+    if str(slot.get("kind") or "text").casefold() != "text":
+        return False
+    if _bbox_tuple(slot) is None:
+        return False
+
+    placeholder_text = str(slot.get("placeholder_text") or "").strip()
+    if not placeholder_text:
+        return False
+    if len(placeholder_text.splitlines()) != 1:
+        return False
+    return len(placeholder_text) <= _INLINE_LABEL_GROUP_MAX_PLACEHOLDER_CHARS
+
+
+def _item_background_inferences_by_slot_id(
+    shape_inferences: list[dict],
+) -> dict[str, dict]:
+    backgrounds_by_slot_id: dict[str, dict] = {}
+    for inference in shape_inferences:
+        if inference.get("inference_type") != "item_background":
+            continue
+        if inference.get("resize_linked") is not True:
+            continue
+        slot_id = str(inference.get("slot_id") or "")
+        if not slot_id:
+            continue
+        backgrounds_by_slot_id[slot_id] = inference
+    return backgrounds_by_slot_id
+
+
+def _cluster_inline_label_rows(slots: tuple[dict, ...]) -> tuple[tuple[dict, ...], ...]:
+    rows: list[list[dict]] = []
+    for slot in sorted(slots, key=_slot_center_y_sort_key):
+        slot_box = _bbox_tuple(slot)
+        if slot_box is None:
+            continue
+
+        matching_row = _matching_inline_label_row(rows, slot)
+        if matching_row is None:
+            rows.append([slot])
+        else:
+            matching_row.append(slot)
+
+    return tuple(
+        _sort_slots_by_position(tuple(row))
+        for row in rows
+        if len(row) >= _INLINE_LABEL_GROUP_MIN_ITEMS
+    )
+
+
+def _slot_center_y_sort_key(slot: dict) -> tuple[float, int, tuple[int, str]]:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return (float("inf"), 10**18, _shape_id_sort_key(str(slot.get("shape_id") or "")))
+    x_emu, y_emu, _w_emu, h_emu = slot_box
+    return (y_emu + (h_emu / 2), x_emu, _shape_id_sort_key(str(slot.get("shape_id") or "")))
+
+
+def _matching_inline_label_row(rows: list[list[dict]], slot: dict) -> list[dict] | None:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return None
+
+    _slot_x, slot_y, _slot_w, slot_h = slot_box
+    slot_center_y = slot_y + (slot_h / 2)
+    for row in rows:
+        row_boxes = tuple(box for row_slot in row if (box := _bbox_tuple(row_slot)) is not None)
+        if not row_boxes:
+            continue
+        row_center_y = sum(y + (height / 2) for _x, y, _width, height in row_boxes) / len(row_boxes)
+        max_height = max(slot_h, *(height for _x, _y, _width, height in row_boxes))
+        tolerance = max_height * _INLINE_LABEL_GROUP_CENTER_Y_TOLERANCE_RATIO
+        if abs(slot_center_y - row_center_y) <= tolerance:
+            return row
+    return None
+
+
+def _inline_label_group_from_row(
+    row: tuple[dict, ...],
+    item_backgrounds_by_slot_id: dict[str, dict],
+    *,
+    runtime_slide_number: int,
+    group_index: int,
+) -> dict | None:
+    if len(row) < _INLINE_LABEL_GROUP_MIN_ITEMS:
+        return None
+    if not _inline_label_row_geometry_is_confident(row):
+        return None
+
+    linked_background_by_item = _linked_background_by_item(row, item_backgrounds_by_slot_id)
+    if not _inline_label_backgrounds_are_confident(len(row), linked_background_by_item):
+        return None
+
+    gaps = _horizontal_gaps(row)
+    slide_index = _runtime_slide_index(row)
+    group_id = f"slide{runtime_slide_number}_inline_label_group{group_index}"
+    return {
+        "group_id": group_id,
+        "slide_index": slide_index,
+        "slide_number": runtime_slide_number,
+        "layout_type": "inline_label_group",
+        "flow": "horizontal",
+        "item_slot_ids": [str(slot.get("slot_id")) for slot in row],
+        "item_shape_ids": [str(slot.get("shape_id")) for slot in row],
+        "gap_emu": _median_int(gaps),
+        "min_gap_emu": min(gaps),
+        "wrap_allowed": False,
+        "linked_background_by_item": linked_background_by_item,
+    }
+
+
+def _inline_label_row_geometry_is_confident(row: tuple[dict, ...]) -> bool:
+    boxes = tuple(box for slot in row if (box := _bbox_tuple(slot)) is not None)
+    if len(boxes) != len(row):
+        return False
+
+    widths = [width for _x, _y, width, _height in boxes]
+    heights = [height for _x, _y, _width, height in boxes]
+    if min(widths, default=0) <= 0 or min(heights, default=0) <= 0:
+        return False
+    if min(heights) / max(heights) < _INLINE_LABEL_GROUP_MIN_HEIGHT_SIMILARITY:
+        return False
+    if max(widths) / min(widths) > _INLINE_LABEL_GROUP_MAX_WIDTH_RATIO:
+        return False
+
+    centers_y = [y + (height / 2) for _x, y, _width, height in boxes]
+    if (
+        max(centers_y) - min(centers_y)
+        > max(heights) * _INLINE_LABEL_GROUP_CENTER_Y_TOLERANCE_RATIO
+    ):
+        return False
+
+    gaps = _horizontal_gaps(row)
+    if len(gaps) != len(row) - 1:
+        return False
+    if min(gaps) < 0:
+        return False
+
+    median_height = _median_int(heights)
+    median_width = _median_int(widths)
+    max_allowed_gap = max(
+        int(median_height * _INLINE_LABEL_GROUP_MAX_GAP_HEIGHT_RATIO),
+        int(median_width * _INLINE_LABEL_GROUP_MAX_GAP_WIDTH_RATIO),
+    )
+    if max(gaps) > max_allowed_gap:
+        return False
+    if min(gaps) > 0 and max(gaps) / min(gaps) > _INLINE_LABEL_GROUP_MAX_GAP_VARIANCE_RATIO:
+        return False
+    if min(gaps) == 0 and max(gaps) > median_height:
+        return False
+    return True
+
+
+def _horizontal_gaps(row: tuple[dict, ...]) -> list[int]:
+    gaps: list[int] = []
+    sorted_row = _sort_slots_by_position(row)
+    for left, right in zip(sorted_row, sorted_row[1:]):
+        left_box = _bbox_tuple(left)
+        right_box = _bbox_tuple(right)
+        if left_box is None or right_box is None:
+            continue
+        left_x, _left_y, left_w, _left_h = left_box
+        right_x, _right_y, _right_w, _right_h = right_box
+        gaps.append(right_x - (left_x + left_w))
+    return gaps
+
+
+def _linked_background_by_item(
+    row: tuple[dict, ...],
+    item_backgrounds_by_slot_id: dict[str, dict],
+) -> dict[str, dict]:
+    linked: dict[str, dict] = {}
+    for slot in row:
+        slot_id = str(slot.get("slot_id") or "")
+        item_shape_id = str(slot.get("shape_id") or "")
+        if not slot_id or not item_shape_id:
+            continue
+        background = item_backgrounds_by_slot_id.get(slot_id)
+        if background is None:
+            continue
+        linked[item_shape_id] = {
+            "slot_id": slot_id,
+            "background_shape_id": background.get("shape_id"),
+            "background_shape_name": background.get("shape_name"),
+            "match_score": background.get("match_score"),
+            "resize_linked": background.get("resize_linked") is True,
+        }
+    return linked
+
+
+def _inline_label_backgrounds_are_confident(
+    item_count: int,
+    linked_background_by_item: dict[str, dict],
+) -> bool:
+    linked_count = len(linked_background_by_item)
+    if linked_count < _INLINE_LABEL_GROUP_MIN_BACKGROUND_ITEMS:
+        return False
+    return linked_count == item_count
+
+
+def _median_int(values: list[int]) -> int:
+    sorted_values = sorted(values)
+    if not sorted_values:
+        return 0
+    middle = len(sorted_values) // 2
+    if len(sorted_values) % 2 == 1:
+        return sorted_values[middle]
+    return round((sorted_values[middle - 1] + sorted_values[middle]) / 2)
 
 
 def _shape_inference_base(

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -62,6 +62,7 @@ def build_template_v2_payloads(
                 source.slots,
                 source.shape_matches,
                 source.shape_inferences,
+                source.layout_groups,
             ),
             "slots",
         ),
@@ -163,14 +164,17 @@ def _enrich_slot_descriptors(
     slots: Sequence[Mapping[str, Any]],
     shape_matches: Sequence[Mapping[str, Any]],
     shape_inferences: Sequence[Mapping[str, Any]],
+    layout_groups: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
     matches_by_slot_id = _shape_matches_by_slot_id(shape_matches)
     item_backgrounds_by_slot_id = _item_backgrounds_by_slot_id(shape_inferences)
+    layout_groups_by_slot_id = _layout_groups_by_slot_id(slots, layout_groups)
     return [
         _enrich_slot_descriptor(
             slot,
             matches_by_slot_id.get(str(slot.get("slot_id"))),
             item_backgrounds_by_slot_id.get(str(slot.get("slot_id"))),
+            layout_groups_by_slot_id.get(str(slot.get("slot_id"))),
         )
         for slot in slots
     ]
@@ -212,6 +216,58 @@ def _item_backgrounds_by_slot_id(
     }
 
 
+def _layout_groups_by_slot_id(
+    slots: Sequence[Mapping[str, Any]],
+    layout_groups: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    slot_ids_by_shape_id = _slot_ids_by_shape_id(slots)
+    groups_by_slot_id: dict[str, Mapping[str, Any]] = {}
+    for group in layout_groups:
+        if not isinstance(group, Mapping):
+            continue
+        group_id = str(group.get("group_id") or "").strip()
+        if not group_id:
+            continue
+        for slot_id in _layout_group_slot_ids(group, slot_ids_by_shape_id):
+            normalized_slot_id = str(slot_id or "").strip()
+            if not normalized_slot_id or normalized_slot_id in groups_by_slot_id:
+                continue
+            groups_by_slot_id[normalized_slot_id] = group
+    return groups_by_slot_id
+
+
+def _slot_ids_by_shape_id(slots: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    slot_ids_by_shape_id: dict[str, str] = {}
+    for slot in slots:
+        shape_id = str(slot.get("shape_id") or "").strip()
+        slot_id = str(slot.get("slot_id") or "").strip()
+        if shape_id and slot_id and shape_id not in slot_ids_by_shape_id:
+            slot_ids_by_shape_id[shape_id] = slot_id
+    return slot_ids_by_shape_id
+
+
+def _layout_group_slot_ids(
+    group: Mapping[str, Any],
+    slot_ids_by_shape_id: Mapping[str, str],
+) -> tuple[str, ...]:
+    item_slot_ids = _string_sequence(group.get("item_slot_ids"))
+    if item_slot_ids:
+        return item_slot_ids
+
+    item_shape_ids = _string_sequence(group.get("item_shape_ids"))
+    return tuple(
+        slot_ids_by_shape_id[shape_id]
+        for shape_id in item_shape_ids
+        if shape_id in slot_ids_by_shape_id
+    )
+
+
+def _string_sequence(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        return ()
+    return tuple(str(item or "").strip() for item in value if str(item or "").strip())
+
+
 def _valid_item_background_inference(inference: Mapping[str, Any]) -> bool:
     if inference.get("resize_linked") is not True:
         return False
@@ -239,6 +295,7 @@ def _enrich_slot_descriptor(
     slot: Mapping[str, Any],
     shape_match: Mapping[str, Any] | None,
     item_background: Mapping[str, Any] | None,
+    layout_group: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     enriched = dict(slot)
     if _is_editable_text_slot(enriched):
@@ -248,10 +305,26 @@ def _enrich_slot_descriptor(
                     enriched[field_name] = shape_match[field_name]
         if item_background is not None:
             enriched["item_background"] = _slot_item_background(item_background)
+        if layout_group is not None:
+            _apply_layout_group_slot_metadata(enriched, layout_group)
         _apply_text_capacity_defaults(enriched)
     elif not _has_allowed_actions(enriched.get("allowed_actions")):
         enriched["allowed_actions"] = _infer_allowed_actions(enriched)
     return enriched
+
+
+def _apply_layout_group_slot_metadata(
+    slot: dict[str, Any],
+    layout_group: Mapping[str, Any],
+) -> None:
+    group_id = str(layout_group.get("group_id") or "").strip()
+    if not group_id:
+        return
+    slot["layout_group_id"] = group_id
+    if layout_group.get("layout_type") == "inline_label_group":
+        slot["fit_policy"] = "resize_label"
+        slot["max_lines"] = 1
+        slot["nowrap"] = True
 
 
 def _slot_item_background(item_background: Mapping[str, Any]) -> dict[str, Any]:

--- a/tasks/phase-2-pptx-template-quality/07-inline-label-group-inference.md
+++ b/tasks/phase-2-pptx-template-quality/07-inline-label-group-inference.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/02-pptx-slot-layout-group-inference.md"
 depends_on: ["2.06"]
 blocks: ["2.10", "2.14"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -22,23 +23,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 첫 슬라이드 하단 기술 스택 chip acceptance fixture 확인
-- [ ] flow, gap, row alignment, wrap_allowed 기본 정책 정리
+- [x] 첫 슬라이드 하단 기술 스택 chip acceptance fixture 확인
+- [x] flow, gap, row alignment, wrap_allowed 기본 정책 정리
 
 ## 구현 체크리스트
 
-- [ ] 반복되는 짧은 editable slot 의 bbox alignment 와 gap 을 기준으로 group 후보 탐지
-- [ ] group 에 `group_id`, `layout_type`, `flow`, `item_shape_ids`, `gap_emu`, `min_gap_emu`, `wrap_allowed` 기록
-- [ ] `linked_background_by_item` 을 group metadata 에 연결
-- [ ] 신뢰도 낮은 후보는 `basic_text_area` 또는 `unknown` fallback 으로 둠
-- [ ] `origin` 특정 shape id/slide index 없이 fixture 를 통과하는 테스트 추가
+- [x] 반복되는 짧은 editable slot 의 bbox alignment 와 gap 을 기준으로 group 후보 탐지
+- [x] group 에 `group_id`, `layout_type`, `flow`, `item_shape_ids`, `gap_emu`, `min_gap_emu`, `wrap_allowed` 기록
+- [x] `linked_background_by_item` 을 group metadata 에 연결
+- [x] 신뢰도 낮은 후보는 `basic_text_area` 또는 `unknown` fallback 으로 둠
+- [x] `origin` 특정 shape id/slide index 없이 fixture 를 통과하는 테스트 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] 첫 슬라이드 하단 chip 이 하나의 `inline_label_group` 으로 묶인다
-- [ ] group item 과 linked background 관계가 metadata 에 함께 기록된다
-- [ ] 애매한 후보는 group 으로 강제 분류되지 않는다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] 첫 슬라이드 하단 chip 이 하나의 `inline_label_group` 으로 묶인다
+- [x] group item 과 linked background 관계가 metadata 에 함께 기록된다
+- [x] 애매한 후보는 group 으로 강제 분류되지 않는다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -200,6 +200,52 @@ def test_v2_payload_writer_enriches_item_background_and_keeps_container_referenc
     assert payloads.reference["shape_inferences"][1]["allowed_actions"] == []
 
 
+def test_v2_payload_writer_maps_layout_group_by_item_shape_ids() -> None:
+    """layout group이 item_shape_ids만 제공해도 slot에 group metadata를 연결한다."""
+    payloads = build_template_v2_payloads(
+        "ppt-v3",
+        extraction=TemplateV2Extraction(
+            slots=(
+                {
+                    "slot_id": "slide2_shape20",
+                    "shape_id": "20",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "Python",
+                },
+                {
+                    "slot_id": "slide2_shape22",
+                    "shape_id": "22",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "FastAPI",
+                },
+            ),
+            layout_groups=(
+                {
+                    "group_id": "slide2_inline_label_group1",
+                    "layout_type": "inline_label_group",
+                    "flow": "horizontal",
+                    "item_shape_ids": ["20", "22"],
+                    "gap_emu": 50,
+                    "min_gap_emu": 50,
+                    "wrap_allowed": False,
+                },
+            ),
+        ),
+    )
+
+    assert [slot["layout_group_id"] for slot in payloads.metadata["slots"]] == [
+        "slide2_inline_label_group1",
+        "slide2_inline_label_group1",
+    ]
+    assert {slot["fit_policy"] for slot in payloads.metadata["slots"]} == {"resize_label"}
+    assert all(slot["nowrap"] is True for slot in payloads.metadata["slots"])
+    assert payloads.metadata["layout_groups"][0]["item_shape_ids"] == ["20", "22"]
+
+
 def test_v2_payload_writer_ignores_invalid_or_duplicate_item_backgrounds() -> None:
     """검증되지 않은 item_background는 slot 계약으로 승격하지 않는다."""
     payloads = build_template_v2_payloads(
@@ -734,6 +780,427 @@ def test_compile_template_v2_links_origin_style_chip_item_backgrounds(
         "slide2_shape22",
     }
     assert {inference["shape_id"] for inference in item_inferences} == {"19", "21"}
+
+
+def test_compile_template_v2_groups_origin_style_inline_label_chips(
+    tmp_path: Path,
+) -> None:
+    """첫 runtime slide 하단 chip row를 하나의 inline_label_group으로 묶는다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_without_text_xml(
+                            19,
+                            "OpenAI chip background",
+                            x=90,
+                            y=790,
+                            width=320,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            20,
+                            "OpenAI chip",
+                            (_run_xml("OpenAI API", color="FF0000"),),
+                            x=100,
+                            y=800,
+                            width=300,
+                            height=100,
+                        ),
+                        _shape_without_text_xml(
+                            21,
+                            "FastAPI chip background",
+                            x=440,
+                            y=790,
+                            width=290,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            22,
+                            "FastAPI chip",
+                            (_run_xml("FastAPI", color="FF0000"),),
+                            x=450,
+                            y=800,
+                            width=270,
+                            height=100,
+                        ),
+                        _shape_without_text_xml(
+                            23,
+                            "LangGraph chip background",
+                            x=770,
+                            y=790,
+                            width=350,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            24,
+                            "LangGraph chip",
+                            (_run_xml("LangGraph", color="FF0000"),),
+                            x=780,
+                            y=800,
+                            width=330,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "OpenAI example",
+                            (_run_xml("OpenAI API", color="123456"),),
+                            x=100,
+                            y=800,
+                            width=300,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            31,
+                            "FastAPI example",
+                            (_run_xml("FastAPI", color="123456"),),
+                            x=450,
+                            y=800,
+                            width=270,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            32,
+                            "LangGraph example",
+                            (_run_xml("LangGraph", color="123456"),),
+                            x=780,
+                            y=800,
+                            width=330,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    assert len(metadata["layout_groups"]) == 1
+    group = metadata["layout_groups"][0]
+    assert group["group_id"] == "slide2_inline_label_group1"
+    assert group["layout_type"] == "inline_label_group"
+    assert group["flow"] == "horizontal"
+    assert group["item_slot_ids"] == ["slide2_shape20", "slide2_shape22", "slide2_shape24"]
+    assert group["item_shape_ids"] == ["20", "22", "24"]
+    assert group["gap_emu"] == 55
+    assert group["min_gap_emu"] == 50
+    assert group["wrap_allowed"] is False
+
+    slots_by_id = {slot["slot_id"]: slot for slot in metadata["slots"]}
+    for slot_id in group["item_slot_ids"]:
+        slot = slots_by_id[slot_id]
+        assert slot["layout_group_id"] == "slide2_inline_label_group1"
+        assert slot["fit_policy"] == "resize_label"
+        assert slot["max_lines"] == 1
+        assert slot["nowrap"] is True
+        assert "layout_type" not in slot
+
+
+def test_compile_template_v2_records_inline_label_group_linked_backgrounds(
+    tmp_path: Path,
+) -> None:
+    """inline_label_group metadata에 item과 linked background 관계를 함께 기록한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_without_text_xml(
+                            19,
+                            "Python chip background",
+                            x=90,
+                            y=790,
+                            width=260,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            20,
+                            "Python chip",
+                            (_run_xml("Python", color="FF0000"),),
+                            x=100,
+                            y=800,
+                            width=240,
+                            height=100,
+                        ),
+                        _shape_without_text_xml(
+                            21,
+                            "FastAPI chip background",
+                            x=390,
+                            y=790,
+                            width=290,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            22,
+                            "FastAPI chip",
+                            (_run_xml("FastAPI", color="FF0000"),),
+                            x=400,
+                            y=800,
+                            width=270,
+                            height=100,
+                        ),
+                        _shape_without_text_xml(
+                            23,
+                            "Postgres chip background",
+                            x=720,
+                            y=790,
+                            width=330,
+                            height=120,
+                        ),
+                        _shape_xml(
+                            24,
+                            "Postgres chip",
+                            (_run_xml("Postgres", color="FF0000"),),
+                            x=730,
+                            y=800,
+                            width=310,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "Python example",
+                            (_run_xml("Python", color="123456"),),
+                            x=100,
+                            y=800,
+                            width=240,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            31,
+                            "FastAPI example",
+                            (_run_xml("FastAPI", color="123456"),),
+                            x=400,
+                            y=800,
+                            width=270,
+                            height=100,
+                        ),
+                        _shape_xml(
+                            32,
+                            "Postgres example",
+                            (_run_xml("Postgres", color="123456"),),
+                            x=730,
+                            y=800,
+                            width=310,
+                            height=100,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    group = metadata["layout_groups"][0]
+    assert group["linked_background_by_item"] == {
+        "20": {
+            "slot_id": "slide2_shape20",
+            "background_shape_id": "19",
+            "background_shape_name": "Python chip background",
+            "match_score": group["linked_background_by_item"]["20"]["match_score"],
+            "resize_linked": True,
+        },
+        "22": {
+            "slot_id": "slide2_shape22",
+            "background_shape_id": "21",
+            "background_shape_name": "FastAPI chip background",
+            "match_score": group["linked_background_by_item"]["22"]["match_score"],
+            "resize_linked": True,
+        },
+        "24": {
+            "slot_id": "slide2_shape24",
+            "background_shape_id": "23",
+            "background_shape_name": "Postgres chip background",
+            "match_score": group["linked_background_by_item"]["24"]["match_score"],
+            "resize_linked": True,
+        },
+    }
+
+
+def test_compile_template_v2_requires_all_inline_label_backgrounds(
+    tmp_path: Path,
+) -> None:
+    """일부 item_background가 빠진 chip row는 group으로 승격하지 않는다."""
+    chip_specs = (
+        (19, 20, "Python", 90, 100, 240),
+        (21, 22, "FastAPI", 360, 370, 260),
+        (23, 24, "Postgres", 650, 660, 280),
+        (None, 25, "LangGraph", 960, 970, 300),
+    )
+    runtime_shapes: list[str] = []
+    example_shapes: list[str] = []
+    for index, (background_id, shape_id, text, background_x, text_x, width) in enumerate(
+        chip_specs,
+        start=1,
+    ):
+        if background_id is not None:
+            runtime_shapes.append(
+                _shape_without_text_xml(
+                    background_id,
+                    f"{text} chip background",
+                    x=background_x,
+                    y=790,
+                    width=width + 20,
+                    height=120,
+                )
+            )
+        runtime_shapes.append(
+            _shape_xml(
+                shape_id,
+                f"{text} chip",
+                (_run_xml(text, color="FF0000"),),
+                x=text_x,
+                y=800,
+                width=width,
+                height=100,
+            )
+        )
+        example_shapes.append(
+            _shape_xml(
+                30 + index,
+                f"{text} example",
+                (_run_xml(text, color="123456"),),
+                x=text_x,
+                y=800,
+                width=width,
+                height=100,
+            )
+        )
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(2, "".join(runtime_shapes)),
+            _slide_xml(3, "".join(example_shapes)),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    assert any("background 신뢰도가 부족" in warning for warning in result.warnings)
+    metadata = read_json_payload(result.meta_path)
+    assert metadata["layout_groups"] == []
+    assert all("layout_group_id" not in slot for slot in metadata["slots"])
+
+
+def test_compile_template_v2_keeps_ambiguous_inline_label_candidate_as_basic_text(
+    tmp_path: Path,
+) -> None:
+    """background 신뢰도가 없는 짧은 row는 group으로 강제 분류하지 않는다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_xml(
+                            20,
+                            "First short text",
+                            (_run_xml("첫째", color="FF0000"),),
+                            x=100,
+                            y=800,
+                            width=160,
+                            height=80,
+                        ),
+                        _shape_xml(
+                            21,
+                            "Second short text",
+                            (_run_xml("둘째", color="FF0000"),),
+                            x=290,
+                            y=800,
+                            width=160,
+                            height=80,
+                        ),
+                        _shape_xml(
+                            22,
+                            "Third short text",
+                            (_run_xml("셋째", color="FF0000"),),
+                            x=480,
+                            y=800,
+                            width=160,
+                            height=80,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                "".join(
+                    (
+                        _shape_xml(
+                            30,
+                            "First example",
+                            (_run_xml("첫째 예시", color="123456"),),
+                            x=100,
+                            y=800,
+                            width=160,
+                            height=80,
+                        ),
+                        _shape_xml(
+                            31,
+                            "Second example",
+                            (_run_xml("둘째 예시", color="123456"),),
+                            x=290,
+                            y=800,
+                            width=160,
+                            height=80,
+                        ),
+                        _shape_xml(
+                            32,
+                            "Third example",
+                            (_run_xml("셋째 예시", color="123456"),),
+                            x=480,
+                            y=800,
+                            width=160,
+                            height=80,
+                        ),
+                    )
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    assert any("background 신뢰도가 부족" in warning for warning in result.warnings)
+    metadata = read_json_payload(result.meta_path)
+    assert metadata["layout_groups"] == []
+    assert all("layout_group_id" not in slot for slot in metadata["slots"])
+    assert {slot["fit_policy"] for slot in metadata["slots"]} == {"basic_text_area"}
 
 
 def test_compile_template_v2_records_large_card_as_container_shape(


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #262

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 반복되는 짧은 editable text slot row를 bbox alignment, 높이/폭 유사도, gap 규칙으로 `inline_label_group` 후보로 추론합니다.
- 확정된 group에 `group_id`, `layout_type`, `flow`, `item_slot_ids`, `item_shape_ids`, `gap_emu`, `min_gap_emu`, `wrap_allowed`를 기록합니다.
- 모든 item에 신뢰 가능한 `item_background` 연결이 있을 때만 group으로 승격하고, 애매한 후보는 warning과 함께 fallback으로 둡니다.
- v2 payload writer가 group metadata를 slot에 연결해 `resize_label`, `max_lines=1`, `nowrap=True` capacity 정책을 부여합니다.
- `item_shape_ids`만 있는 group도 slot 매핑이 가능하도록 fallback 경로를 추가했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `git diff --check`
  - `uv run pytest -q tests/test_features/test_visualization/test_template_v2_compiler.py` → `29 passed`
  - `uv run pytest -q` → `904 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 background 연결 비율이 아닌 전 item 연결 요구로 강화했습니다.
- `layout_type`은 group 단위 metadata로 유지하고, slot에는 `layout_group_id`와 fit capacity만 반영합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 프레젠테이션 템플릿에서 인라인 라벨 그룹 추론 기능을 추가하여 텍스트 슬롯 처리 정확도를 향상했습니다.

* **Improvements**
  * 슬롯 메타데이터를 레이아웃 그룹 정보로 보강하여 템플릿 컴파일 성능을 개선했습니다.

* **Tests**
  * 템플릿 컴파일 및 페이로드 생성 동작을 검증하는 포괄적인 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->