### PR TITLE
[PPTX] basic_text_area fit preflight 추가

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -35,6 +35,11 @@ from features.visualization.pptx import (
 from features.visualization.qa import SlidePreview, VisualQA, VisualQAFixVerifyStep
 from features.visualization.storage.gcs_client import GcsClient, job_workdir, preview_key
 from features.visualization.templates import require_template_v2_metadata
+from features.visualization.text_fit import (
+    BasicTextFitResult,
+    TextFitPreflightError,
+    apply_text_fit_preflight,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -379,6 +384,11 @@ class VisualizationTaskService:
                 toolchain = self._toolchain_factory()
                 editor = self._editor_factory()
                 renderer = self._renderer_factory()
+                template_metadata = _load_optional_template_metadata(
+                    job_context=job_context,
+                    storage=storage,
+                    workdir=workdir,
+                )
 
                 current_pptx = workdir / "current.pptx"
                 unpacked_dir = workdir / "unpacked"
@@ -393,10 +403,22 @@ class VisualizationTaskService:
 
                 slide_xml_path = _slide_xml_path(unpacked_dir, registered_slide.slide_filename)
                 slots = await asyncio.to_thread(editor.extract_slots, str(slide_xml_path))
+                slots = _enrich_slots_with_template_metadata(
+                    slots,
+                    template_metadata=template_metadata,
+                    slide_filename=registered_slide.slide_filename,
+                )
                 if task.is_retry:
                     updated_fills = await self._create_fills_with_timeout_retry(
                         content_brief=content_brief,
                         slots=slots,
+                    )
+                    updated_fills = _preflight_text_fills(
+                        job_id=task.job_id,
+                        slide_id=registered_slide.slide_id,
+                        slide_order=registered_slide.slide_order,
+                        slots=slots,
+                        fills=updated_fills,
                     )
                     await asyncio.to_thread(editor.apply_fills, str(slide_xml_path), updated_fills)
                 else:
@@ -409,6 +431,13 @@ class VisualizationTaskService:
                     )
                     if not changes:
                         raise ValueError("재생성 변경 지시가 비어 있습니다.")
+                    changes = _preflight_text_fills(
+                        job_id=task.job_id,
+                        slide_id=registered_slide.slide_id,
+                        slide_order=registered_slide.slide_order,
+                        slots=slots,
+                        fills=changes,
+                    )
                     await asyncio.to_thread(editor.apply_fills, str(slide_xml_path), changes)
                     updated_fills = merge_current_fills(current_fills, changes)
 
@@ -592,6 +621,7 @@ class VisualizationTaskService:
                     unpacked_dir=unpacked_dir,
                     planned_slides=slide_plan.selected_slides,
                     registered_slides=registered_slides,
+                    template_metadata=template_metadata,
                 )
                 ready_content = [
                     outcome for outcome in content_outcomes if outcome.status == "ready"
@@ -755,6 +785,7 @@ class VisualizationTaskService:
         unpacked_dir: Path,
         planned_slides: Sequence[PlannedSlide],
         registered_slides: dict[int, RegisteredSlide],
+        template_metadata: Mapping[str, Any],
     ) -> list[_ContentOutcome]:
         semaphore = asyncio.Semaphore(self._max_content_concurrency)
         tasks = [
@@ -766,6 +797,7 @@ class VisualizationTaskService:
                     unpacked_dir=unpacked_dir,
                     planned_slide=planned_slide,
                     registered_slide=registered_slides[planned_slide.slide_order],
+                    template_metadata=template_metadata,
                     semaphore=semaphore,
                 )
             )
@@ -791,15 +823,28 @@ class VisualizationTaskService:
         unpacked_dir: Path,
         planned_slide: PlannedSlide,
         registered_slide: RegisteredSlide,
+        template_metadata: Mapping[str, Any],
         semaphore: asyncio.Semaphore,
     ) -> _ContentOutcome:
         async with semaphore:
             slide_xml_path = _slide_xml_path(unpacked_dir, planned_slide.slide_filename)
             try:
                 slots = await asyncio.to_thread(editor.extract_slots, str(slide_xml_path))
+                slots = _enrich_slots_with_template_metadata(
+                    slots,
+                    template_metadata=template_metadata,
+                    slide_filename=planned_slide.slide_filename,
+                )
                 fills = await self._create_fills_with_timeout_retry(
                     content_brief=planned_slide.content_brief,
                     slots=slots,
+                )
+                fills = _preflight_text_fills(
+                    job_id=task.job_id,
+                    slide_id=registered_slide.slide_id,
+                    slide_order=registered_slide.slide_order,
+                    slots=slots,
+                    fills=fills,
                 )
                 await asyncio.to_thread(editor.apply_fills, str(slide_xml_path), fills)
             except Exception as exc:
@@ -1037,6 +1082,58 @@ __all__ = [
 ]
 
 
+def _preflight_text_fills(
+    *,
+    job_id: str,
+    slide_id: str,
+    slide_order: int,
+    slots: Sequence[Mapping[str, Any]],
+    fills: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """OOXML 적용 전 `basic_text_area` 텍스트 fit 정책을 실행한다."""
+    try:
+        preflight = apply_text_fit_preflight(slots=slots, fills=fills)
+    except TextFitPreflightError as exc:
+        for result in exc.results:
+            _log_text_fit_result(
+                job_id=job_id,
+                slide_id=slide_id,
+                slide_order=slide_order,
+                result=result,
+            )
+        raise
+
+    for result in preflight.results:
+        _log_text_fit_result(
+            job_id=job_id,
+            slide_id=slide_id,
+            slide_order=slide_order,
+            result=result,
+        )
+    return preflight.fills
+
+
+def _log_text_fit_result(
+    *,
+    job_id: str,
+    slide_id: str,
+    slide_order: int,
+    result: BasicTextFitResult,
+) -> None:
+    """fit 결과와 실패 사유를 structured log 로 남긴다."""
+    logger.info(
+        "pptx text fit preflight result",
+        extra={
+            "pptx_text_fit": {
+                "job_id": job_id,
+                "slide_id": slide_id,
+                "slide_order": slide_order,
+                **result.to_log_dict(),
+            }
+        },
+    )
+
+
 def _default_qa_step_factory(
     storage: StorageClient,
     main_client: MainClient,
@@ -1097,6 +1194,115 @@ def _load_template_metadata(path: Path) -> dict[str, Any]:
             error_code="TEMPLATE_METADATA_SCHEMA_INVALID",
         ) from exc
     return metadata
+
+
+def _load_optional_template_metadata(
+    *,
+    job_context: Mapping[str, Any],
+    storage: StorageClient,
+    workdir: Path,
+) -> dict[str, Any] | None:
+    """재생성 경로에서 가능하면 v2 template metadata 를 확보한다."""
+    embedded_metadata = _template_metadata_from_job_context(job_context)
+    if embedded_metadata is not None:
+        require_template_v2_metadata(embedded_metadata)
+        return embedded_metadata
+
+    template_id = _optional_text(job_context, "template_id")
+    if template_id is None:
+        return None
+
+    template_meta_path = workdir / "meta.json"
+    try:
+        storage.download_template_meta(template_id, template_meta_path)
+        return _load_template_metadata(template_meta_path)
+    except Exception:
+        logger.warning(
+            "template metadata unavailable for regenerate; using raw slots: template_id=%s",
+            template_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _template_metadata_from_job_context(job_context: Mapping[str, Any]) -> dict[str, Any] | None:
+    for key in ("template_metadata", "templateMetadata", "template_meta", "templateMeta"):
+        value = job_context.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return None
+
+
+def _enrich_slots_with_template_metadata(
+    slots: Sequence[Mapping[str, Any]],
+    *,
+    template_metadata: Mapping[str, Any] | None,
+    slide_filename: str,
+) -> list[dict[str, Any]]:
+    """OOXML slot 에 v2 metadata slot 필드를 overlay 한다."""
+    raw_slots = [dict(slot) for slot in slots]
+    if template_metadata is None:
+        return raw_slots
+
+    template_slots = _template_slots_by_shape_id(
+        template_metadata=template_metadata,
+        slide_filename=slide_filename,
+    )
+    if not template_slots:
+        return raw_slots
+
+    enriched_slots: list[dict[str, Any]] = []
+    for slot in raw_slots:
+        shape_id = str(slot.get("shape_id") or "")
+        template_slot = template_slots.get(shape_id)
+        if template_slot is None:
+            enriched_slots.append(slot)
+            continue
+        merged = dict(template_slot)
+        merged.update(slot)
+        enriched_slots.append(merged)
+    return enriched_slots
+
+
+def _template_slots_by_shape_id(
+    *,
+    template_metadata: Mapping[str, Any],
+    slide_filename: str,
+) -> dict[str, Mapping[str, Any]]:
+    slots = template_metadata.get("slots")
+    if not isinstance(slots, Sequence) or isinstance(slots, str | bytes | bytearray):
+        return {}
+
+    indexed: dict[str, Mapping[str, Any]] = {}
+    for slot in slots:
+        if not isinstance(slot, Mapping):
+            continue
+        if not _metadata_slot_matches_slide(slot, slide_filename):
+            continue
+        shape_id = str(slot.get("shape_id") or "")
+        if not shape_id:
+            continue
+        indexed.setdefault(shape_id, slot)
+    return indexed
+
+
+def _metadata_slot_matches_slide(slot: Mapping[str, Any], slide_filename: str) -> bool:
+    slot_filename = _optional_text(slot, "slide_filename")
+    if slot_filename is not None:
+        return Path(slot_filename).name == slide_filename
+
+    slide_part = _optional_text(slot, "slide_part")
+    if slide_part is not None:
+        return Path(slide_part).name == slide_filename
+
+    return True
+
+
+def _optional_text(data: Mapping[str, Any], key: str) -> str | None:
+    value = data.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
 
 
 def _registered_slides_by_order(

--- a/features/visualization/text_fit.py
+++ b/features/visualization/text_fit.py
@@ -1,0 +1,689 @@
+"""PPTX 텍스트 fit preflight 휴리스틱."""
+
+from __future__ import annotations
+
+import math
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+EMU_PER_PT = 12_700.0
+DEFAULT_SAFETY_MARGIN_RATIO = 0.12
+MIN_SAFETY_MARGIN_RATIO = 0.10
+MAX_SAFETY_MARGIN_RATIO = 0.15
+DEFAULT_HORIZONTAL_PADDING_PT = 4.0
+DEFAULT_VERTICAL_PADDING_PT = 2.0
+DEFAULT_FONT_PT = 12.0
+DEFAULT_MIN_FONT_PT = 10.0
+ABSOLUTE_MIN_FONT_PT = 8.0
+LINE_HEIGHT_MULTIPLIER = 1.2
+SHRINK_STEP_PT = 0.5
+LOG_LINE_WIDTH_LIMIT = 8
+
+_BASIC_TEXT_TYPES = {"basic_text_area"}
+_BASIC_TEXT_POLICIES = {"basic_text_area"}
+
+TextFitStatus = Literal["fit", "shrunk", "summarize_needed", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class TextWidthBreakdown:
+    """문자군별 폭 계산 근거."""
+
+    hangul: int = 0
+    latin: int = 0
+    digit: int = 0
+    space: int = 0
+    symbol: int = 0
+    wide: int = 0
+    newline: int = 0
+
+    def to_log_dict(self) -> dict[str, int]:
+        """structured log 에 넣을 dict 로 변환한다."""
+        return {
+            "hangul": self.hangul,
+            "latin": self.latin,
+            "digit": self.digit,
+            "space": self.space,
+            "symbol": self.symbol,
+            "wide": self.wide,
+            "newline": self.newline,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TextMeasurement:
+    """휴리스틱 텍스트 폭 측정 결과."""
+
+    text: str
+    font_size_pt: float
+    width_pt: float
+    line_widths_pt: tuple[float, ...]
+    breakdown: TextWidthBreakdown
+
+    @property
+    def line_count(self) -> int:
+        """명시적 줄바꿈 기준 줄 수."""
+        return len(self.line_widths_pt)
+
+    def to_log_dict(self) -> dict[str, Any]:
+        """structured log 에 넣을 dict 로 변환한다."""
+        return {
+            "font_size_pt": self.font_size_pt,
+            "width_pt": self.width_pt,
+            "line_widths_pt": _limited_log_line_widths(self.line_widths_pt),
+            "line_widths_truncated": len(self.line_widths_pt) > LOG_LINE_WIDTH_LIMIT,
+            "line_count": self.line_count,
+            "breakdown": self.breakdown.to_log_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TextLayoutEstimate:
+    """줄바꿈 적용 후 텍스트 박스 안에서의 예상 배치."""
+
+    font_size_pt: float
+    nowrap: bool
+    line_widths_pt: tuple[float, ...]
+    line_count: int
+    max_line_width_pt: float
+    height_pt: float
+    overflow_reasons: tuple[str, ...]
+
+    @property
+    def fits(self) -> bool:
+        """현재 제약 안에 들어가는지 여부."""
+        return not self.overflow_reasons
+
+    def to_log_dict(self) -> dict[str, Any]:
+        """structured log 에 넣을 dict 로 변환한다."""
+        return {
+            "font_size_pt": self.font_size_pt,
+            "nowrap": self.nowrap,
+            "line_widths_pt": _limited_log_line_widths(self.line_widths_pt),
+            "line_widths_truncated": len(self.line_widths_pt) > LOG_LINE_WIDTH_LIMIT,
+            "line_count": self.line_count,
+            "max_line_width_pt": self.max_line_width_pt,
+            "height_pt": self.height_pt,
+            "overflow_reasons": list(self.overflow_reasons),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TextBoxConstraints:
+    """텍스트 fit 검사에 사용하는 박스 제약."""
+
+    width_pt: float
+    height_pt: float
+    content_width_pt: float
+    content_height_pt: float
+    padding_left_pt: float
+    padding_right_pt: float
+    padding_top_pt: float
+    padding_bottom_pt: float
+    safety_margin_ratio: float
+    max_lines: int
+    nowrap: bool
+
+    @property
+    def available_width_pt(self) -> float:
+        """safety margin 을 뺀 실제 사용 가능 폭."""
+        return self.content_width_pt / (1.0 + self.safety_margin_ratio)
+
+    @property
+    def available_height_pt(self) -> float:
+        """safety margin 을 뺀 실제 사용 가능 높이."""
+        return self.content_height_pt / (1.0 + self.safety_margin_ratio)
+
+    def to_log_dict(self) -> dict[str, Any]:
+        """structured log 에 넣을 dict 로 변환한다."""
+        return {
+            "width_pt": self.width_pt,
+            "height_pt": self.height_pt,
+            "content_width_pt": self.content_width_pt,
+            "content_height_pt": self.content_height_pt,
+            "available_width_pt": self.available_width_pt,
+            "available_height_pt": self.available_height_pt,
+            "padding_left_pt": self.padding_left_pt,
+            "padding_right_pt": self.padding_right_pt,
+            "padding_top_pt": self.padding_top_pt,
+            "padding_bottom_pt": self.padding_bottom_pt,
+            "safety_margin_ratio": self.safety_margin_ratio,
+            "max_lines": self.max_lines,
+            "nowrap": self.nowrap,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BasicTextFitResult:
+    """`basic_text_area` preflight 판정 결과."""
+
+    shape_id: str
+    status: TextFitStatus
+    reason: str | None
+    original_font_pt: float
+    applied_font_pt: float
+    min_font_pt: float
+    max_lines: int
+    nowrap: bool
+    measurement: TextMeasurement
+    initial_layout: TextLayoutEstimate
+    final_layout: TextLayoutEstimate
+    constraints: TextBoxConstraints
+
+    @property
+    def is_blocking(self) -> bool:
+        """OOXML 적용을 중단해야 하는 결과인지 반환한다."""
+        return self.status in {"summarize_needed", "failed"}
+
+    def to_log_dict(self) -> dict[str, Any]:
+        """structured log 에 넣을 dict 로 변환한다."""
+        return {
+            "shape_id": self.shape_id,
+            "fit_policy": "basic_text_area",
+            "status": self.status,
+            "reason": self.reason,
+            "original_font_pt": self.original_font_pt,
+            "applied_font_pt": self.applied_font_pt,
+            "min_font_pt": self.min_font_pt,
+            "max_lines": self.max_lines,
+            "nowrap": self.nowrap,
+            "measurement": self.measurement.to_log_dict(),
+            "initial_layout": self.initial_layout.to_log_dict(),
+            "final_layout": self.final_layout.to_log_dict(),
+            "constraints": self.constraints.to_log_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TextFitPreflightResult:
+    """fill 맵에 대한 text fit preflight 전체 결과."""
+
+    fills: dict[str, dict[str, Any]]
+    results: tuple[BasicTextFitResult, ...]
+
+
+class TextFitPreflightError(ValueError):
+    """텍스트 fit preflight 가 차단 결과로 끝났을 때 발생한다."""
+
+    def __init__(self, results: Sequence[BasicTextFitResult]) -> None:
+        self.results = tuple(results)
+        first = next((result for result in self.results if result.is_blocking), self.results[0])
+        super().__init__(
+            "basic_text_area 텍스트가 slot 용량을 초과했습니다. "
+            f"shape_id={first.shape_id}, status={first.status}, reason={first.reason}"
+        )
+
+
+def measure_text_width(text: str, *, font_size_pt: float) -> TextMeasurement:
+    """
+    문자군별 계수로 텍스트 폭을 deterministic 하게 추정한다.
+
+    실제 font metric 이 아니라 한글/CJK, 영문, 숫자, 공백, 기호에 고정 계수를 곱한다.
+    """
+    font_size = _positive_float(font_size_pt) or DEFAULT_FONT_PT
+    line_widths: list[float] = []
+    current_width = 0.0
+    counts = {
+        "hangul": 0,
+        "latin": 0,
+        "digit": 0,
+        "space": 0,
+        "symbol": 0,
+        "wide": 0,
+        "newline": 0,
+    }
+    for char in text:
+        if char == "\n":
+            line_widths.append(_round_pt(current_width))
+            current_width = 0.0
+            counts["newline"] += 1
+            continue
+        group, unit = _character_width_unit(char)
+        counts[group] += 1
+        current_width += unit * font_size
+    line_widths.append(_round_pt(current_width))
+
+    return TextMeasurement(
+        text=text,
+        font_size_pt=_round_pt(font_size),
+        width_pt=max(line_widths) if line_widths else 0.0,
+        line_widths_pt=tuple(line_widths),
+        breakdown=TextWidthBreakdown(**counts),
+    )
+
+
+def estimate_text_layout(
+    text: str,
+    *,
+    font_size_pt: float,
+    constraints: TextBoxConstraints,
+) -> TextLayoutEstimate:
+    """텍스트가 주어진 제약 안에서 몇 줄로 배치될지 추정한다."""
+    font_size = _positive_float(font_size_pt) or DEFAULT_FONT_PT
+    available_width = constraints.available_width_pt
+    if constraints.nowrap:
+        line_widths = measure_text_width(text, font_size_pt=font_size).line_widths_pt
+    else:
+        line_widths = _wrap_text_line_widths(
+            text,
+            font_size_pt=font_size,
+            available_width_pt=available_width,
+        )
+
+    max_line_width = max(line_widths) if line_widths else 0.0
+    line_count = len(line_widths)
+    height = _round_pt(line_count * font_size * LINE_HEIGHT_MULTIPLIER)
+    overflow_reasons: list[str] = []
+    if constraints.content_width_pt <= 0:
+        overflow_reasons.append("content_width_too_small")
+    if constraints.content_height_pt <= 0:
+        overflow_reasons.append("content_height_too_small")
+    if constraints.nowrap and any(width > available_width for width in line_widths):
+        overflow_reasons.append("nowrap_width_overflow")
+    if line_count > constraints.max_lines:
+        overflow_reasons.append("max_lines_overflow")
+    if max_line_width > available_width:
+        overflow_reasons.append("width_overflow")
+    if height > constraints.available_height_pt:
+        overflow_reasons.append("height_overflow")
+
+    return TextLayoutEstimate(
+        font_size_pt=_round_pt(font_size),
+        nowrap=constraints.nowrap,
+        line_widths_pt=tuple(_round_pt(width) for width in line_widths),
+        line_count=line_count,
+        max_line_width_pt=_round_pt(max_line_width),
+        height_pt=height,
+        overflow_reasons=tuple(dict.fromkeys(overflow_reasons)),
+    )
+
+
+def evaluate_basic_text_area_fit(
+    *,
+    slot: Mapping[str, Any],
+    fill: Mapping[str, Any],
+) -> BasicTextFitResult:
+    """단일 `basic_text_area` fill 을 측정하고 shrink/요약/실패 상태를 판정한다."""
+    shape_id = str(slot.get("shape_id") or "")
+    text = str(fill.get("text") or "")
+    original_font = _fill_font_size(slot, fill)
+    min_font = _min_font_size(slot, original_font)
+    constraints = _constraints_from_slot(slot)
+    effective_font = max(original_font, min_font)
+    measurement = measure_text_width(text, font_size_pt=effective_font)
+
+    if constraints.content_width_pt <= 0 or constraints.content_height_pt <= 0:
+        layout = estimate_text_layout(text, font_size_pt=effective_font, constraints=constraints)
+        return BasicTextFitResult(
+            shape_id=shape_id,
+            status="failed",
+            reason=_first_reason(layout, "invalid_text_box"),
+            original_font_pt=_round_pt(original_font),
+            applied_font_pt=_round_pt(effective_font),
+            min_font_pt=min_font,
+            max_lines=constraints.max_lines,
+            nowrap=constraints.nowrap,
+            measurement=measurement,
+            initial_layout=layout,
+            final_layout=layout,
+            constraints=constraints,
+        )
+
+    initial_layout = estimate_text_layout(
+        text,
+        font_size_pt=effective_font,
+        constraints=constraints,
+    )
+    if initial_layout.fits:
+        return BasicTextFitResult(
+            shape_id=shape_id,
+            status="fit",
+            reason=None if original_font >= min_font else "font_below_min",
+            original_font_pt=_round_pt(original_font),
+            applied_font_pt=_round_pt(effective_font),
+            min_font_pt=min_font,
+            max_lines=constraints.max_lines,
+            nowrap=constraints.nowrap,
+            measurement=measurement,
+            initial_layout=initial_layout,
+            final_layout=initial_layout,
+            constraints=constraints,
+        )
+
+    for candidate_font in _shrink_candidates(effective_font, min_font):
+        candidate_layout = estimate_text_layout(
+            text,
+            font_size_pt=candidate_font,
+            constraints=constraints,
+        )
+        if candidate_layout.fits:
+            return BasicTextFitResult(
+                shape_id=shape_id,
+                status="shrunk",
+                reason=None,
+                original_font_pt=_round_pt(original_font),
+                applied_font_pt=_round_pt(candidate_font),
+                min_font_pt=min_font,
+                max_lines=constraints.max_lines,
+                nowrap=constraints.nowrap,
+                measurement=measurement,
+                initial_layout=initial_layout,
+                final_layout=candidate_layout,
+                constraints=constraints,
+            )
+
+    min_layout = estimate_text_layout(text, font_size_pt=min_font, constraints=constraints)
+    status: TextFitStatus = "summarize_needed"
+    reason = _first_reason(min_layout, "text_overflow")
+    if "content_width_too_small" in min_layout.overflow_reasons:
+        status = "failed"
+    elif "content_height_too_small" in min_layout.overflow_reasons:
+        status = "failed"
+    elif min_font * LINE_HEIGHT_MULTIPLIER > constraints.available_height_pt:
+        status = "failed"
+        reason = "min_font_height_overflow"
+
+    return BasicTextFitResult(
+        shape_id=shape_id,
+        status=status,
+        reason=reason,
+        original_font_pt=_round_pt(original_font),
+        applied_font_pt=min_font,
+        min_font_pt=min_font,
+        max_lines=constraints.max_lines,
+        nowrap=constraints.nowrap,
+        measurement=measurement,
+        initial_layout=initial_layout,
+        final_layout=min_layout,
+        constraints=constraints,
+    )
+
+
+def apply_text_fit_preflight(
+    *,
+    slots: Sequence[Mapping[str, Any]],
+    fills: Mapping[str, Mapping[str, Any]],
+) -> TextFitPreflightResult:
+    """
+    fill 맵에 `basic_text_area` preflight 를 적용한다.
+
+    성공한 shrink 는 `font_size_override` 로 반영하고, 요약/실패가 필요한 결과는
+    `TextFitPreflightError` 로 구조화해 호출자가 렌더 전 중단할 수 있게 한다.
+    """
+    slots_by_id = {str(slot.get("shape_id")): slot for slot in slots if slot.get("shape_id")}
+    adjusted = {str(shape_id): dict(fill) for shape_id, fill in fills.items()}
+    results: list[BasicTextFitResult] = []
+    blocking: list[BasicTextFitResult] = []
+
+    for shape_id, fill in adjusted.items():
+        slot = slots_by_id.get(shape_id)
+        if slot is None or not _uses_basic_text_area(slot):
+            continue
+        if str(fill.get("action") or "text") != "text":
+            continue
+        if not _has_geometry(slot):
+            continue
+
+        result = evaluate_basic_text_area_fit(slot=slot, fill=fill)
+        results.append(result)
+        if result.is_blocking:
+            blocking.append(result)
+            continue
+        if _should_apply_font_override(fill, result):
+            fill["font_size_override"] = result.applied_font_pt
+
+    if blocking:
+        raise TextFitPreflightError(results)
+    return TextFitPreflightResult(fills=adjusted, results=tuple(results))
+
+
+def emu_to_pt(value: Any) -> float | None:
+    """EMU 값을 pt 로 변환한다."""
+    number = _positive_float(value)
+    if number is None:
+        return None
+    return _round_pt(number / EMU_PER_PT)
+
+
+def _character_width_unit(char: str) -> tuple[str, float]:
+    if _is_hangul(char):
+        return "hangul", 1.0
+    if char.isascii() and char.isalpha():
+        return "latin", 0.65 if char.isupper() else 0.55
+    if char.isascii() and char.isdigit():
+        return "digit", 0.55
+    if char.isspace():
+        return "space", 0.33
+    if unicodedata.east_asian_width(char) in {"F", "W"}:
+        return "wide", 1.0
+    return "symbol", 0.45
+
+
+def _is_hangul(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        0xAC00 <= codepoint <= 0xD7A3
+        or 0x1100 <= codepoint <= 0x11FF
+        or 0x3130 <= codepoint <= 0x318F
+        or 0xA960 <= codepoint <= 0xA97F
+        or 0xD7B0 <= codepoint <= 0xD7FF
+    )
+
+
+def _wrap_text_line_widths(
+    text: str,
+    *,
+    font_size_pt: float,
+    available_width_pt: float,
+) -> tuple[float, ...]:
+    if not text:
+        return (0.0,)
+
+    widths: list[float] = []
+    for explicit_line in text.split("\n"):
+        if explicit_line == "":
+            widths.append(0.0)
+            continue
+
+        current_width = 0.0
+        for char in explicit_line:
+            _group, unit = _character_width_unit(char)
+            char_width = unit * font_size_pt
+            if current_width > 0 and current_width + char_width > available_width_pt:
+                widths.append(_round_pt(current_width))
+                current_width = char_width
+            else:
+                current_width += char_width
+        widths.append(_round_pt(current_width))
+    return tuple(widths) or (0.0,)
+
+
+def _constraints_from_slot(slot: Mapping[str, Any]) -> TextBoxConstraints:
+    width_pt = emu_to_pt(slot.get("w_emu")) or 0.0
+    height_pt = emu_to_pt(slot.get("h_emu")) or 0.0
+    padding_left = _slot_padding_pt(slot, "left", DEFAULT_HORIZONTAL_PADDING_PT)
+    padding_right = _slot_padding_pt(slot, "right", DEFAULT_HORIZONTAL_PADDING_PT)
+    padding_top = _slot_padding_pt(slot, "top", DEFAULT_VERTICAL_PADDING_PT)
+    padding_bottom = _slot_padding_pt(slot, "bottom", DEFAULT_VERTICAL_PADDING_PT)
+    max_lines = _positive_int(slot.get("max_lines")) or _fallback_max_lines(slot)
+    nowrap = slot.get("nowrap")
+    if not isinstance(nowrap, bool):
+        nowrap = max_lines == 1
+    safety_margin = _safety_margin_ratio(slot.get("safety_margin_ratio"))
+    content_width = max(0.0, width_pt - padding_left - padding_right)
+    content_height = max(0.0, height_pt - padding_top - padding_bottom)
+    return TextBoxConstraints(
+        width_pt=width_pt,
+        height_pt=height_pt,
+        content_width_pt=_round_pt(content_width),
+        content_height_pt=_round_pt(content_height),
+        padding_left_pt=padding_left,
+        padding_right_pt=padding_right,
+        padding_top_pt=padding_top,
+        padding_bottom_pt=padding_bottom,
+        safety_margin_ratio=safety_margin,
+        max_lines=max_lines,
+        nowrap=nowrap,
+    )
+
+
+def _slot_padding_pt(slot: Mapping[str, Any], side: str, default: float) -> float:
+    side_value = _non_negative_float(slot.get(f"padding_{side}_pt"))
+    if side_value is not None:
+        return _round_pt(side_value)
+
+    axis = "x" if side in {"left", "right"} else "y"
+    axis_value = _non_negative_float(slot.get(f"padding_{axis}_pt"))
+    if axis_value is not None:
+        return _round_pt(axis_value)
+
+    all_value = _non_negative_float(slot.get("padding_pt"))
+    if all_value is not None:
+        return _round_pt(all_value)
+
+    return default
+
+
+def _safety_margin_ratio(value: Any) -> float:
+    ratio = _positive_float(value)
+    if ratio is None:
+        return DEFAULT_SAFETY_MARGIN_RATIO
+    return _round_ratio(min(max(ratio, MIN_SAFETY_MARGIN_RATIO), MAX_SAFETY_MARGIN_RATIO))
+
+
+def _fill_font_size(slot: Mapping[str, Any], fill: Mapping[str, Any]) -> float:
+    return (
+        _positive_float(fill.get("font_size_override"))
+        or _positive_float(slot.get("font_size_pt"))
+        or _positive_float(slot.get("max_font_pt"))
+        or DEFAULT_FONT_PT
+    )
+
+
+def _min_font_size(slot: Mapping[str, Any], original_font: float) -> float:
+    inferred = max(DEFAULT_MIN_FONT_PT, original_font * 0.6)
+    min_font = _positive_float(slot.get("min_font_pt")) or inferred
+    if min_font <= ABSOLUTE_MIN_FONT_PT:
+        min_font = ABSOLUTE_MIN_FONT_PT + SHRINK_STEP_PT
+    return _round_pt(max(min_font, ABSOLUTE_MIN_FONT_PT))
+
+
+def _fallback_max_lines(slot: Mapping[str, Any]) -> int:
+    for field in ("example_text", "placeholder_text", "current_text"):
+        value = slot.get(field)
+        if isinstance(value, str) and value:
+            return max(1, len(value.splitlines()))
+    return 1
+
+
+def _shrink_candidates(original_font: float, min_font: float) -> tuple[float, ...]:
+    candidates: list[float] = []
+    current = _round_pt(original_font - SHRINK_STEP_PT)
+    while current > min_font:
+        candidates.append(current)
+        current = _round_pt(current - SHRINK_STEP_PT)
+    if original_font > min_font:
+        candidates.append(min_font)
+    return tuple(dict.fromkeys(candidates))
+
+
+def _uses_basic_text_area(slot: Mapping[str, Any]) -> bool:
+    if str(slot.get("kind") or "text").casefold() != "text":
+        return False
+    layout_type = str(slot.get("layout_type") or "").strip().casefold()
+    layout_group_type = str(slot.get("layout_group_type") or "").strip().casefold()
+    fit_policy = str(slot.get("fit_policy") or "").strip().casefold()
+    if fit_policy:
+        return fit_policy in _BASIC_TEXT_POLICIES
+    if layout_type or layout_group_type:
+        return layout_type in _BASIC_TEXT_TYPES or layout_group_type in _BASIC_TEXT_TYPES
+    return True
+
+
+def _has_geometry(slot: Mapping[str, Any]) -> bool:
+    return (
+        _positive_float(slot.get("w_emu")) is not None
+        and _positive_float(slot.get("h_emu")) is not None
+    )
+
+
+def _should_apply_font_override(
+    fill: Mapping[str, Any],
+    result: BasicTextFitResult,
+) -> bool:
+    existing = _positive_float(fill.get("font_size_override"))
+    if existing is None:
+        return result.status == "shrunk"
+    return _round_pt(existing) != result.applied_font_pt
+
+
+def _first_reason(layout: TextLayoutEstimate, fallback: str) -> str:
+    if layout.overflow_reasons:
+        return layout.overflow_reasons[0]
+    return fallback
+
+
+def _positive_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number) or number <= 0:
+        return None
+    return number
+
+
+def _non_negative_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number) or number < 0:
+        return None
+    return number
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def _round_pt(value: float) -> float:
+    return round(value, 2)
+
+
+def _round_ratio(value: float) -> float:
+    return round(value, 4)
+
+
+def _limited_log_line_widths(line_widths: Sequence[float]) -> list[float]:
+    return list(line_widths[:LOG_LINE_WIDTH_LIMIT])
+
+
+__all__ = [
+    "ABSOLUTE_MIN_FONT_PT",
+    "BasicTextFitResult",
+    "TextFitPreflightError",
+    "TextFitPreflightResult",
+    "TextLayoutEstimate",
+    "TextMeasurement",
+    "TextWidthBreakdown",
+    "apply_text_fit_preflight",
+    "emu_to_pt",
+    "estimate_text_layout",
+    "evaluate_basic_text_area_fit",
+    "measure_text_width",
+]

--- a/tasks/phase-2-pptx-template-quality/09-heuristic-text-measurement-basic-policy.md
+++ b/tasks/phase-2-pptx-template-quality/09-heuristic-text-measurement-basic-policy.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/03-pptx-deterministic-text-fit-preflight.md"
 depends_on: ["2.08"]
 blocks: []
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -22,23 +23,23 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 한글/영문/숫자/공백/기호 폭 heuristic 기준 정리
-- [ ] 현재 텍스트 축소/요약 정책이 구현된 위치 확인
+- [x] 한글/영문/숫자/공백/기호 폭 heuristic 기준 정리
+- [x] 현재 텍스트 축소/요약 정책이 구현된 위치 확인
 
 ## 구현 체크리스트
 
-- [ ] 문자군별 heuristic text width 측정 유틸 구현
-- [ ] 10~15% safety margin, padding, `max_lines`, `nowrap` 검사 추가
-- [ ] `basic_text_area` fit policy 의 요약, `min_font_pt` 제한, 실패 판정 모델 구현
-- [ ] 8pt 이하 shrink 금지 테스트 추가
-- [ ] fit 결과와 실패 사유 structured log 출력 추가
+- [x] 문자군별 heuristic text width 측정 유틸 구현
+- [x] 10~15% safety margin, padding, `max_lines`, `nowrap` 검사 추가
+- [x] `basic_text_area` fit policy 의 요약, `min_font_pt` 제한, 실패 판정 모델 구현
+- [x] 8pt 이하 shrink 금지 테스트 추가
+- [x] fit 결과와 실패 사유 structured log 출력 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] 한글/영문/숫자 혼합 텍스트의 예상 폭이 deterministic 하게 계산된다
-- [ ] `basic_text_area` 는 `min_font_pt` 아래로 줄이지 않는다
-- [ ] overflow 가 숨겨지지 않고 요약 또는 실패로 수렴한다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] 한글/영문/숫자 혼합 텍스트의 예상 폭이 deterministic 하게 계산된다
+- [x] `basic_text_area` 는 `min_font_pt` 아래로 줄이지 않는다
+- [x] overflow 가 숨겨지지 않고 요약 또는 실패로 수렴한다
 
 ## 리스크 / 메모
 

--- a/tests/test_features/test_visualization/test_text_fit.py
+++ b/tests/test_features/test_visualization/test_text_fit.py
@@ -1,0 +1,188 @@
+"""PPTX 텍스트 fit 휴리스틱 테스트."""
+
+import pytest
+
+from features.visualization.text_fit import (
+    EMU_PER_PT,
+    TextBoxConstraints,
+    TextFitPreflightError,
+    apply_text_fit_preflight,
+    estimate_text_layout,
+    evaluate_basic_text_area_fit,
+    measure_text_width,
+)
+
+
+def test_measure_text_width_is_deterministic_for_mixed_character_groups() -> None:
+    """한글/영문/숫자/공백/기호 혼합 텍스트 폭을 고정 계수로 계산한다."""
+    first = measure_text_width("한A1 !%", font_size_pt=10)
+    second = measure_text_width("한A1 !%", font_size_pt=10)
+
+    assert first == second
+    assert first.width_pt == 34.3
+    assert first.breakdown.hangul == 1
+    assert first.breakdown.latin == 1
+    assert first.breakdown.digit == 1
+    assert first.breakdown.space == 1
+    assert first.breakdown.symbol == 2
+
+
+def test_measure_text_width_counts_uppercase_latin_as_wider_than_lowercase() -> None:
+    """대문자는 소문자보다 넓은 고정 계수로 추정한다."""
+    uppercase = measure_text_width("AAA", font_size_pt=10)
+    lowercase = measure_text_width("aaa", font_size_pt=10)
+
+    assert uppercase.width_pt == 19.5
+    assert lowercase.width_pt == 16.5
+    assert uppercase.width_pt > lowercase.width_pt
+
+
+def test_text_fit_log_dict_caps_line_width_payloads() -> None:
+    """structured log payload 의 line_widths_pt 배열은 최대 개수를 제한한다."""
+    text = "\n".join("A" for _ in range(12))
+    measurement = measure_text_width(text, font_size_pt=10)
+    constraints = TextBoxConstraints(
+        width_pt=80.0,
+        height_pt=200.0,
+        content_width_pt=80.0,
+        content_height_pt=200.0,
+        padding_left_pt=0.0,
+        padding_right_pt=0.0,
+        padding_top_pt=0.0,
+        padding_bottom_pt=0.0,
+        safety_margin_ratio=0.12,
+        max_lines=20,
+        nowrap=True,
+    )
+    layout = estimate_text_layout(text, font_size_pt=10, constraints=constraints)
+
+    measurement_log = measurement.to_log_dict()
+    layout_log = layout.to_log_dict()
+    assert len(measurement_log["line_widths_pt"]) == 8
+    assert measurement_log["line_widths_truncated"] is True
+    assert measurement_log["line_count"] == 12
+    assert len(layout_log["line_widths_pt"]) == 8
+    assert layout_log["line_widths_truncated"] is True
+    assert layout_log["line_count"] == 12
+
+
+def test_nowrap_overflow_keeps_single_line_without_arbitrary_wrap() -> None:
+    """nowrap 텍스트는 공백이 있어도 임의 줄바꿈하지 않고 폭 overflow 로 판정한다."""
+    constraints = TextBoxConstraints(
+        width_pt=50.0,
+        height_pt=30.0,
+        content_width_pt=50.0,
+        content_height_pt=30.0,
+        padding_left_pt=0.0,
+        padding_right_pt=0.0,
+        padding_top_pt=0.0,
+        padding_bottom_pt=0.0,
+        safety_margin_ratio=0.12,
+        max_lines=1,
+        nowrap=True,
+    )
+
+    layout = estimate_text_layout("OpenAI API", font_size_pt=12, constraints=constraints)
+
+    assert layout.line_count == 1
+    assert "nowrap_width_overflow" in layout.overflow_reasons
+
+
+def test_max_lines_overflow_is_reported_after_wrapping() -> None:
+    """자동 줄바꿈 결과가 max_lines 를 넘으면 overflow 로 판정한다."""
+    constraints = TextBoxConstraints(
+        width_pt=60.0,
+        height_pt=80.0,
+        content_width_pt=60.0,
+        content_height_pt=80.0,
+        padding_left_pt=0.0,
+        padding_right_pt=0.0,
+        padding_top_pt=0.0,
+        padding_bottom_pt=0.0,
+        safety_margin_ratio=0.12,
+        max_lines=1,
+        nowrap=False,
+    )
+
+    layout = estimate_text_layout("가나다라마바사", font_size_pt=12, constraints=constraints)
+
+    assert layout.line_count == 2
+    assert "max_lines_overflow" in layout.overflow_reasons
+
+
+def test_basic_text_area_shrinks_only_until_min_font_pt() -> None:
+    """basic_text_area 는 fit 가능한 경우에도 min_font_pt 아래로 줄이지 않는다."""
+    result = evaluate_basic_text_area_fit(
+        slot=_slot(width_pt=75, min_font_pt=10, font_size_pt=12),
+        fill={"action": "text", "text": "OpenAI API", "font_size_override": 12},
+    )
+
+    assert result.status == "shrunk"
+    assert result.applied_font_pt == 10
+    assert result.applied_font_pt == result.min_font_pt
+    assert result.final_layout.fits is True
+
+
+def test_basic_text_area_allows_explicit_zero_padding() -> None:
+    """padding_pt=0 은 기본 padding 으로 대체하지 않고 그대로 적용한다."""
+    result = evaluate_basic_text_area_fit(
+        slot={**_slot(width_pt=80, min_font_pt=10, font_size_pt=12), "padding_pt": 0},
+        fill={"action": "text", "text": "OpenAI", "font_size_override": 12},
+    )
+
+    assert result.constraints.padding_left_pt == 0
+    assert result.constraints.padding_right_pt == 0
+    assert result.constraints.content_width_pt == 80
+
+
+def test_basic_text_area_does_not_hide_overflow_by_shrinking_to_8pt_or_below() -> None:
+    """8pt 이하로 숨길 수 있는 overflow 도 구조적 요약 필요 결과로 남긴다."""
+    with pytest.raises(TextFitPreflightError) as exc_info:
+        apply_text_fit_preflight(
+            slots=[_slot(width_pt=58.4, min_font_pt=8, font_size_pt=12)],
+            fills={"2": {"action": "text", "text": "OpenAI API", "font_size_override": 12}},
+        )
+
+    result = exc_info.value.results[0]
+    assert result.status == "summarize_needed"
+    assert result.applied_font_pt == 8.5
+    assert result.applied_font_pt > 8
+    assert result.reason in {"nowrap_width_overflow", "width_overflow"}
+
+
+def test_preflight_skips_explicit_non_basic_text_fit_policy() -> None:
+    """inline_label_group 은 후속 geometry action 범위라 basic_text_area 정책을 적용하지 않는다."""
+    slot = {
+        **_slot(width_pt=30, min_font_pt=10, font_size_pt=12),
+        "layout_type": "inline_label_group",
+        "fit_policy": "resize_label",
+    }
+
+    result = apply_text_fit_preflight(
+        slots=[slot],
+        fills={"2": {"action": "text", "text": "OpenAI API OpenAI API"}},
+    )
+
+    assert result.results == ()
+    assert result.fills["2"] == {"action": "text", "text": "OpenAI API OpenAI API"}
+
+
+def _slot(
+    *,
+    width_pt: float,
+    min_font_pt: float,
+    font_size_pt: float,
+) -> dict[str, object]:
+    """테스트용 basic_text_area slot 을 생성한다."""
+    return {
+        "shape_id": "2",
+        "kind": "text",
+        "fit_policy": "basic_text_area",
+        "w_emu": int(width_pt * EMU_PER_PT),
+        "h_emu": int(30 * EMU_PER_PT),
+        "font_size_pt": font_size_pt,
+        "min_font_pt": min_font_pt,
+        "max_lines": 1,
+        "nowrap": True,
+        "allowed_actions": ["text", "remove"],
+    }

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -19,6 +20,7 @@ from features.visualization.service import (
     RetryableError,
     VisualizationTaskService,
 )
+from features.visualization.text_fit import EMU_PER_PT
 
 
 @dataclass(frozen=True)
@@ -315,13 +317,14 @@ class FakeFillGenerator:
     def __init__(self, responses: dict[int, list[object]] | None = None) -> None:
         self.responses = responses or {}
         self.calls: list[int] = []
+        self.slot_calls: list[tuple[int, list[dict[str, Any]]]] = []
 
     def create_fills(
         self, *, content_brief: str, slots: list[dict[str, Any]]
     ) -> dict[str, dict[str, Any]]:
-        del slots
         slide_order = int(content_brief.rsplit("-", maxsplit=1)[1])
         self.calls.append(slide_order)
+        self.slot_calls.append((slide_order, [dict(slot) for slot in slots]))
         responses = self.responses.get(slide_order)
         if responses:
             result = responses.pop(0)
@@ -520,6 +523,100 @@ async def test_content_timeout_retries_then_blanks_slide_and_continues_partial()
 
 
 @pytest.mark.asyncio
+async def test_text_fit_overflow_logs_structured_result_and_continues_partial(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """basic_text_area overflow 는 structured log 를 남기고 콘텐츠 실패로 수렴한다."""
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "min_font_pt": 10,
+                "kind": "text",
+                "fit_policy": "basic_text_area",
+                "w_emu": int(80 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+                "max_lines": 1,
+                "nowrap": True,
+            }
+        ]
+    )
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "OpenAI API OpenAI API OpenAI API",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        }
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+
+    with caplog.at_level(logging.INFO, logger="features.visualization.generation_pipeline"):
+        await context.service.generate(_task())
+
+    error_events = _events(context.main_client, "slide_content_error")
+    assert len(error_events) == 1
+    assert error_events[0]["slide_order"] == 3
+    assert "summarize_needed" in error_events[0]["message"]
+    assert len(context.editor.cleared) == 1
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 6, "failed": 1}
+
+    text_fit_logs = [
+        record.pptx_text_fit for record in caplog.records if hasattr(record, "pptx_text_fit")
+    ]
+    overflow_log = next(item for item in text_fit_logs if item["slide_order"] == 3)
+    assert overflow_log["status"] == "summarize_needed"
+    assert overflow_log["reason"] in {"nowrap_width_overflow", "width_overflow"}
+    assert overflow_log["applied_font_pt"] == 10
+    assert overflow_log["final_layout"]["overflow_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_generate_enriches_slots_from_template_metadata_before_preflight() -> None:
+    """초기 생성은 v2 metadata slot 용량 정보를 prompt/preflight 에 전달한다."""
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "kind": "text",
+                "w_emu": int(120 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+            }
+        ]
+    )
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "OpenAI API OpenAI API OpenAI API",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        }
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+    context.storage.template_metadata = _template_metadata_with_resize_label_slot()
+
+    await context.service.generate(_task())
+
+    assert _events(context.main_client, "slide_content_error") == []
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 7, "failed": 0}
+    slots_by_order = dict(context.filler.slot_calls)
+    assert slots_by_order[3][0]["fit_policy"] == "resize_label"
+    assert slots_by_order[3][0]["layout_type"] == "inline_label_group"
+
+
+@pytest.mark.asyncio
 async def test_all_content_failures_send_error_without_render_or_upload() -> None:
     """모든 슬라이드 콘텐츠 생성 실패는 전체 실패 final callback 으로 마감한다."""
     filler = FakeFillGenerator(
@@ -637,6 +734,47 @@ async def test_regenerate_user_request_changes_only_requested_shape() -> None:
         item[:3] == ("job-1", "task-key", 3) for item in context.storage.uploaded_attempt_previews
     )
     assert context.storage.promoted_attempts == [("job-1", "task-key", 3)]
+
+
+@pytest.mark.asyncio
+async def test_regenerate_enriches_slots_from_downloaded_template_metadata() -> None:
+    """재생성은 template_id 로 v2 metadata 를 내려받아 slot 정책을 복원한다."""
+    main_client = FakeMainClient()
+    main_client.job_context["template_id"] = "blue"
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "kind": "text",
+                "current_text": "기존 제목",
+                "w_emu": int(120 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+            }
+        ]
+    )
+    change_generator = FakeChangeGenerator(
+        response={
+            "2": {
+                "action": "text",
+                "text": "OpenAI API OpenAI API OpenAI API",
+                "font_size_override": 12,
+            }
+        }
+    )
+    context = PipelineContext(
+        main_client=main_client,
+        editor=editor,
+        change_generator=change_generator,
+    )
+    context.storage.template_metadata = _template_metadata_with_resize_label_slot()
+
+    await context.service.regenerate(_regenerate_task(user_request="제목을 자세히 써줘"))
+
+    assert _events(context.main_client, "slide_preview_error") == []
+    assert len(_events(context.main_client, "slide_regenerated")) == 1
+    assert context.change_generator.calls[0]["slots"][0]["fit_policy"] == "resize_label"
+    assert context.change_generator.calls[0]["slots"][0]["layout_type"] == "inline_label_group"
 
 
 @pytest.mark.asyncio
@@ -937,3 +1075,25 @@ def _regenerate_task(
 
 def _events(main_client: FakeMainClient, event: str) -> list[dict[str, Any]]:
     return [item for item in main_client.slide_events if item["event"] == event]
+
+
+def _template_metadata_with_resize_label_slot() -> dict[str, Any]:
+    """shape 2를 basic_text_area 가 아닌 inline label slot 으로 선언한 v2 metadata."""
+    return {
+        "schema_version": 2,
+        "template_id": "blue",
+        "runtime_slides": [],
+        "layout_groups": [],
+        "slots": [
+            {
+                "slot_id": "slide3_shape2",
+                "slide_filename": "slide3.xml",
+                "shape_id": "2",
+                "kind": "text",
+                "fit_policy": "resize_label",
+                "layout_type": "inline_label_group",
+                "max_lines": 1,
+                "nowrap": True,
+            }
+        ],
+    }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #264

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 한글/영문 대소문자/숫자/공백/기호 문자군별 deterministic text width heuristic을 추가했습니다.
- `basic_text_area` slot에 padding, safety margin, `max_lines`, `nowrap`, `min_font_pt` 기반 preflight를 적용합니다.
- fit 가능하면 `font_size_override`를 안전하게 축소하고, overflow는 `summarize_needed` 또는 `failed`로 렌더 전 차단합니다.
- 초기 생성과 재생성 pipeline에서 OOXML slot에 v2 template metadata를 overlay해 prompt와 preflight가 같은 capacity 계약을 사용하게 했습니다.
- fit 결과 structured log를 추가하고, line width 배열은 log payload에서 최대 개수로 제한했습니다.

## 📸 스크린샷

- 해당 없음. 테스트 결과:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `git diff --check`
  - `uv run pytest -q tests/test_features/test_visualization/test_text_fit.py` → `9 passed`
  - `uv run pytest -q tests/test_pptx_worker/test_visualization/test_generation_pipeline.py` → `21 passed`
  - `uv run pytest -q` → `911 passed`

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 서브에이전트 리뷰 1회 수행 후 v2 metadata slot overlay, 대소문자 폭 계수, 0 padding 허용, log payload 제한을 반영했습니다.
- `resize_label`/`inline_label_group` 계열은 후속 2.10 geometry action 범위라 이번 basic preflight에서 제외합니다.
