### PR TITLE
feat: apply pptx layout actions in pipeline

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -39,6 +39,7 @@ from features.visualization.text_fit import (
     BasicTextFitResult,
     InlineLabelGroupFitResult,
     TextFitPreflightError,
+    TextFitPreflightResult,
     apply_text_fit_preflight,
 )
 
@@ -414,14 +415,15 @@ class VisualizationTaskService:
                         content_brief=content_brief,
                         slots=slots,
                     )
-                    updated_fills = _preflight_text_fills(
+                    preflight = _preflight_text_fills(
                         job_id=task.job_id,
                         slide_id=registered_slide.slide_id,
                         slide_order=registered_slide.slide_order,
                         slots=slots,
                         fills=updated_fills,
                     )
-                    await asyncio.to_thread(editor.apply_fills, str(slide_xml_path), updated_fills)
+                    await _apply_preflighted_fills(editor, str(slide_xml_path), preflight, slots)
+                    updated_fills = _public_current_fills(preflight.fills)
                 else:
                     if task.user_request is None:
                         raise ValueError("일반 재생성에는 user_request 가 필요합니다.")
@@ -432,15 +434,17 @@ class VisualizationTaskService:
                     )
                     if not changes:
                         raise ValueError("재생성 변경 지시가 비어 있습니다.")
-                    changes = _preflight_text_fills(
+                    preflight = _preflight_text_fills(
                         job_id=task.job_id,
                         slide_id=registered_slide.slide_id,
                         slide_order=registered_slide.slide_order,
                         slots=slots,
                         fills=changes,
                     )
-                    await asyncio.to_thread(editor.apply_fills, str(slide_xml_path), changes)
+                    await _apply_preflighted_fills(editor, str(slide_xml_path), preflight, slots)
+                    changes = _public_current_fills(preflight.fills)
                     updated_fills = merge_current_fills(current_fills, changes)
+                    updated_fills = _public_current_fills(updated_fills)
 
                 self._pack_and_validate(
                     toolchain=toolchain,
@@ -493,7 +497,9 @@ class VisualizationTaskService:
                 final_pptx = (
                     fixed_pptx if qa_result.pack_count and fixed_pptx.is_file() else updated_pptx
                 )
-                final_fills = dict(getattr(ready_outcome, "current_fills", None) or updated_fills)
+                final_fills = _public_current_fills(
+                    getattr(ready_outcome, "current_fills", None) or updated_fills
+                )
                 final_pdf = render_result.pdf_path
                 if final_pptx != updated_pptx:
                     final_pdf = renderer.render(
@@ -840,14 +846,15 @@ class VisualizationTaskService:
                     content_brief=planned_slide.content_brief,
                     slots=slots,
                 )
-                fills = _preflight_text_fills(
+                preflight = _preflight_text_fills(
                     job_id=task.job_id,
                     slide_id=registered_slide.slide_id,
                     slide_order=registered_slide.slide_order,
                     slots=slots,
                     fills=fills,
                 )
-                await asyncio.to_thread(editor.apply_fills, str(slide_xml_path), fills)
+                await _apply_preflighted_fills(editor, str(slide_xml_path), preflight, slots)
+                fills = _public_current_fills(preflight.fills)
             except Exception as exc:
                 logger.warning(
                     "slide content generation failed: job_id=%s slide_order=%s error=%s",
@@ -1090,8 +1097,8 @@ def _preflight_text_fills(
     slide_order: int,
     slots: Sequence[Mapping[str, Any]],
     fills: Mapping[str, Mapping[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    """OOXML 적용 전 `basic_text_area` 텍스트 fit 정책을 실행한다."""
+) -> TextFitPreflightResult:
+    """OOXML 적용 전 deterministic text fit preflight 를 실행한다."""
     try:
         preflight = apply_text_fit_preflight(slots=slots, fills=fills)
     except TextFitPreflightError as exc:
@@ -1131,7 +1138,31 @@ def _preflight_text_fills(
                 }
             },
         )
-    return preflight.fills
+    return preflight
+
+
+async def _apply_preflighted_fills(
+    editor: SlideEditor,
+    slide_xml_path: str,
+    preflight: TextFitPreflightResult,
+    slots: Sequence[Mapping[str, Any]],
+) -> None:
+    """layout action 을 먼저 적용한 뒤 fill 과 slot style metadata 를 적용한다."""
+    if preflight.layout_actions:
+        await asyncio.to_thread(
+            editor.apply_layout_actions,
+            slide_xml_path,
+            preflight.layout_actions,
+        )
+
+    warnings = await asyncio.to_thread(
+        editor.apply_fills,
+        slide_xml_path,
+        preflight.fills,
+        _slot_metadata_by_shape_id(slots),
+    )
+    for warning in warnings or []:
+        logger.warning("pptx fill warning: %s", warning)
 
 
 def _log_text_fit_result(
@@ -1393,7 +1424,34 @@ def _current_fills_from_context(slide_context: Mapping[str, Any]) -> dict[str, A
     normalized: dict[str, Any] = {}
     for shape_id, fill in current_fills.items():
         normalized[str(shape_id)] = dict(fill) if isinstance(fill, Mapping) else fill
-    return normalized
+    return _public_current_fills(normalized)
+
+
+def _slot_metadata_by_shape_id(
+    slots: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    """v2 slot metadata 를 SlideEditor 에 전달할 shape_id index 로 변환한다."""
+    indexed: dict[str, Mapping[str, Any]] = {}
+    for slot in slots:
+        shape_id = str(slot.get("shape_id") or "")
+        if shape_id:
+            indexed[shape_id] = slot
+    return indexed
+
+
+def _public_current_fills(fills: Mapping[str, Any]) -> dict[str, Any]:
+    """워커 내부 layout action 값을 currentFills callback 계약에서 제거한다."""
+    public_fills: dict[str, Any] = {}
+    for shape_id, fill in fills.items():
+        if str(shape_id) == "layout_actions":
+            continue
+        if isinstance(fill, Mapping):
+            public_fills[str(shape_id)] = {
+                str(key): value for key, value in fill.items() if str(key) != "layout_actions"
+            }
+        else:
+            public_fills[str(shape_id)] = fill
+    return public_fills
 
 
 def _content_brief_for_slide(

--- a/tasks/phase-2-pptx-template-quality/13-pipeline-layout-actions-integration.md
+++ b/tasks/phase-2-pptx-template-quality/13-pipeline-layout-actions-integration.md
@@ -6,7 +6,8 @@ spec: "specs/phase-2/04-pptx-layout-action-application.md"
 depends_on: ["1.05", "2.10", "2.12"]
 blocks: ["2.17"]
 estimate: "M"
-status: "todo"
+status: "done"
+completed_at: "2026-06-14"
 owner: ""
 sprint: ""
 ---
@@ -24,24 +25,38 @@ sprint: ""
 
 ## 사전 준비
 
-- [ ] 생성과 재생성 pipeline 의 공통 편집 경로 확인
-- [ ] Main callback payload 테스트에서 `currentFills` 구조 검증 위치 확인
+- [x] 생성과 재생성 pipeline 의 공통 편집 경로 확인
+- [x] Main callback payload 테스트에서 `currentFills` 구조 검증 위치 확인
 
 ## 구현 체크리스트
 
-- [ ] LLM fill 결정 후 `layout_actions` 계산 단계를 추가
-- [ ] `apply_layout_actions()` 를 `apply_fills()` 전에 호출하도록 pipeline 순서 변경
-- [ ] `layout_actions` 는 워커 내부 객체로만 전달하고 callback payload 에 넣지 않도록 guard 추가
-- [ ] layout action 실패 시 해당 slide error 로 격리
-- [ ] pack/validate/render 통합 테스트 또는 pipeline fake 테스트 추가
+- [x] LLM fill 결정 후 `layout_actions` 계산 단계를 추가
+- [x] `apply_layout_actions()` 를 `apply_fills()` 전에 호출하도록 pipeline 순서 변경
+- [x] `layout_actions` 는 워커 내부 객체로만 전달하고 callback payload 에 넣지 않도록 guard 추가
+- [x] layout action 실패 시 해당 slide error 로 격리
+- [x] pack/validate/render 통합 테스트 또는 pipeline fake 테스트 추가
 
 ## Definition of Done
 
-- [ ] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
-- [ ] `currentFills` callback payload 에 `layout_actions` 가 포함되지 않는다
-- [ ] layout action 결과가 최종 PPTX/PDF/preview 생성 경로에 반영된다
-- [ ] layout action 실패가 전체 job retry 로 번지지 않고 slide-level 오류로 수렴한다
+- [x] 작업 중 또는 완료 후 새 사용자 확인사항이 생기면 `tasks/phase-2-pptx-template-quality/18-user-signoff-and-operational-readiness.md` 에 추가했다.
+- [x] `currentFills` callback payload 에 `layout_actions` 가 포함되지 않는다
+- [x] layout action 결과가 최종 PPTX/PDF/preview 생성 경로에 반영된다
+- [x] layout action 실패가 전체 job retry 로 번지지 않고 slide-level 오류로 수렴한다
+
+## 검증 기록
+
+- `uv run pytest tests/test_pptx_worker/test_visualization/test_generation_pipeline.py -q` — 27 passed
+- `uv run pytest tests/test_pptx_worker/test_visualization tests/test_features/test_visualization -q` — 290 passed
+- `uv run pytest -q` — 935 passed
+- `uv run ruff check apps/pptx-worker/features/visualization/generation_pipeline.py tests/test_pptx_worker/test_visualization/test_generation_pipeline.py` — passed
+- `uv run ruff format --check apps/pptx-worker/features/visualization/generation_pipeline.py tests/test_pptx_worker/test_visualization/test_generation_pipeline.py` — 2 files already formatted
+- `uv run ruff check .` — passed
+- `uv run ruff format --check .` — 200 files already formatted
+- `git diff --check` — passed
+- subagent review 1차 지적 반영 — QA outcome/current_fills sanitize, 재생성 layout action failure 격리, 저장 current_fills 오염 방지 테스트 추가
+- subagent review 2차 — 추가 발견 없음, 1차 지적 3건 해소 확인
 
 ## 리스크 / 메모
 
 - 메인 백엔드 계약은 바꾸지 않는다. Geometry state 는 최종 PPTX 에만 반영한다.
+- 실제 렌더 픽셀 검증은 포함하지 않고, OOXML action 자체는 2.11/2.12 SlideEditor 테스트에 의존한다.

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -269,20 +269,52 @@ class FakeToolchain:
 class FakeEditor:
     """SlideEditor 대역."""
 
-    def __init__(self, slots: list[dict[str, Any]] | None = None) -> None:
+    def __init__(
+        self,
+        slots: list[dict[str, Any]] | None = None,
+        *,
+        layout_action_error: Exception | None = None,
+    ) -> None:
         self.slots = slots or [
             {"shape_id": "2", "font_size_pt": 20, "kind": "text"},
         ]
         self.applied: list[tuple[str, dict[str, dict[str, Any]]]] = []
+        self.applied_slot_metadata: list[dict[str, dict[str, Any]]] = []
+        self.layout_actions: list[tuple[str, tuple[dict[str, Any], ...]]] = []
+        self.layout_action_error = layout_action_error
         self.cleared: list[str] = []
+        self.operations: list[tuple[str, str]] = []
 
     def extract_slots(self, slide_xml_path: str) -> list[dict[str, Any]]:
         return [dict(slot, path=slide_xml_path) for slot in self.slots]
 
-    def apply_fills(self, slide_xml_path: str, fills: dict[str, dict[str, Any]]) -> None:
+    def apply_layout_actions(
+        self,
+        slide_xml_path: str,
+        layout_actions: tuple[dict[str, Any], ...],
+    ) -> None:
+        self.operations.append(("layout_actions", slide_xml_path))
+        self.layout_actions.append(
+            (slide_xml_path, tuple(dict(action) for action in layout_actions))
+        )
+        if self.layout_action_error is not None:
+            raise self.layout_action_error
+
+    def apply_fills(
+        self,
+        slide_xml_path: str,
+        fills: dict[str, dict[str, Any]],
+        slot_metadata: dict[str, dict[str, Any]] | None = None,
+    ) -> list[str]:
+        self.operations.append(("fills", slide_xml_path))
         self.applied.append((slide_xml_path, fills))
+        self.applied_slot_metadata.append(
+            {shape_id: dict(metadata) for shape_id, metadata in (slot_metadata or {}).items()}
+        )
+        return []
 
     def clear_content(self, slide_xml_path: str) -> None:
+        self.operations.append(("clear", slide_xml_path))
         self.cleared.append(slide_xml_path)
         Path(slide_xml_path).write_text(
             "<p:sld><p:cSld><p:spTree/></p:cSld></p:sld>", encoding="utf-8"
@@ -394,10 +426,12 @@ class FakeQAStep:
         main_client: FakeMainClient,
         storage: FakeStorage | None = None,
         statuses: dict[int, str] | None = None,
+        outcome_fills: dict[int, dict[str, Any]] | None = None,
     ) -> None:
         self.main_client = main_client
         self.storage = storage
         self.statuses = statuses or {}
+        self.outcome_fills = outcome_fills or {}
         self.received_orders: list[int] = []
 
     async def process(self, *, job_id: str, slides: list[Any], **kwargs: Any) -> FakeQAResult:
@@ -452,7 +486,12 @@ class FakeQAStep:
                     slide.slide_order,
                     status,
                     gcs_preview_key=gcs_preview_key,
-                    current_fills=dict(getattr(slide, "current_fills", {}) or {}),
+                    current_fills=dict(
+                        self.outcome_fills.get(
+                            slide.slide_order,
+                            getattr(slide, "current_fills", {}) or {},
+                        )
+                    ),
                 )
             )
         return FakeQAResult(outcomes=tuple(outcomes))
@@ -617,6 +656,101 @@ async def test_generate_enriches_slots_from_template_metadata_before_preflight()
 
 
 @pytest.mark.asyncio
+async def test_generate_applies_layout_actions_and_sanitizes_current_fills() -> None:
+    """초기 생성은 layout action 을 먼저 적용하고 callback 에 내부 action 을 노출하지 않는다."""
+    editor = FakeEditor(slots=_inline_label_slots())
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "OpenAI API OpenAI API OpenAI API",
+                        "font_size_override": 20,
+                        "layout_actions": [{"action": "internal"}],
+                    },
+                    "3": {
+                        "action": "text",
+                        "text": "KPI 개선",
+                        "font_size_override": 20,
+                    },
+                    "layout_actions": {"action": "internal"},
+                }
+            ]
+        }
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+    context.storage.template_metadata = _template_metadata_with_inline_label_layout()
+
+    await context.service.generate(_task())
+
+    slide3_ops = [name for name, path in editor.operations if path.endswith("slide3.xml")]
+    assert slide3_ops[:2] == ["layout_actions", "fills"]
+    assert editor.layout_actions
+    layout_action_path, layout_actions = editor.layout_actions[0]
+    assert layout_action_path.endswith("slide3.xml")
+    assert {action["action"] for action in layout_actions} >= {
+        "resize_linked_shape",
+        "relayout_row",
+    }
+
+    slide3_apply_index = next(
+        index for index, (path, _fills) in enumerate(editor.applied) if path.endswith("slide3.xml")
+    )
+    assert editor.applied_slot_metadata[slide3_apply_index]["2"]["marker_color"] == "#FF0000"
+    assert editor.applied_slot_metadata[slide3_apply_index]["2"]["output_text_color"] == "#1F4D1D"
+
+    ready_event = next(
+        event
+        for event in _events(context.main_client, "slide_content_ready")
+        if event["slide_order"] == 3
+    )
+    assert "layout_actions" not in ready_event["current_fills"]
+    assert "layout_actions" not in ready_event["current_fills"]["2"]
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 7, "failed": 0}
+    assert context.storage.uploaded_pptx
+
+
+@pytest.mark.asyncio
+async def test_generate_layout_action_failure_blanks_slide_and_continues() -> None:
+    """layout action 실패는 slide_content_error 와 clear_content 로 격리된다."""
+    editor = FakeEditor(
+        slots=_inline_label_slots(),
+        layout_action_error=ValueError("layout action failed"),
+    )
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "OpenAI API OpenAI API OpenAI API",
+                        "font_size_override": 20,
+                    },
+                    "3": {
+                        "action": "text",
+                        "text": "KPI 개선",
+                        "font_size_override": 20,
+                    },
+                }
+            ]
+        }
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+    context.storage.template_metadata = _template_metadata_with_inline_label_layout()
+
+    await context.service.generate(_task())
+
+    error_events = _events(context.main_client, "slide_content_error")
+    assert len(error_events) == 1
+    assert error_events[0]["slide_order"] == 3
+    assert "layout action failed" in error_events[0]["message"]
+    assert len(editor.cleared) == 1
+    assert editor.cleared[0].endswith("slide3.xml")
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 6, "failed": 1}
+
+
+@pytest.mark.asyncio
 async def test_all_content_failures_send_error_without_render_or_upload() -> None:
     """모든 슬라이드 콘텐츠 생성 실패는 전체 실패 final callback 으로 마감한다."""
     filler = FakeFillGenerator(
@@ -775,6 +909,133 @@ async def test_regenerate_enriches_slots_from_downloaded_template_metadata() -> 
     assert len(_events(context.main_client, "slide_regenerated")) == 1
     assert context.change_generator.calls[0]["slots"][0]["fit_policy"] == "resize_label"
     assert context.change_generator.calls[0]["slots"][0]["layout_type"] == "inline_label_group"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_applies_layout_actions_before_fills_with_slot_metadata() -> None:
+    """재생성도 layout action 을 먼저 적용하고 marker style metadata 를 전달한다."""
+    main_client = FakeMainClient()
+    main_client.job_context["template_id"] = "blue"
+    editor = FakeEditor(slots=_inline_label_slots())
+    change_generator = FakeChangeGenerator(
+        response={
+            "2": {
+                "action": "text",
+                "text": "OpenAI API OpenAI API OpenAI API",
+                "font_size_override": 20,
+                "layout_actions": [{"action": "internal"}],
+            },
+            "3": {
+                "action": "text",
+                "text": "KPI 개선",
+                "font_size_override": 20,
+            },
+            "layout_actions": {"action": "internal"},
+        }
+    )
+    context = PipelineContext(
+        main_client=main_client,
+        editor=editor,
+        change_generator=change_generator,
+    )
+    context.storage.template_metadata = _template_metadata_with_inline_label_layout()
+
+    await context.service.regenerate(_regenerate_task(user_request="라벨을 자세히 써줘"))
+
+    slide3_ops = [name for name, path in editor.operations if path.endswith("slide3.xml")]
+    assert slide3_ops[:2] == ["layout_actions", "fills"]
+    assert editor.applied_slot_metadata[0]["2"]["output_text_color"] == "#1F4D1D"
+
+    regenerated_event = _events(context.main_client, "slide_regenerated")[0]
+    assert "layout_actions" not in regenerated_event["current_fills"]
+    assert "layout_actions" not in regenerated_event["current_fills"]["2"]
+    assert regenerated_event["current_fills"]["3"]["text"] == "KPI 개선"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_sanitizes_qa_outcome_current_fills() -> None:
+    """QA/fix 결과가 내부 layout action 을 되돌려도 최종 callback 에 노출하지 않는다."""
+    qa_step = FakeQAStep(
+        FakeMainClient(),
+        outcome_fills={
+            3: {
+                "2": {
+                    "action": "text",
+                    "text": "수정된 제목",
+                    "layout_actions": [{"action": "internal"}],
+                },
+                "layout_actions": {"action": "internal"},
+            }
+        },
+    )
+    context = PipelineContext(qa_step=qa_step)
+
+    await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
+
+    regenerated_event = _events(context.main_client, "slide_regenerated")[0]
+    assert regenerated_event["current_fills"] == {"2": {"action": "text", "text": "수정된 제목"}}
+
+
+@pytest.mark.asyncio
+async def test_regenerate_layout_action_failure_sends_preview_error_without_upload() -> None:
+    """재생성 layout action 실패는 preview error 로 격리하고 attempt 산출물을 만들지 않는다."""
+    main_client = FakeMainClient()
+    main_client.job_context["template_id"] = "blue"
+    editor = FakeEditor(
+        slots=_inline_label_slots(),
+        layout_action_error=ValueError("layout action failed"),
+    )
+    change_generator = FakeChangeGenerator(
+        response={
+            "2": {
+                "action": "text",
+                "text": "OpenAI API OpenAI API OpenAI API",
+                "font_size_override": 20,
+            },
+            "3": {
+                "action": "text",
+                "text": "KPI 개선",
+                "font_size_override": 20,
+            },
+        }
+    )
+    context = PipelineContext(
+        main_client=main_client,
+        editor=editor,
+        change_generator=change_generator,
+    )
+    context.storage.template_metadata = _template_metadata_with_inline_label_layout()
+
+    await context.service.regenerate(_regenerate_task(user_request="라벨을 자세히 써줘"))
+
+    assert _events(context.main_client, "slide_regenerated") == []
+    error_events = _events(context.main_client, "slide_preview_error")
+    assert len(error_events) == 1
+    assert error_events[0]["slide_order"] == 3
+    assert error_events[0]["retryable"] is False
+    assert "layout action failed" in error_events[0]["message"]
+    assert context.storage.uploaded_attempt_pptx == []
+    assert context.storage.uploaded_attempt_pdf == []
+    assert context.storage.uploaded_attempt_previews == []
+    assert context.storage.promoted_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_regenerate_sanitizes_stored_current_fills_before_change_generation() -> None:
+    """backend 저장 current_fills 가 오염되어도 변경 생성기와 callback 계약에는 넘기지 않는다."""
+    main_client = FakeMainClient()
+    main_client.slide_context["current_fills"]["2"]["layout_actions"] = [{"action": "internal"}]
+    main_client.slide_context["current_fills"]["layout_actions"] = {"action": "internal"}
+    context = PipelineContext(main_client=main_client)
+
+    await context.service.regenerate(_regenerate_task(user_request="제목 크기 키워줘"))
+
+    generator_current_fills = context.change_generator.calls[0]["current_fills"]
+    assert "layout_actions" not in generator_current_fills
+    assert "layout_actions" not in generator_current_fills["2"]
+    regenerated_event = _events(context.main_client, "slide_regenerated")[0]
+    assert "layout_actions" not in regenerated_event["current_fills"]
+    assert "layout_actions" not in regenerated_event["current_fills"]["2"]
 
 
 @pytest.mark.asyncio
@@ -1095,5 +1356,72 @@ def _template_metadata_with_resize_label_slot() -> dict[str, Any]:
                 "max_lines": 1,
                 "nowrap": True,
             }
+        ],
+    }
+
+
+def _inline_label_slots() -> list[dict[str, Any]]:
+    """pipeline test 에서 metadata overlay 를 받을 inline label shape 목록."""
+    return [
+        {"shape_id": "2", "font_size_pt": 20, "kind": "text", "current_text": "기존 라벨"},
+        {"shape_id": "3", "font_size_pt": 20, "kind": "text", "current_text": "기존 값"},
+    ]
+
+
+def _template_metadata_with_inline_label_layout() -> dict[str, Any]:
+    """slide3 inline label group 이 layout action 을 만들도록 하는 v2 metadata."""
+    return {
+        "schema_version": 2,
+        "template_id": "blue",
+        "runtime_slides": [],
+        "layout_groups": [
+            {
+                "group_id": "slide3_labels",
+                "slide_filename": "slide3.xml",
+                "layout_type": "inline_label_group",
+            }
+        ],
+        "slots": [
+            {
+                "slot_id": "slide3_shape2",
+                "slide_filename": "slide3.xml",
+                "shape_id": "2",
+                "kind": "text",
+                "fit_policy": "resize_label",
+                "layout_type": "inline_label_group",
+                "layout_group_id": "slide3_labels",
+                "x_emu": 1_100_000,
+                "y_emu": 1_000_000,
+                "w_emu": 220_000,
+                "h_emu": 240_000,
+                "row_right_bound_emu": 12_000_000,
+                "gap_emu": 400_000,
+                "min_gap_emu": 100_000,
+                "marker_color": "#FF0000",
+                "output_text_color": "#1F4D1D",
+                "item_background": {
+                    "shape_id": "12",
+                    "x_emu": 1_000_000,
+                    "y_emu": 940_000,
+                    "w_emu": 420_000,
+                    "h_emu": 360_000,
+                },
+            },
+            {
+                "slot_id": "slide3_shape3",
+                "slide_filename": "slide3.xml",
+                "shape_id": "3",
+                "kind": "text",
+                "fit_policy": "resize_label",
+                "layout_type": "inline_label_group",
+                "layout_group_id": "slide3_labels",
+                "x_emu": 2_100_000,
+                "y_emu": 1_000_000,
+                "w_emu": 220_000,
+                "h_emu": 240_000,
+                "row_right_bound_emu": 12_000_000,
+                "gap_emu": 400_000,
+                "min_gap_emu": 100_000,
+            },
         ],
     }


### PR DESCRIPTION
## Summary
- apply text-fit layout_actions through the generation and regeneration pipeline before fills
- pass v2 slot metadata into SlideEditor.apply_fills so marker/output colors survive replacement
- keep layout_actions internal by sanitizing currentFills at input, callback, and QA outcome boundaries
- add generation/regeneration tests for action order, failure isolation, and sanitized callback contracts

## Validation
- uv run pytest tests/test_pptx_worker/test_visualization/test_generation_pipeline.py -q
- uv run pytest tests/test_pptx_worker/test_visualization tests/test_features/test_visualization -q
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .
- git diff --check

Closes #268