### PR TITLE
feat: add strict validation for pptx v2 templates

### DIFF
--- a/features/visualization/templates/validation.py
+++ b/features/visualization/templates/validation.py
@@ -2,18 +2,31 @@
 
 import json
 from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from .categories import DEFAULT_CATEGORY_SCHEMA_PATH, CategorySchema, load_category_schema
-from .pptx import count_pptx_slides
+from .pptx import count_pptx_slides, extract_template_v2_from_pptx
+from .v2 import SCHEMA_VERSION_V2
 
 _REQUIRED_TOP_LEVEL_FIELDS = ("template_id", "template_file", "theme", "slides")
 _REQUIRED_THEME_FIELDS = ("primary_color", "name")
 _REQUIRED_SLIDE_FIELDS = ("slide_index", "id", "category", "description", "best_for")
+_REQUIRED_V2_META_ARRAY_FIELDS = ("runtime_slides", "slots", "layout_groups")
+_REQUIRED_V2_REFERENCE_ARRAY_FIELDS = ("slide_pairs", "shape_matches")
 _TEMPLATE_FILE_NAME = "template.pptx"
 _THUMBNAIL_FILE_NAME = "thumbnail.jpg"
+_REFERENCE_FILE_NAME = "reference.json"
+_EXACT_MARKER_COLOR = "#FF0000"
+_STRICT_EXTRACTION_WARNING_SNIPPETS = (("inline_label_group", "background 신뢰도가 부족"),)
+_REFERENCE_MATCH_FRESH_FIELDS = (
+    "runtime_shape_id",
+    "example_shape_id",
+    "example_text",
+    "output_text_color",
+)
 
 
 @dataclass(frozen=True)
@@ -33,6 +46,7 @@ def validate_template_directory(
     template_dir: Path | str,
     *,
     category_schema_path: Path | str = DEFAULT_CATEGORY_SCHEMA_PATH,
+    strict: bool = False,
 ) -> TemplateValidationResult:
     """템플릿 디렉터리의 template.pptx/meta.json 무결성을 검증한다."""
     root = Path(template_dir)
@@ -43,8 +57,19 @@ def validate_template_directory(
 
     meta_path = root / "meta.json"
     metadata = _load_meta_json(meta_path, errors)
+    if metadata is None:
+        return TemplateValidationResult(errors=tuple(errors), warnings=tuple(warnings))
+
+    schema_version = metadata.get("schema_version")
+    if schema_version == SCHEMA_VERSION_V2:
+        _validate_v2_template(root, metadata, strict=strict, errors=errors, warnings=warnings)
+        return TemplateValidationResult(errors=tuple(errors), warnings=tuple(warnings))
+
+    if "schema_version" in metadata:
+        errors.append(f"meta.json schema_version은 2여야 합니다. 현재 값: {schema_version!r}")
+
     schema = _load_schema(category_schema_path, errors)
-    if metadata is None or schema is None:
+    if schema is None:
         return TemplateValidationResult(errors=tuple(errors), warnings=tuple(warnings))
 
     _validate_required_schema(metadata, errors)
@@ -65,6 +90,400 @@ def validate_template_directory(
         _validate_slides(slides, schema, pptx_slide_count, errors, warnings)
 
     return TemplateValidationResult(errors=tuple(errors), warnings=tuple(warnings))
+
+
+def _validate_v2_template(
+    root: Path,
+    metadata: dict[str, Any],
+    *,
+    strict: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    _validate_non_empty_file(root / _TEMPLATE_FILE_NAME, _TEMPLATE_FILE_NAME, errors)
+    _validate_v2_meta_schema(metadata, errors)
+
+    reference = _load_optional_json(root / _REFERENCE_FILE_NAME, _REFERENCE_FILE_NAME, errors)
+    if reference is not None:
+        _validate_v2_reference_schema(reference, metadata, errors)
+
+    extraction = None
+    template_path = root / _TEMPLATE_FILE_NAME
+    if template_path.is_file() and _file_has_content(template_path):
+        try:
+            extraction = extract_template_v2_from_pptx(template_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+        else:
+            errors.extend(extraction.errors)
+            _append_extraction_warnings(extraction.warnings, strict, errors, warnings)
+
+    _validate_v2_runtime_contract(metadata, reference, extraction, errors)
+    _validate_v2_slot_contract(metadata, reference, extraction, strict, errors, warnings)
+    _validate_v2_layout_groups(metadata, strict, errors, warnings)
+
+
+def _validate_v2_meta_schema(metadata: dict[str, Any], errors: list[str]) -> None:
+    if metadata.get("schema_version") != SCHEMA_VERSION_V2:
+        errors.append(
+            f"meta.json schema_version은 2여야 합니다. 현재 값: {metadata.get('schema_version')!r}"
+        )
+    _validate_required_string(metadata.get("template_id"), "meta.json.template_id", errors)
+    for field in _REQUIRED_V2_META_ARRAY_FIELDS:
+        if not isinstance(metadata.get(field), list):
+            errors.append(f"meta.json.{field} 필드는 배열이어야 합니다.")
+
+
+def _validate_v2_reference_schema(
+    reference: dict[str, Any],
+    metadata: dict[str, Any],
+    errors: list[str],
+) -> None:
+    if reference.get("schema_version") != SCHEMA_VERSION_V2:
+        errors.append(
+            "reference.json schema_version은 2여야 합니다. "
+            f"현재 값: {reference.get('schema_version')!r}"
+        )
+    _validate_required_string(reference.get("template_id"), "reference.json.template_id", errors)
+    if (
+        isinstance(reference.get("template_id"), str)
+        and isinstance(metadata.get("template_id"), str)
+        and reference.get("template_id") != metadata.get("template_id")
+    ):
+        errors.append("reference.json.template_id가 meta.json.template_id와 일치하지 않습니다.")
+    for field in _REQUIRED_V2_REFERENCE_ARRAY_FIELDS:
+        if not isinstance(reference.get(field), list):
+            errors.append(f"reference.json.{field} 필드는 배열이어야 합니다.")
+    if "shape_inferences" in reference and not isinstance(reference.get("shape_inferences"), list):
+        errors.append("reference.json.shape_inferences 필드는 배열이어야 합니다.")
+
+
+def _validate_v2_runtime_contract(
+    metadata: dict[str, Any],
+    reference: dict[str, Any] | None,
+    extraction: Any,
+    errors: list[str],
+) -> None:
+    runtime_slides = _list_value(metadata.get("runtime_slides"))
+    if runtime_slides is None:
+        return
+    if not runtime_slides:
+        errors.append("meta.json runtime_slides에 runtime 대상 슬라이드가 없습니다.")
+
+    runtime_indexes: set[int] = set()
+    runtime_parts: set[str] = set()
+    for position, slide in enumerate(runtime_slides):
+        label = f"meta.json.runtime_slides[{position}]"
+        if not isinstance(slide, dict):
+            errors.append(f"{label} 항목은 객체여야 합니다.")
+            continue
+        slide_index = _required_int(slide.get("slide_index"), f"{label}.slide_index", errors)
+        slide_number = _required_int(slide.get("slide_number"), f"{label}.slide_number", errors)
+        slide_part = _required_string(slide.get("slide_part"), f"{label}.slide_part", errors)
+        _required_string(slide.get("slide_filename"), f"{label}.slide_filename", errors)
+        if slide_index is not None:
+            runtime_indexes.add(slide_index)
+        if slide_part is not None:
+            runtime_parts.add(slide_part)
+        if slide_number is not None and slide_number % 2 != 0:
+            errors.append(f"{label}에 example slide가 runtime 후보로 포함되어 있습니다.")
+
+    if extraction is not None:
+        extracted_runtime_parts = {
+            str(slide.get("slide_part"))
+            for slide in extraction.runtime_slides
+            if isinstance(slide, dict) and slide.get("slide_part")
+        }
+        missing_parts = sorted(runtime_parts - extracted_runtime_parts)
+        if missing_parts:
+            errors.append(
+                "meta.json.runtime_slides에 template.pptx runtime 대상이 아닌 슬라이드가 "
+                f"포함되어 있습니다: {', '.join(missing_parts)}"
+            )
+
+    if reference is not None:
+        _validate_v2_slide_pairs(reference, runtime_indexes, errors)
+
+
+def _validate_v2_slide_pairs(
+    reference: dict[str, Any],
+    runtime_indexes: set[int],
+    errors: list[str],
+) -> None:
+    slide_pairs = _list_value(reference.get("slide_pairs"))
+    if slide_pairs is None:
+        return
+
+    pair_runtime_indexes: set[int] = set()
+    pair_example_indexes: set[int] = set()
+    for position, pair in enumerate(slide_pairs):
+        label = f"reference.json.slide_pairs[{position}]"
+        if not isinstance(pair, dict):
+            errors.append(f"{label} 항목은 객체여야 합니다.")
+            continue
+        runtime_index = _required_int(
+            pair.get("runtime_slide_index"), f"{label}.runtime_slide_index", errors
+        )
+        example_index = _required_int(
+            pair.get("example_slide_index"), f"{label}.example_slide_index", errors
+        )
+        if runtime_index is not None:
+            pair_runtime_indexes.add(runtime_index)
+        if example_index is not None:
+            pair_example_indexes.add(example_index)
+        if (
+            runtime_index is not None
+            and example_index is not None
+            and runtime_index == example_index
+        ):
+            errors.append(f"{label}의 runtime/example slide가 동일합니다.")
+
+    missing_pairs = sorted(runtime_indexes - pair_runtime_indexes)
+    if missing_pairs:
+        errors.append(
+            "reference.json에 필수 example slide pair가 없습니다. "
+            f"runtime_slide_index: {missing_pairs}"
+        )
+
+    leaked_examples = sorted(runtime_indexes & pair_example_indexes)
+    if leaked_examples:
+        errors.append(
+            f"example slide가 runtime 후보에 포함되어 있습니다. slide_index: {leaked_examples}"
+        )
+
+
+def _validate_v2_slot_contract(
+    metadata: dict[str, Any],
+    reference: dict[str, Any] | None,
+    extraction: Any,
+    strict: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    slots = _list_value(metadata.get("slots"))
+    if slots is None:
+        return
+
+    slot_ids: list[str] = []
+    editable_text_slot_ids: set[str] = set()
+    for position, slot in enumerate(slots):
+        label = f"meta.json.slots[{position}]"
+        if not isinstance(slot, dict):
+            errors.append(f"{label} 항목은 객체여야 합니다.")
+            continue
+        slot_id = _required_string(slot.get("slot_id"), f"{label}.slot_id", errors)
+        _required_string(slot.get("shape_id"), f"{label}.shape_id", errors)
+        if slot_id is not None:
+            slot_ids.append(slot_id)
+
+        if _is_editable_text_slot(slot):
+            if slot_id is not None:
+                editable_text_slot_ids.add(slot_id)
+            _validate_v2_editable_text_slot(slot, label, strict, errors, warnings)
+
+    duplicate_slot_ids = sorted({slot_id for slot_id in slot_ids if slot_ids.count(slot_id) > 1})
+    if duplicate_slot_ids:
+        errors.append(f"meta.json slot_id 중복: {', '.join(duplicate_slot_ids)}")
+
+    if extraction is not None:
+        extracted_slot_ids = {
+            str(slot.get("slot_id"))
+            for slot in extraction.slots
+            if isinstance(slot, dict) and slot.get("slot_id")
+        }
+        metadata_slot_ids = set(slot_ids)
+        missing_slot_ids = sorted(extracted_slot_ids - metadata_slot_ids)
+        extra_slot_ids = sorted(editable_text_slot_ids - extracted_slot_ids)
+        if missing_slot_ids:
+            errors.append(
+                "meta.json.slots에 template.pptx editable marker slot이 누락되었습니다: "
+                f"{', '.join(missing_slot_ids)}"
+            )
+        if extra_slot_ids:
+            errors.append(
+                "meta.json.slots에 template.pptx #FF0000 marker가 아닌 editable slot이 "
+                f"포함되어 있습니다: {', '.join(extra_slot_ids)}"
+            )
+
+    if reference is not None:
+        _validate_v2_reference_matches(reference, editable_text_slot_ids, errors)
+        if extraction is not None:
+            _validate_v2_reference_matches_against_extraction(reference, extraction, errors)
+
+
+def _validate_v2_editable_text_slot(
+    slot: dict[str, Any],
+    label: str,
+    strict: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    _required_string(slot.get("placeholder_text"), f"{label}.placeholder_text", errors)
+    marker_color = str(slot.get("marker_color") or "").upper()
+    if marker_color != _EXACT_MARKER_COLOR:
+        errors.append(f"{label}.marker_color는 정확한 #FF0000 이어야 합니다.")
+
+    layout_name = _editable_slot_layout_name(slot)
+    if layout_name == "unknown":
+        _append_warning_or_strict_error(
+            f"{label} editable slot layout이 unknown입니다.",
+            strict,
+            errors,
+            warnings,
+        )
+
+
+def _validate_v2_reference_matches(
+    reference: dict[str, Any],
+    editable_text_slot_ids: set[str],
+    errors: list[str],
+) -> None:
+    shape_matches = _list_value(reference.get("shape_matches"))
+    if shape_matches is None:
+        return
+
+    matched_slot_ids: set[str] = set()
+    for position, match in enumerate(shape_matches):
+        label = f"reference.json.shape_matches[{position}]"
+        if not isinstance(match, dict):
+            errors.append(f"{label} 항목은 객체여야 합니다.")
+            continue
+        slot_id = _required_string(match.get("slot_id"), f"{label}.slot_id", errors)
+        _required_string(match.get("example_shape_id"), f"{label}.example_shape_id", errors)
+        _required_string(match.get("example_text"), f"{label}.example_text", errors)
+        if slot_id is not None:
+            matched_slot_ids.add(slot_id)
+
+    unmatched_slot_ids = sorted(editable_text_slot_ids - matched_slot_ids)
+    if unmatched_slot_ids:
+        errors.append(
+            "editable slot의 example shape 매칭에 실패했습니다. "
+            f"slot_id: {', '.join(unmatched_slot_ids)}"
+        )
+
+
+def _validate_v2_reference_matches_against_extraction(
+    reference: dict[str, Any],
+    extraction: Any,
+    errors: list[str],
+) -> None:
+    shape_matches = _list_value(reference.get("shape_matches"))
+    if shape_matches is None:
+        return
+
+    extracted_by_slot_id: dict[str, dict[str, Any]] = {}
+    for extracted_match in extraction.shape_matches:
+        if not isinstance(extracted_match, dict):
+            continue
+        slot_id = extracted_match.get("slot_id")
+        if not isinstance(slot_id, str) or not slot_id.strip():
+            continue
+        extracted_by_slot_id[slot_id] = extracted_match
+
+    for position, match in enumerate(shape_matches):
+        label = f"reference.json.shape_matches[{position}]"
+        if not isinstance(match, dict):
+            continue
+        slot_id = match.get("slot_id")
+        if not isinstance(slot_id, str) or not slot_id.strip():
+            continue
+
+        extracted_match = extracted_by_slot_id.get(slot_id)
+        if extracted_match is None:
+            errors.append(f"{label}.slot_id {slot_id!r}는 template.pptx 추출 결과에 없습니다.")
+            continue
+
+        for field in _REFERENCE_MATCH_FRESH_FIELDS:
+            reference_value = match.get(field)
+            extracted_value = extracted_match.get(field)
+            if reference_value != extracted_value:
+                errors.append(
+                    f"{label}.{field}가 template.pptx 추출 결과와 일치하지 않습니다. "
+                    f"reference.json={reference_value!r}, template.pptx={extracted_value!r}"
+                )
+
+
+def _validate_v2_layout_groups(
+    metadata: dict[str, Any],
+    strict: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    layout_groups = _list_value(metadata.get("layout_groups"))
+    if layout_groups is None:
+        return
+
+    for position, group in enumerate(layout_groups):
+        label = f"meta.json.layout_groups[{position}]"
+        if not isinstance(group, dict):
+            errors.append(f"{label} 항목은 객체여야 합니다.")
+            continue
+        if str(group.get("layout_type") or "") != "inline_label_group":
+            continue
+        if not _inline_label_group_linked_backgrounds_are_confident(group):
+            _append_warning_or_strict_error(
+                f"{label} inline_label_group linked background 신뢰도가 낮습니다.",
+                strict,
+                errors,
+                warnings,
+            )
+
+
+def _inline_label_group_linked_backgrounds_are_confident(group: dict[str, Any]) -> bool:
+    item_shape_ids = _string_list(group.get("item_shape_ids"))
+    linked_background_by_item = group.get("linked_background_by_item")
+    if not item_shape_ids or not isinstance(linked_background_by_item, dict):
+        return False
+    for item_shape_id in item_shape_ids:
+        linked = linked_background_by_item.get(item_shape_id)
+        if not isinstance(linked, dict):
+            return False
+        if linked.get("resize_linked") is not True:
+            return False
+        if not str(linked.get("background_shape_id") or "").strip():
+            return False
+        match_score = linked.get("match_score")
+        if isinstance(match_score, bool) or not isinstance(match_score, int | float):
+            return False
+    return True
+
+
+def _append_extraction_warnings(
+    extraction_warnings: Sequence[str],
+    strict: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    for warning in extraction_warnings:
+        if strict and _is_strict_extraction_warning(warning):
+            errors.append(warning)
+            continue
+        warnings.append(warning)
+
+
+def _is_strict_extraction_warning(warning: str) -> bool:
+    return any(
+        all(snippet in warning for snippet in snippets)
+        for snippets in _STRICT_EXTRACTION_WARNING_SNIPPETS
+    )
+
+
+def _load_optional_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        errors.append(f"{label}을 읽을 수 없습니다: {exc}")
+        return None
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label} JSON 형식이 올바르지 않습니다: {exc}")
+        return None
+
+    if not isinstance(loaded, dict):
+        errors.append(f"{label} 최상위 값은 객체여야 합니다.")
+        return None
+    return loaded
 
 
 def _load_meta_json(path: Path, errors: list[str]) -> dict[str, Any] | None:
@@ -100,6 +519,13 @@ def _validate_non_empty_file(path: Path, label: str, errors: list[str]) -> None:
             errors.append(f"{label} 파일이 비어 있습니다: {path}")
     except OSError as exc:
         errors.append(f"{label} 파일을 확인할 수 없습니다: {exc}")
+
+
+def _file_has_content(path: Path) -> bool:
+    try:
+        return path.stat().st_size > 0
+    except OSError:
+        return False
 
 
 def _validate_required_schema(metadata: dict[str, Any], errors: list[str]) -> None:
@@ -213,3 +639,55 @@ def _append_distribution_warnings(
 def _validate_required_string(value: Any, label: str, errors: list[str]) -> None:
     if not isinstance(value, str) or not value.strip():
         errors.append(f"{label}는 비어 있지 않은 문자열이어야 합니다.")
+
+
+def _required_string(value: Any, label: str, errors: list[str]) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label}는 비어 있지 않은 문자열이어야 합니다.")
+        return None
+    return value
+
+
+def _required_int(value: Any, label: str, errors: list[str]) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        errors.append(f"{label}는 정수여야 합니다.")
+        return None
+    return value
+
+
+def _list_value(value: Any) -> list[Any] | None:
+    if isinstance(value, list):
+        return value
+    return None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _is_editable_text_slot(slot: dict[str, Any]) -> bool:
+    if slot.get("editable") is False:
+        return False
+    return str(slot.get("kind") or "text").casefold() == "text"
+
+
+def _editable_slot_layout_name(slot: dict[str, Any]) -> str:
+    for field in ("layout_type", "fit_policy"):
+        value = slot.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip().casefold()
+    return ""
+
+
+def _append_warning_or_strict_error(
+    message: str,
+    strict: bool,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    if strict:
+        errors.append(message)
+        return
+    warnings.append(message)

--- a/scripts/templates/validate_template.py
+++ b/scripts/templates/validate_template.py
@@ -21,6 +21,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=_DEFAULT_CATEGORY_SCHEMA_PATH,
         help="표준 카테고리 스키마 JSON 경로",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="v2 배포 전 품질 warning을 실패로 승격합니다.",
+    )
     return parser.parse_args(argv)
 
 
@@ -29,7 +34,11 @@ def main(argv: list[str] | None = None) -> int:
     from features.visualization.templates import validate_template_directory
 
     args = parse_args(argv)
-    result = validate_template_directory(args.template_dir, category_schema_path=args.categories)
+    result = validate_template_directory(
+        args.template_dir,
+        category_schema_path=args.categories,
+        strict=args.strict,
+    )
 
     for warning in result.warnings:
         print(f"WARNING: {warning}", file=sys.stderr)

--- a/tasks/phase-2-pptx-template-quality/14-validator-v2-contract-strict-cli.md
+++ b/tasks/phase-2-pptx-template-quality/14-validator-v2-contract-strict-cli.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/05-pptx-template-validator-v2-strict-mode.md"
 depends_on: ["2.04", "2.07"]
 blocks: ["2.15"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -23,24 +24,38 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 기존 `validate_template.py` 와 `features.visualization.templates.validation` 책임 확인
-- [ ] 기본 모드 fail 항목과 strict 승격 항목 목록 확정
+- [x] 기존 `validate_template.py` 와 `features.visualization.templates.validation` 책임 확인
+- [x] 기본 모드 fail 항목과 strict 승격 항목 목록 확정
 
 ## 구현 체크리스트
 
-- [ ] `validate_template.py --strict` 인자 추가
-- [ ] `template.pptx`, `meta.json`, 선택적 `reference.json` 의 `schema_version: 2` 구조 검증
-- [ ] runtime/example slide 분리, runtime 대상 존재, example runtime 포함 금지 검증
-- [ ] `#FF0000` marker 없음, mixed-color run, 예시 매칭 실패를 기본 fail 로 처리
-- [ ] editable `unknown` layout 은 strict mode 에서 fail 로 승격
+- [x] `validate_template.py --strict` 인자 추가
+- [x] `template.pptx`, `meta.json`, 선택적 `reference.json` 의 `schema_version: 2` 구조 검증
+- [x] runtime/example slide 분리, runtime 대상 존재, example runtime 포함 금지 검증
+- [x] `#FF0000` marker 없음, mixed-color run, 예시 매칭 실패를 기본 fail 로 처리
+- [x] editable `unknown` layout 은 strict mode 에서 fail 로 승격
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] 기본 모드와 strict mode 의 exit code 차이가 테스트로 고정된다
-- [ ] 예시 슬라이드가 runtime 후보에 포함되면 실패한다
-- [ ] mixed-color run fixture 가 validator 실패로 보고된다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] 기본 모드와 strict mode 의 exit code 차이가 테스트로 고정된다
+- [x] 예시 슬라이드가 runtime 후보에 포함되면 실패한다
+- [x] mixed-color run fixture 가 validator 실패로 보고된다
+
+## 검증 기록
+
+- `uv run pytest tests/test_features/test_visualization/test_template_registration.py -q` — 38 passed
+- `uv run pytest tests/test_features/test_visualization/test_template_v2_compiler.py -q` — 29 passed
+- `uv run pytest tests/test_features/test_visualization -q` — 186 passed
+- `uv run pytest -q` — 939 passed
+- `uv run ruff check .` — passed
+- `uv run ruff format --check .` — 200 files already formatted
+- `uv run ruff check features/visualization/templates/validation.py scripts/templates/validate_template.py tests/test_features/test_visualization/test_template_registration.py` — passed
+- `uv run ruff format --check features/visualization/templates/validation.py scripts/templates/validate_template.py tests/test_features/test_visualization/test_template_registration.py` — passed
+- `git diff --check` — passed
+- subagent review 2차 — 추가 발견 없음, 1차 지적 2건 해소 확인
 
 ## 리스크 / 메모
 
 - 기존 category/thumbnail 검증은 유지한다. v2 slot/layout 검증을 추가하는 방향이다.
+- `reference.json.shape_matches` fresh 검증 테스트는 대표 필드 `example_text` stale 사례를 고정한다.

--- a/tests/test_features/test_visualization/test_template_registration.py
+++ b/tests/test_features/test_visualization/test_template_registration.py
@@ -5,6 +5,7 @@ import json
 import zipfile
 from collections.abc import Sequence
 from dataclasses import dataclass
+from html import escape
 from pathlib import Path
 
 import pytest
@@ -16,8 +17,10 @@ from features.visualization.templates import (
     SlideText,
     TextExtractionResult,
     build_template_metadata,
+    compile_template_v2,
     count_pptx_slides,
     extract_slide_texts,
+    read_json_payload,
     validate_template_directory,
 )
 from features.visualization.templates.thumbnail import PillowThumbnailBuilder
@@ -416,6 +419,317 @@ def test_validate_template_cli_returns_nonzero_on_validation_errors(tmp_path: Pa
     assert validate_template_main([str(template_dir)]) == 1
 
 
+def test_validate_template_directory_accepts_valid_v2_metadata(tmp_path: Path) -> None:
+    """검증기는 v2 meta/reference 계약과 기존 thumbnail 검증을 함께 통과시킨다."""
+    template_dir = _make_v2_template_dir(tmp_path)
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is True
+    assert result.errors == ()
+
+
+def test_validate_template_directory_rejects_v2_missing_thumbnail(tmp_path: Path) -> None:
+    """v2 metadata 경로에서도 기존 thumbnail 검증을 유지한다."""
+    template_dir = _make_v2_template_dir(tmp_path)
+    (template_dir / "thumbnail.jpg").unlink()
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("thumbnail.jpg 파일을 찾을 수 없습니다" in error for error in result.errors)
+
+
+def test_validate_template_cli_strict_promotes_unknown_layout_warning(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """editable unknown layout은 기본 모드 warning, strict 모드 실패로 처리한다."""
+    template_dir = _make_v2_template_dir(tmp_path)
+    metadata = read_json_payload(template_dir / "meta.json")
+    metadata["slots"][0]["fit_policy"] = "unknown"
+    _write_json(template_dir / "meta.json", metadata)
+
+    assert validate_template_main([str(template_dir)]) == 0
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "unknown" in captured.err
+
+    assert validate_template_main([str(template_dir), "--strict"]) == 1
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.err
+    assert "unknown" in captured.err
+
+
+def test_validate_template_directory_strict_promotes_low_confidence_layout_group(
+    tmp_path: Path,
+) -> None:
+    """linked background 신뢰도가 낮은 inline_label_group은 strict 모드에서 실패한다."""
+    template_dir = _make_v2_template_dir(tmp_path)
+    metadata = read_json_payload(template_dir / "meta.json")
+    metadata["layout_groups"] = [
+        {
+            "group_id": "slide2_inline_label_group1",
+            "slide_index": 1,
+            "slide_number": 2,
+            "layout_type": "inline_label_group",
+            "item_shape_ids": ["10"],
+            "linked_background_by_item": {},
+        }
+    ]
+    _write_json(template_dir / "meta.json", metadata)
+
+    default_result = validate_template_directory(template_dir)
+    strict_result = validate_template_directory(template_dir, strict=True)
+
+    assert default_result.ok is True
+    assert any(
+        "linked background 신뢰도가 낮습니다" in warning for warning in default_result.warnings
+    )
+    assert strict_result.ok is False
+    assert any("linked background 신뢰도가 낮습니다" in error for error in strict_result.errors)
+
+
+def test_validate_template_directory_strict_promotes_low_confidence_extraction_warning(
+    tmp_path: Path,
+) -> None:
+    """PPTX 재추출 중 발견한 낮은 신뢰도 inline_label_group 후보도 strict 실패로 본다."""
+    template_dir = tmp_path / "ppt-v3"
+    template_dir.mkdir()
+    chip_specs = (
+        (19, 20, "Python", 90, 100, 240),
+        (21, 22, "FastAPI", 360, 370, 260),
+        (23, 24, "Postgres", 650, 660, 280),
+        (None, 25, "LangGraph", 960, 970, 300),
+    )
+    runtime_shapes: list[str] = []
+    example_shapes: list[str] = []
+    for index, (background_id, shape_id, text, background_x, text_x, width) in enumerate(
+        chip_specs,
+        start=1,
+    ):
+        if background_id is not None:
+            runtime_shapes.append(
+                _v2_shape_without_text_xml(
+                    background_id,
+                    f"{text} chip background",
+                    x=background_x,
+                    y=790,
+                    width=width + 20,
+                    height=120,
+                )
+            )
+        runtime_shapes.append(
+            _v2_shape_xml(
+                shape_id,
+                f"{text} chip",
+                (_v2_run_xml(text, color="FF0000"),),
+                x=text_x,
+                y=800,
+                width=width,
+                height=100,
+            )
+        )
+        example_shapes.append(
+            _v2_shape_xml(
+                30 + index,
+                f"{text} example",
+                (_v2_run_xml(text, color="123456"),),
+                x=text_x,
+                y=800,
+                width=width,
+                height=100,
+            )
+        )
+    _make_v2_template_pptx(
+        template_dir / "template.pptx",
+        (
+            _v2_slide_xml(1, ""),
+            _v2_slide_xml(2, "".join(runtime_shapes)),
+            _v2_slide_xml(3, "".join(example_shapes)),
+        ),
+    )
+    compile_result = compile_template_v2(template_dir)
+    assert compile_result.ok is True
+    assert any("background 신뢰도가 부족" in warning for warning in compile_result.warnings)
+    (template_dir / "thumbnail.jpg").write_bytes(b"thumbnail")
+
+    default_result = validate_template_directory(template_dir)
+    strict_result = validate_template_directory(template_dir, strict=True)
+
+    assert default_result.ok is True
+    assert any("background 신뢰도가 부족" in warning for warning in default_result.warnings)
+    assert strict_result.ok is False
+    assert any("background 신뢰도가 부족" in error for error in strict_result.errors)
+
+
+def test_validate_template_directory_rejects_stale_reference_shape_match(
+    tmp_path: Path,
+) -> None:
+    """reference.json shape match 핵심 필드는 template.pptx 재추출 결과와 일치해야 한다."""
+    template_dir = _make_v2_template_dir(tmp_path)
+    reference = read_json_payload(template_dir / "reference.json")
+    reference["shape_matches"][0]["example_text"] = "오래된 예시 텍스트"
+    _write_json(template_dir / "reference.json", reference)
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any(
+        "reference.json.shape_matches[0].example_text" in error
+        and "template.pptx 추출 결과와 일치하지 않습니다" in error
+        for error in result.errors
+    )
+
+
+def test_validate_template_directory_rejects_example_slide_in_runtime_slides(
+    tmp_path: Path,
+) -> None:
+    """예시 슬라이드가 runtime 후보에 포함된 v2 metadata는 실패한다."""
+    template_dir = _make_v2_template_dir(tmp_path)
+    metadata = read_json_payload(template_dir / "meta.json")
+    metadata["runtime_slides"].append(
+        {
+            "slide_index": 2,
+            "slide_number": 3,
+            "slide_filename": "slide3.xml",
+            "slide_part": "ppt/slides/slide3.xml",
+        }
+    )
+    _write_json(template_dir / "meta.json", metadata)
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("example slide" in error for error in result.errors)
+
+
+def test_validate_template_directory_rejects_mixed_color_run(tmp_path: Path) -> None:
+    """red run과 non-red run이 섞인 runtime shape는 기본 모드에서도 실패한다."""
+    template_dir = tmp_path / "ppt-v3"
+    template_dir.mkdir()
+    _make_v2_template_pptx(
+        template_dir / "template.pptx",
+        (
+            _v2_slide_xml(1, ""),
+            _v2_slide_xml(
+                2,
+                _v2_shape_xml(
+                    20,
+                    "Mixed marker",
+                    (
+                        _v2_run_xml("경험명", color="FF0000"),
+                        _v2_run_xml(" - 고정 문구"),
+                    ),
+                ),
+            ),
+            _v2_slide_xml(3, _v2_shape_xml(30, "Example", (_v2_run_xml("경험명 예시"),))),
+        ),
+    )
+    (template_dir / "thumbnail.jpg").write_bytes(b"thumbnail")
+    _write_json(
+        template_dir / "meta.json",
+        {
+            "schema_version": 2,
+            "template_id": "ppt-v3",
+            "runtime_slides": [
+                {
+                    "slide_index": 1,
+                    "slide_number": 2,
+                    "slide_filename": "slide2.xml",
+                    "slide_part": "ppt/slides/slide2.xml",
+                }
+            ],
+            "slots": [],
+            "layout_groups": [],
+        },
+    )
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("non-red run이 섞여 있습니다" in error for error in result.errors)
+
+
+def test_validate_template_directory_rejects_runtime_slide_without_exact_marker(
+    tmp_path: Path,
+) -> None:
+    """정확한 #FF0000 marker가 없는 runtime slide는 기본 모드에서도 실패한다."""
+    template_dir = tmp_path / "ppt-v3"
+    template_dir.mkdir()
+    _make_v2_template_pptx(
+        template_dir / "template.pptx",
+        (
+            _v2_slide_xml(1, ""),
+            _v2_slide_xml(
+                2,
+                _v2_shape_xml(20, "Fixed non-red", (_v2_run_xml("고정 문구", color="222222"),)),
+            ),
+            _v2_slide_xml(3, _v2_shape_xml(30, "Example", (_v2_run_xml("예시"),))),
+        ),
+    )
+    (template_dir / "thumbnail.jpg").write_bytes(b"thumbnail")
+    _write_minimal_v2_meta(template_dir, slots=[])
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("정확한 #FF0000 editable marker가 없습니다" in error for error in result.errors)
+
+
+def test_validate_template_directory_rejects_reference_match_failure(tmp_path: Path) -> None:
+    """editable slot의 example shape 매칭 실패는 기본 모드에서도 실패한다."""
+    template_dir = tmp_path / "ppt-v3"
+    template_dir.mkdir()
+    _make_v2_template_pptx(
+        template_dir / "template.pptx",
+        (
+            _v2_slide_xml(1, ""),
+            _v2_slide_xml(2, _v2_shape_xml(20, "Marker", (_v2_run_xml("경험명", color="FF0000"),))),
+            _v2_slide_xml(
+                3,
+                _v2_shape_xml(
+                    30,
+                    "Far example",
+                    (_v2_run_xml("너무 먼 예시", color="123456"),),
+                    x=1000,
+                    y=1000,
+                ),
+            ),
+        ),
+    )
+    (template_dir / "thumbnail.jpg").write_bytes(b"thumbnail")
+    _write_minimal_v2_meta(
+        template_dir,
+        slots=[
+            {
+                "slot_id": "slide2_shape20",
+                "slide_index": 1,
+                "slide_number": 2,
+                "slide_filename": "slide2.xml",
+                "slide_part": "ppt/slides/slide2.xml",
+                "shape_id": "20",
+                "shape_name": "Marker",
+                "x_emu": 0,
+                "y_emu": 0,
+                "w_emu": 100,
+                "h_emu": 100,
+                "placeholder_text": "경험명",
+                "marker_color": "#FF0000",
+                "kind": "text",
+                "editable": True,
+                "required": True,
+                "allowed_actions": ["text", "remove"],
+            }
+        ],
+    )
+
+    result = validate_template_directory(template_dir)
+
+    assert result.ok is False
+    assert any("example shape 매칭에 실패했습니다" in error for error in result.errors)
+
+
 def _valid_slides() -> list[dict[str, object]]:
     """유효한 meta.json slides fixture를 만든다.
 
@@ -474,6 +788,32 @@ def _write_meta(
         (template_dir / "thumbnail.jpg").write_bytes(thumbnail_content)
 
 
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    """테스트용 JSON 파일을 작성한다."""
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_minimal_v2_meta(template_dir: Path, *, slots: list[dict[str, object]]) -> None:
+    """테스트용 최소 v2 meta.json 파일을 작성한다."""
+    _write_json(
+        template_dir / "meta.json",
+        {
+            "schema_version": 2,
+            "template_id": "ppt-v3",
+            "runtime_slides": [
+                {
+                    "slide_index": 1,
+                    "slide_number": 2,
+                    "slide_filename": "slide2.xml",
+                    "slide_part": "ppt/slides/slide2.xml",
+                }
+            ],
+            "slots": slots,
+            "layout_groups": [],
+        },
+    )
+
+
 def _make_template_pptx(
     path: Path,
     *,
@@ -520,6 +860,150 @@ def _make_template_pptx(
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
         for name, content in entries.items():
             zf.writestr(name, content)
+
+
+def _make_v2_template_dir(tmp_path: Path) -> Path:
+    """검증 가능한 v2 template dir fixture를 만든다."""
+    template_dir = tmp_path / "ppt-v3"
+    template_dir.mkdir()
+    _make_v2_template_pptx(template_dir / "template.pptx", _valid_v2_slide_xmls())
+    result = compile_template_v2(template_dir)
+    assert result.ok is True
+    (template_dir / "thumbnail.jpg").write_bytes(b"thumbnail")
+    return template_dir
+
+
+def _valid_v2_slide_xmls() -> tuple[str, ...]:
+    """기본 v2 validator 테스트용 slide pair fixture를 만든다."""
+    return (
+        _v2_slide_xml(1, ""),
+        _v2_slide_xml(
+            2,
+            _v2_shape_xml(
+                10,
+                "Exact red marker",
+                (_v2_run_xml("프로젝트명", color="FF0000", font_size=1800),),
+                x=100,
+                y=200,
+                width=300,
+                height=400,
+            ),
+        ),
+        _v2_slide_xml(
+            3,
+            _v2_shape_xml(
+                30,
+                "Example text",
+                (_v2_run_xml("실제 프로젝트명", color="123456"),),
+                x=100,
+                y=200,
+                width=300,
+                height=400,
+            ),
+        ),
+    )
+
+
+def _make_v2_template_pptx(path: Path, slide_xmls: tuple[str, ...]) -> None:
+    """테스트용 최소 v2 PPTX 패키지를 생성한다."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    slide_count = len(slide_xmls)
+    entries: dict[str, str] = {
+        "[Content_Types].xml": _content_types(slide_count),
+        "_rels/.rels": (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}">'
+            '<Relationship Id="rId1" '
+            'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+            'Target="ppt/presentation.xml"/>'
+            "</Relationships>"
+        ),
+        "ppt/presentation.xml": _presentation(slide_count),
+        "ppt/_rels/presentation.xml.rels": _presentation_rels(slide_count),
+    }
+    for index, slide_xml in enumerate(slide_xmls, start=1):
+        entries[f"ppt/slides/slide{index}.xml"] = slide_xml
+        entries[f"ppt/slides/_rels/slide{index}.xml.rels"] = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Relationships xmlns="{_PACKAGE_RELATIONSHIPS_NS}"/>'
+        )
+
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+
+
+def _v2_slide_xml(index: int, shapes_xml: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<p:sld xmlns:p="{_PRESENTATION_NS}" xmlns:a="{_DRAWINGML_NS}" '
+        f'xmlns:r="{_RELATIONSHIPS_NS}">'
+        "<p:cSld><p:spTree>"
+        f'<p:nvGrpSpPr><p:cNvPr id="{index}" name=""/><p:cNvGrpSpPr/><p:nvPr/>'
+        "</p:nvGrpSpPr><p:grpSpPr/>"
+        f"{shapes_xml}"
+        "</p:spTree></p:cSld></p:sld>"
+    )
+
+
+def _v2_shape_xml(
+    shape_id: int,
+    name: str,
+    runs_xml: tuple[str, ...],
+    *,
+    x: int = 0,
+    y: int = 0,
+    width: int = 100,
+    height: int = 100,
+) -> str:
+    return (
+        "<p:sp>"
+        "<p:nvSpPr>"
+        f'<p:cNvPr id="{shape_id}" name="{escape(name)}"/>'
+        '<p:cNvSpPr txBox="1"/><p:nvPr/>'
+        "</p:nvSpPr>"
+        "<p:spPr>"
+        f'<a:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm>'
+        '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+        "</p:spPr>"
+        "<p:txBody><a:bodyPr/><a:lstStyle/><a:p>"
+        f"{''.join(runs_xml)}"
+        "</a:p></p:txBody>"
+        "</p:sp>"
+    )
+
+
+def _v2_shape_without_text_xml(
+    shape_id: int,
+    name: str,
+    *,
+    x: int = 0,
+    y: int = 0,
+    width: int = 100,
+    height: int = 100,
+) -> str:
+    return (
+        "<p:sp>"
+        "<p:nvSpPr>"
+        f'<p:cNvPr id="{shape_id}" name="{escape(name)}"/>'
+        "<p:cNvSpPr/><p:nvPr/>"
+        "</p:nvSpPr>"
+        "<p:spPr>"
+        f'<a:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{width}" cy="{height}"/></a:xfrm>'
+        '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+        "</p:spPr>"
+        "</p:sp>"
+    )
+
+
+def _v2_run_xml(
+    text: str,
+    *,
+    color: str | None = None,
+    font_size: int = 1200,
+) -> str:
+    fill_xml = f'<a:solidFill><a:srgbClr val="{color}"/></a:solidFill>' if color else ""
+    return f'<a:r><a:rPr sz="{font_size}">{fill_xml}</a:rPr><a:t>{escape(text)}</a:t></a:r>'
 
 
 def _content_types(slide_count: int) -> str:


### PR DESCRIPTION
## Summary
- add v2 template validation for meta/reference/runtime contracts behind schema_version 2
- add --strict support to validate_template.py and promote unknown/low-confidence layout warnings to failures
- verify stale reference shape matches against fresh template.pptx extraction

## Validation
- uv run pytest tests/test_features/test_visualization/test_template_registration.py -q
- uv run pytest tests/test_features/test_visualization/test_template_v2_compiler.py -q
- uv run pytest tests/test_features/test_visualization -q
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .
- git diff --check

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * v2 스키마 기반 템플릿 검증 지원 추가
  * 템플릿 검증의 엄격 모드(`--strict`) 옵션 추가로 경고를 오류로 승격 가능
  * 템플릿 구성 요소(PPTX, 참조 데이터, 추출 결과)의 다중 계약 검증 강화

* **테스트**
  * v2 메타데이터 검증 및 엄격 모드 동작 검증을 위한 포괄적인 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->