### PR TITLE
[Fix] PPTX text-fit overflow 재요약 복구

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -846,10 +846,11 @@ class VisualizationTaskService:
                     content_brief=planned_slide.content_brief,
                     slots=slots,
                 )
-                preflight = _preflight_text_fills(
+                preflight = await self._preflight_text_fills_with_fit_retry(
                     job_id=task.job_id,
                     slide_id=registered_slide.slide_id,
                     slide_order=registered_slide.slide_order,
+                    content_brief=planned_slide.content_brief,
                     slots=slots,
                     fills=fills,
                 )
@@ -913,6 +914,65 @@ class VisualizationTaskService:
                 status="ready",
                 current_fills=fills,
             )
+
+    async def _preflight_text_fills_with_fit_retry(
+        self,
+        *,
+        job_id: str,
+        slide_id: str,
+        slide_order: int,
+        content_brief: str,
+        slots: Sequence[Mapping[str, Any]],
+        fills: Mapping[str, Mapping[str, Any]],
+    ) -> TextFitPreflightResult:
+        """summarize_needed text-fit 실패는 LLM에 한 번 짧게 재요청한다."""
+        try:
+            return _preflight_text_fills(
+                job_id=job_id,
+                slide_id=slide_id,
+                slide_order=slide_order,
+                slots=slots,
+                fills=fills,
+            )
+        except TextFitPreflightError as exc:
+            if not _text_fit_error_retryable(exc):
+                raise
+            fit_issues = _text_fit_retry_issues(exc, fills)
+            logger.info(
+                "slide content fit retry: job_id=%s slide_order=%s blocking_slots=%s",
+                job_id,
+                slide_order,
+                ",".join(str(issue.get("shape_id")) for issue in fit_issues),
+            )
+            try:
+                revised_fills = await asyncio.to_thread(
+                    self._content_fill_generator.revise_fills_for_fit,
+                    content_brief=content_brief,
+                    slots=slots,
+                    current_fills=fills,
+                    fit_issues=fit_issues,
+                )
+                preflight = _preflight_text_fills(
+                    job_id=job_id,
+                    slide_id=slide_id,
+                    slide_order=slide_order,
+                    slots=slots,
+                    fills=revised_fills,
+                )
+            except Exception:
+                logger.warning(
+                    "slide content fit retry failed: job_id=%s slide_order=%s",
+                    job_id,
+                    slide_order,
+                    exc_info=True,
+                )
+                raise exc
+            logger.info(
+                "slide content fit retry succeeded: job_id=%s slide_order=%s",
+                job_id,
+                slide_order,
+            )
+            return preflight
 
     async def _create_fills_with_timeout_retry(
         self,
@@ -1139,6 +1199,49 @@ def _preflight_text_fills(
             },
         )
     return preflight
+
+
+def _text_fit_error_retryable(exc: TextFitPreflightError) -> bool:
+    """LLM 재요약으로 복구 가능한 text-fit 실패인지 판정한다."""
+    blocking = [
+        result
+        for result in exc.results
+        if isinstance(result, BasicTextFitResult) and result.is_blocking
+    ]
+    if not blocking:
+        return False
+    return all(result.status == "summarize_needed" for result in blocking)
+
+
+def _text_fit_retry_issues(
+    exc: TextFitPreflightError,
+    fills: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """LLM 재요약 prompt에 넣을 text-fit 실패 요약을 만든다."""
+    issues: list[dict[str, Any]] = []
+    for result in exc.results:
+        if not isinstance(result, BasicTextFitResult) or not result.is_blocking:
+            continue
+        shape_id = result.shape_id
+        current_fill = fills.get(shape_id, {})
+        current_text = str(current_fill.get("text") or "")
+        issues.append(
+            {
+                "shape_id": shape_id,
+                "status": result.status,
+                "reason": result.reason,
+                "current_text": current_text,
+                "current_char_count": len(current_text.replace("\n", "")),
+                "nowrap": result.nowrap,
+                "max_lines": result.max_lines,
+                "applied_font_pt": result.applied_font_pt,
+                "min_font_pt": result.min_font_pt,
+                "available_width_pt": result.constraints.available_width_pt,
+                "final_max_line_width_pt": result.final_layout.max_line_width_pt,
+                "overflow_reasons": list(result.final_layout.overflow_reasons),
+            }
+        )
+    return issues
 
 
 async def _apply_preflighted_fills(

--- a/features/visualization/agents/generation.py
+++ b/features/visualization/agents/generation.py
@@ -50,6 +50,19 @@ _FILL_SYSTEM_PROMPT = """PPTX 슬라이드 Slot 을 채우는 편집 데이터 �
 - 텍스트 요약이 필요하면 고유명사, 수치, 기술 스택, 성과 지표를 보존하세요.
 """
 
+_FIT_RETRY_SYSTEM_PROMPT = """PPTX text-fit preflight 실패를 복구하는 편집 데이터 수정기입니다.
+응답은 반드시 JSON 객체 하나로만 작성하세요.
+스키마: {"fills": {"shape_id": {"action": "text"|"remove"|"chart", "text": string, "font_size_override": number|null, "is_title": boolean|null, "data": object|null}}}
+지침:
+- current_fills 와 동일한 shape_id 집합을 반환하세요. 새 shape_id 를 추가하지 마세요.
+- 실패한 text slot 은 반드시 더 짧게 다시 작성하세요.
+- nowrap=true 또는 max_lines=1 slot 은 줄바꿈 없이 한 줄 문구로 작성하세요.
+- reason 이 nowrap_width_overflow, width_overflow, height_overflow 이면 핵심 명사, 수치, 기술 스택만 남기세요.
+- 고유명사, 수치, 기술 스택, 성과 지표를 우선 보존하고 설명형 수식어를 제거하세요.
+- action, chart data, remove 결정은 current_fills 의 의도를 유지하세요.
+- layout_actions, 좌표, geometry, XML, 임의 필드를 만들지 마세요.
+"""
+
 _REGENERATE_SYSTEM_PROMPT = """PPTX 단일 슬라이드 수정 요청을 fill 변경 지시로 해석하는 편집자입니다.
 응답은 반드시 JSON 객체 하나로만 작성하세요.
 스키마: {"fills": {"shape_id": {"action": "text", "text": string|null, "font_size_override": number|null, "is_title": boolean|null}}}
@@ -158,6 +171,17 @@ class ContentFillGenerator(Protocol):
         slots: Sequence[Mapping[str, Any]],
     ) -> dict[str, dict[str, Any]]:
         """SlideEditor.apply_fills 입력 형식의 fill 맵을 반환한다."""
+        ...
+
+    def revise_fills_for_fit(
+        self,
+        *,
+        content_brief: str,
+        slots: Sequence[Mapping[str, Any]],
+        current_fills: Mapping[str, Mapping[str, Any]],
+        fit_issues: Sequence[Mapping[str, Any]],
+    ) -> dict[str, dict[str, Any]]:
+        """Text-fit 실패 정보를 반영해 더 짧은 fill 맵을 반환한다."""
         ...
 
 
@@ -309,6 +333,41 @@ class LLMContentFillGenerator:
             HumanMessage(
                 content=(
                     "다음 슬라이드 요지와 Slot 정보를 보고 fills 를 작성하세요.\n"
+                    f"{json.dumps(prompt_payload, ensure_ascii=False, default=str)}"
+                )
+            ),
+        ]
+        response = llm.invoke(messages)
+        response_text = _normalize_response_text(getattr(response, "content", response))
+        payload = _loads_json_object(response_text)
+        return _parse_fills_payload(payload, slots)
+
+    def revise_fills_for_fit(
+        self,
+        *,
+        content_brief: str,
+        slots: Sequence[Mapping[str, Any]],
+        current_fills: Mapping[str, Mapping[str, Any]],
+        fit_issues: Sequence[Mapping[str, Any]],
+    ) -> dict[str, dict[str, Any]]:
+        """Text-fit 실패 slot 을 더 짧게 수정한 fill 맵을 생성한다."""
+        if not slots:
+            return {}
+        if not fit_issues:
+            return {str(shape_id): dict(fill) for shape_id, fill in current_fills.items()}
+
+        llm = self._llm or get_llm_uncached(temperature=0.1, timeout=120)
+        prompt_payload = _build_fit_retry_prompt_payload(
+            content_brief=content_brief,
+            slots=slots,
+            current_fills=current_fills,
+            fit_issues=fit_issues,
+        )
+        messages = [
+            SystemMessage(content=_FIT_RETRY_SYSTEM_PROMPT),
+            HumanMessage(
+                content=(
+                    "다음 text-fit preflight 실패 정보를 보고 current_fills 를 더 짧게 수정하세요.\n"
                     f"{json.dumps(prompt_payload, ensure_ascii=False, default=str)}"
                 )
             ),
@@ -559,6 +618,27 @@ def _build_fill_prompt_payload(
             "length_hint": "텍스트 생성 시 우선 준수해야 하는 길이 제약입니다.",
         },
         "slots": [_build_fill_slot_prompt_payload(slot) for slot in slots],
+    }
+
+
+def _build_fit_retry_prompt_payload(
+    *,
+    content_brief: str,
+    slots: Sequence[Mapping[str, Any]],
+    current_fills: Mapping[str, Mapping[str, Any]],
+    fit_issues: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Text-fit 복구 호출에 전달할 실패 요약 payload를 구성한다."""
+    return {
+        "content_brief": content_brief,
+        "slot_guidance": {
+            "placeholder_text": "slot 의 의미를 알려주는 입력 힌트입니다.",
+            "example_text": "복사 대상이 아니라 형식, 길이, 줄 수 참고용입니다.",
+            "length_hint": "텍스트 수정 시 우선 준수해야 하는 길이 제약입니다.",
+        },
+        "slots": [_build_fill_slot_prompt_payload(slot) for slot in slots],
+        "current_fills": {str(shape_id): dict(fill) for shape_id, fill in current_fills.items()},
+        "fit_issues": [dict(issue) for issue in fit_issues],
     }
 
 

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -335,6 +335,69 @@ def test_content_fill_prompt_uses_inline_label_one_line_length_hint() -> None:
     assert "줄바꿈하지 말고" in slot_payload["length_hint"]
 
 
+def test_content_fill_generator_revises_fills_with_fit_issue_payload() -> None:
+    """text-fit 재요청은 기존 fills와 overflow issue를 전달하고 같은 fill schema를 반환한다."""
+    llm = FakeLLM(
+        [
+            {
+                "fills": {
+                    "26": {
+                        "action": "text",
+                        "text": "AI 상담",
+                        "font_size_override": 12,
+                    }
+                }
+            }
+        ]
+    )
+    generator = LLMContentFillGenerator(llm=llm)
+
+    fills = generator.revise_fills_for_fit(
+        content_brief="AI 상담 서비스 표지",
+        slots=[
+            {
+                "shape_id": "26",
+                "kind": "text",
+                "editable": True,
+                "required": True,
+                "placeholder_text": "프로젝트명",
+                "example_text": "Folioo AI",
+                "font_size_pt": 20,
+                "max_lines": 1,
+                "nowrap": True,
+                "fit_policy": "basic_text_area",
+                "allowed_actions": ["text"],
+            }
+        ],
+        current_fills={
+            "26": {
+                "action": "text",
+                "text": "이커머스 고객센터 AI 상담 서비스 구축 프로젝트",
+                "font_size_override": 20,
+            }
+        },
+        fit_issues=[
+            {
+                "shape_id": "26",
+                "status": "summarize_needed",
+                "reason": "nowrap_width_overflow",
+                "current_char_count": 26,
+                "nowrap": True,
+                "max_lines": 1,
+            }
+        ],
+    )
+
+    assert fills == {"26": {"action": "text", "text": "AI 상담", "font_size_override": 12}}
+    system_prompt = llm.messages[0][0].content
+    prompt_payload = _last_fill_prompt_payload(llm)
+    assert "text-fit preflight 실패" in system_prompt
+    assert "current_fills" in prompt_payload
+    assert prompt_payload["current_fills"]["26"]["text"].startswith("이커머스")
+    assert prompt_payload["fit_issues"][0]["reason"] == "nowrap_width_overflow"
+    assert prompt_payload["slots"][0]["nowrap"] is True
+
+
 def test_content_fill_prompt_does_not_add_text_capacity_hint_to_chart_slot() -> None:
     """chart slot 에는 text length hint를 붙여 action 계약을 흐리지 않는다."""
     llm = FakeLLM(

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -346,10 +346,16 @@ class FakePlanGenerator:
 class FakeFillGenerator:
     """슬라이드별 fill 생성 결과/예외를 반환한다."""
 
-    def __init__(self, responses: dict[int, list[object]] | None = None) -> None:
+    def __init__(
+        self,
+        responses: dict[int, list[object]] | None = None,
+        revise_responses: dict[int, list[object]] | None = None,
+    ) -> None:
         self.responses = responses or {}
+        self.revise_responses = revise_responses or {}
         self.calls: list[int] = []
         self.slot_calls: list[tuple[int, list[dict[str, Any]]]] = []
+        self.revise_calls: list[dict[str, Any]] = []
 
     def create_fills(
         self, *, content_brief: str, slots: list[dict[str, Any]]
@@ -366,6 +372,33 @@ class FakeFillGenerator:
         return {
             "2": {"action": "text", "text": f"슬라이드 {slide_order}", "font_size_override": 18}
         }
+
+    def revise_fills_for_fit(
+        self,
+        *,
+        content_brief: str,
+        slots: list[dict[str, Any]],
+        current_fills: dict[str, dict[str, Any]],
+        fit_issues: list[dict[str, Any]],
+    ) -> dict[str, dict[str, Any]]:
+        slide_order = int(content_brief.rsplit("-", maxsplit=1)[1])
+        self.revise_calls.append(
+            {
+                "slide_order": slide_order,
+                "slots": [dict(slot) for slot in slots],
+                "current_fills": {
+                    str(shape_id): dict(fill) for shape_id, fill in current_fills.items()
+                },
+                "fit_issues": [dict(issue) for issue in fit_issues],
+            }
+        )
+        responses = self.revise_responses.get(slide_order)
+        if responses:
+            result = responses.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result  # type: ignore[return-value]
+        raise AssertionError("fit retry 응답이 없습니다.")
 
 
 class FakeChangeGenerator:
@@ -614,6 +647,119 @@ async def test_text_fit_overflow_logs_structured_result_and_continues_partial(
     assert overflow_log["reason"] in {"nowrap_width_overflow", "width_overflow"}
     assert overflow_log["applied_font_pt"] == 10
     assert overflow_log["final_layout"]["overflow_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_text_fit_summarize_needed_retries_with_shorter_fills() -> None:
+    """summarize_needed overflow 는 한 번 더 짧은 fill 을 요청하고 성공 경로로 복구한다."""
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "min_font_pt": 10,
+                "kind": "text",
+                "fit_policy": "basic_text_area",
+                "w_emu": int(80 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+                "max_lines": 1,
+                "nowrap": True,
+            }
+        ]
+    )
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "OpenAI API OpenAI API OpenAI API",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        },
+        revise_responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "AI 상담",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        },
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+
+    await context.service.generate(_task())
+
+    assert _events(context.main_client, "slide_content_error") == []
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 7, "failed": 0}
+    assert len(filler.revise_calls) == 1
+    retry_call = filler.revise_calls[0]
+    assert retry_call["slide_order"] == 3
+    assert retry_call["fit_issues"][0]["shape_id"] == "2"
+    assert retry_call["fit_issues"][0]["status"] == "summarize_needed"
+    assert retry_call["fit_issues"][0]["reason"] in {"nowrap_width_overflow", "width_overflow"}
+    slide3_fills = [fills for path, fills in editor.applied if path.endswith("slide3.xml")][0]
+    assert slide3_fills["2"]["text"] == "AI 상담"
+
+
+@pytest.mark.asyncio
+async def test_text_fit_retry_failure_keeps_original_overflow_error() -> None:
+    """짧게 재요청한 fill 도 실패하면 원래 overflow 오류로 콘텐츠 실패를 전송한다."""
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "min_font_pt": 10,
+                "kind": "text",
+                "fit_policy": "basic_text_area",
+                "w_emu": int(80 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+                "max_lines": 1,
+                "nowrap": True,
+            }
+        ]
+    )
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "OpenAI API OpenAI API OpenAI API",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        },
+        revise_responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "여전히 너무 긴 OpenAI API 상담 서비스 설명 문구",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        },
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+
+    await context.service.generate(_task())
+
+    error_events = _events(context.main_client, "slide_content_error")
+    assert len(error_events) == 1
+    assert error_events[0]["slide_order"] == 3
+    assert "summarize_needed" in error_events[0]["message"]
+    assert len(filler.revise_calls) == 1
+    assert len(context.editor.cleared) == 1
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 6, "failed": 1}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📌 관련 이슈

- Refs #274

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- 초기 생성 중 text-fit preflight가 `summarize_needed`로 실패하면 즉시 슬라이드 실패로 처리하지 않고, LLM fill 생성기에 한 번 더 짧은 문구 재생성을 요청하도록 했습니다.
- 재요청 대상은 `BasicTextFitResult.status == "summarize_needed"`인 text slot으로 제한했습니다. `failed` 성격의 geometry/box 오류와 inline label abbreviation은 기존처럼 실패 처리합니다.
- 재요청 prompt에는 기존 `current_fills`, slot capacity hint, 실패한 shape_id/reason/nowrap/max_lines/current_text 요약을 전달합니다.
- 재요청 후에도 preflight가 실패하면 원래 overflow 오류를 유지해 기존 `slide_content_error` 경로로 수렴합니다.
- Main Backend `currentFills`/DTO/SSE 계약은 변경하지 않았습니다.

## 📸 스크린샷

- 백엔드 파이프라인/테스트 변경 PR이라 스크린샷은 없습니다.

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 검증

- `uv run pytest tests/test_pptx_worker/test_visualization/test_generation_pipeline.py::test_text_fit_summarize_needed_retries_with_shorter_fills tests/test_pptx_worker/test_visualization/test_generation_pipeline.py::test_text_fit_retry_failure_keeps_original_overflow_error tests/test_pptx_worker/test_visualization/test_generation_pipeline.py::test_text_fit_overflow_logs_structured_result_and_continues_partial -q` — 3 passed
- `uv run pytest tests/test_features/test_visualization/test_generation_agents.py::test_content_fill_generator_revises_fills_with_fit_issue_payload -q` — 1 passed
- `uv run pytest tests/test_pptx_worker/test_visualization/test_generation_pipeline.py tests/test_features/test_visualization/test_generation_agents.py -q` — 69 passed
- `uv run pytest -q` — 962 passed
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 200 files already formatted
- `git diff --check`

## 📎 기타 참고사항

- 이 PR은 배포 smoke에서 확인된 `nowrap_width_overflow` 실패를 줄이기 위한 worker-side 복구입니다.
- 머지/배포 후 같은 방식으로 `ppt-v3` smoke job을 다시 생성해 mixed-color marker output까지 확인해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 슬라이드 텍스트 콘텐츠 생성 중 텍스트 공간 부족 오류 발생 시 자동으로 텍스트를 더 짧게 요약하여 재시도하는 기능 추가. 재시도 성공 시 최종 슬라이드에 단축된 텍스트가 반영됩니다.

* **Tests**
  * 텍스트 단축 재시도 성공 및 실패 케이스에 대한 테스트 커버리지 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->