### PR TITLE
fix: add deterministic pptx text fit fallback

### DIFF
--- a/apps/pptx-worker/features/visualization/generation_pipeline.py
+++ b/apps/pptx-worker/features/visualization/generation_pipeline.py
@@ -41,6 +41,7 @@ from features.visualization.text_fit import (
     TextFitPreflightError,
     TextFitPreflightResult,
     apply_text_fit_preflight,
+    evaluate_basic_text_area_fit,
 )
 
 logger = logging.getLogger(__name__)
@@ -952,13 +953,45 @@ class VisualizationTaskService:
                     current_fills=fills,
                     fit_issues=fit_issues,
                 )
-                preflight = _preflight_text_fills(
-                    job_id=job_id,
-                    slide_id=slide_id,
-                    slide_order=slide_order,
-                    slots=slots,
-                    fills=revised_fills,
-                )
+                try:
+                    preflight = _preflight_text_fills(
+                        job_id=job_id,
+                        slide_id=slide_id,
+                        slide_order=slide_order,
+                        slots=slots,
+                        fills=revised_fills,
+                    )
+                except TextFitPreflightError as retry_exc:
+                    if not _text_fit_error_retryable(retry_exc):
+                        raise
+                    fallback_fills = _condense_text_fills_for_fit(
+                        slots=slots,
+                        fills=revised_fills,
+                        exc=retry_exc,
+                    )
+                    logger.info(
+                        "slide content fit deterministic fallback: "
+                        "job_id=%s slide_order=%s blocking_slots=%s",
+                        job_id,
+                        slide_order,
+                        ",".join(
+                            str(issue.get("shape_id"))
+                            for issue in _text_fit_retry_issues(retry_exc, revised_fills)
+                        ),
+                    )
+                    preflight = _preflight_text_fills(
+                        job_id=job_id,
+                        slide_id=slide_id,
+                        slide_order=slide_order,
+                        slots=slots,
+                        fills=fallback_fills,
+                    )
+                    logger.info(
+                        "slide content fit deterministic fallback succeeded: "
+                        "job_id=%s slide_order=%s",
+                        job_id,
+                        slide_order,
+                    )
             except Exception:
                 logger.warning(
                     "slide content fit retry failed: job_id=%s slide_order=%s",
@@ -1238,10 +1271,173 @@ def _text_fit_retry_issues(
                 "min_font_pt": result.min_font_pt,
                 "available_width_pt": result.constraints.available_width_pt,
                 "final_max_line_width_pt": result.final_layout.max_line_width_pt,
+                "max_recommended_char_count": _recommended_fit_char_count(
+                    result,
+                    current_text,
+                ),
                 "overflow_reasons": list(result.final_layout.overflow_reasons),
             }
         )
     return issues
+
+
+def _recommended_fit_char_count(result: BasicTextFitResult, current_text: str) -> int:
+    """LLM retry 가 참고할 text-fit 기반 권장 글자 수를 계산한다."""
+    current_count = len(current_text.replace("\n", ""))
+    if current_count <= 0:
+        return 0
+    available_width = result.constraints.available_width_pt
+    final_width = result.final_layout.max_line_width_pt
+    if available_width <= 0 or final_width <= 0:
+        return max(1, current_count // 2)
+    fit_ratio = min(1.0, available_width / final_width)
+    return max(1, int(current_count * fit_ratio * 0.85))
+
+
+def _condense_text_fills_for_fit(
+    *,
+    slots: Sequence[Mapping[str, Any]],
+    fills: Mapping[str, Mapping[str, Any]],
+    exc: TextFitPreflightError,
+) -> dict[str, dict[str, Any]]:
+    """LLM retry 이후에도 넘치는 basic text slot 을 측정 기반으로 축약한다."""
+    slots_by_id = {str(slot.get("shape_id")): slot for slot in slots if slot.get("shape_id")}
+    adjusted = {str(shape_id): dict(fill) for shape_id, fill in fills.items()}
+    for result in exc.results:
+        if not isinstance(result, BasicTextFitResult) or result.status != "summarize_needed":
+            continue
+        shape_id = result.shape_id
+        slot = slots_by_id.get(shape_id)
+        fill = adjusted.get(shape_id)
+        if slot is None or fill is None or str(fill.get("action") or "text") != "text":
+            continue
+        text = str(fill.get("text") or "")
+        condensed = _condense_text_to_fit(slot=slot, fill=fill, result=result, text=text)
+        if condensed is None:
+            continue
+        next_fill = dict(fill)
+        next_fill["text"] = condensed
+        next_fill["font_size_override"] = result.min_font_pt
+        adjusted[shape_id] = next_fill
+    return adjusted
+
+
+def _condense_text_to_fit(
+    *,
+    slot: Mapping[str, Any],
+    fill: Mapping[str, Any],
+    result: BasicTextFitResult,
+    text: str,
+) -> str | None:
+    """단일 text slot 에 들어가는 가장 긴 prefix 후보를 찾는다."""
+    normalized = _normalize_fit_text(text)
+    if not normalized:
+        return normalized if _text_candidate_fits(slot, fill, result, normalized) else None
+    if _text_candidate_fits(slot, fill, result, normalized):
+        return normalized
+
+    for candidate in _dash_preserving_candidates(normalized):
+        if _text_candidate_fits(slot, fill, result, candidate):
+            return candidate
+
+    token_prefix = _longest_fitting_token_prefix(slot, fill, result, normalized)
+    if token_prefix:
+        return token_prefix
+    return _longest_fitting_char_prefix(slot, fill, result, normalized)
+
+
+def _normalize_fit_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+_DASH_SEPARATOR_PATTERN = re.compile("\\s+([-\\u2013\\u2014])\\s+")
+
+
+def _dash_preserving_candidates(text: str) -> list[str]:
+    """`경험명 - 역할` 형태는 양쪽 핵심을 남긴 후보를 우선 시도한다."""
+    match = _DASH_SEPARATOR_PATTERN.search(text)
+    if match is None:
+        return []
+
+    left_tokens = _text_tokens(text[: match.start()])
+    right_tokens = _text_tokens(text[match.end() :])
+    if not left_tokens or not right_tokens:
+        return []
+
+    separator = f" {match.group(1)} "
+    candidates: set[str] = set()
+    for left_count in range(len(left_tokens), 0, -1):
+        for right_count in range(len(right_tokens), 0, -1):
+            candidates.add(
+                f"{' '.join(left_tokens[:left_count])}"
+                f"{separator}"
+                f"{' '.join(right_tokens[:right_count])}"
+            )
+    return sorted(candidates, key=len, reverse=True)
+
+
+def _longest_fitting_token_prefix(
+    slot: Mapping[str, Any],
+    fill: Mapping[str, Any],
+    result: BasicTextFitResult,
+    text: str,
+) -> str | None:
+    tokens = _text_tokens(text)
+    if not tokens:
+        return None
+
+    best: str | None = None
+    low = 1
+    high = len(tokens)
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = _clean_condensed_text(" ".join(tokens[:mid]))
+        if candidate and _text_candidate_fits(slot, fill, result, candidate):
+            best = candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    return best
+
+
+def _longest_fitting_char_prefix(
+    slot: Mapping[str, Any],
+    fill: Mapping[str, Any],
+    result: BasicTextFitResult,
+    text: str,
+) -> str | None:
+    best: str | None = None
+    low = 1
+    high = len(text)
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = _clean_condensed_text(text[:mid])
+        if candidate and _text_candidate_fits(slot, fill, result, candidate):
+            best = candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    return best
+
+
+def _text_candidate_fits(
+    slot: Mapping[str, Any],
+    fill: Mapping[str, Any],
+    result: BasicTextFitResult,
+    text: str,
+) -> bool:
+    candidate_fill = dict(fill)
+    candidate_fill["text"] = text
+    candidate_fill["font_size_override"] = result.min_font_pt
+    return not evaluate_basic_text_area_fit(slot=slot, fill=candidate_fill).is_blocking
+
+
+def _text_tokens(text: str) -> list[str]:
+    return [token for token in _normalize_fit_text(text).split(" ") if token]
+
+
+def _clean_condensed_text(text: str) -> str:
+    return text.strip().rstrip(" -\u2013\u2014").strip()
 
 
 async def _apply_preflighted_fills(

--- a/features/visualization/agents/generation.py
+++ b/features/visualization/agents/generation.py
@@ -58,6 +58,7 @@ _FIT_RETRY_SYSTEM_PROMPT = """PPTX text-fit preflight 실패를 복구하는 편
 - 실패한 text slot 은 반드시 더 짧게 다시 작성하세요.
 - nowrap=true 또는 max_lines=1 slot 은 줄바꿈 없이 한 줄 문구로 작성하세요.
 - reason 이 nowrap_width_overflow, width_overflow, height_overflow 이면 핵심 명사, 수치, 기술 스택만 남기세요.
+- fit_issues.max_recommended_char_count 가 있으면 해당 글자 수 이하로 줄이세요.
 - 고유명사, 수치, 기술 스택, 성과 지표를 우선 보존하고 설명형 수식어를 제거하세요.
 - action, chart data, remove 결정은 current_fills 의 의도를 유지하세요.
 - layout_actions, 좌표, geometry, XML, 임의 필드를 만들지 마세요.

--- a/tests/test_features/test_visualization/test_generation_agents.py
+++ b/tests/test_features/test_visualization/test_generation_agents.py
@@ -392,6 +392,7 @@ def test_content_fill_generator_revises_fills_with_fit_issue_payload() -> None:
     system_prompt = llm.messages[0][0].content
     prompt_payload = _last_fill_prompt_payload(llm)
     assert "text-fit preflight 실패" in system_prompt
+    assert "max_recommended_char_count" in system_prompt
     assert "current_fills" in prompt_payload
     assert prompt_payload["current_fills"]["26"]["text"].startswith("이커머스")
     assert prompt_payload["fit_issues"][0]["reason"] == "nowrap_width_overflow"

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -703,13 +703,18 @@ async def test_text_fit_summarize_needed_retries_with_shorter_fills() -> None:
     assert retry_call["fit_issues"][0]["shape_id"] == "2"
     assert retry_call["fit_issues"][0]["status"] == "summarize_needed"
     assert retry_call["fit_issues"][0]["reason"] in {"nowrap_width_overflow", "width_overflow"}
+    assert retry_call["fit_issues"][0]["max_recommended_char_count"] < len(
+        "OpenAI API OpenAI API OpenAI API"
+    )
     slide3_fills = [fills for path, fills in editor.applied if path.endswith("slide3.xml")][0]
     assert slide3_fills["2"]["text"] == "AI 상담"
 
 
 @pytest.mark.asyncio
-async def test_text_fit_retry_failure_keeps_original_overflow_error() -> None:
-    """짧게 재요청한 fill 도 실패하면 원래 overflow 오류로 콘텐츠 실패를 전송한다."""
+async def test_text_fit_retry_failure_uses_deterministic_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """짧게 재요청한 fill 도 실패하면 측정 기반 축약으로 콘텐츠 생성을 복구한다."""
     editor = FakeEditor(
         slots=[
             {
@@ -751,15 +756,69 @@ async def test_text_fit_retry_failure_keeps_original_overflow_error() -> None:
     )
     context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
 
+    with caplog.at_level(logging.INFO, logger="features.visualization.generation_pipeline"):
+        await context.service.generate(_task())
+
+    error_events = _events(context.main_client, "slide_content_error")
+    assert error_events == []
+    assert context.main_client.job_events[-1]["summary"] == {"completed": 7, "failed": 0}
+    assert len(filler.revise_calls) == 1
+    slide3_fills = [fills for path, fills in editor.applied if path.endswith("slide3.xml")][0]
+    assert len(slide3_fills["2"]["text"]) < len("여전히 너무 긴 OpenAI API 상담 서비스 설명 문구")
+    assert slide3_fills["2"]["font_size_override"] == 10
+    assert "slide content fit deterministic fallback succeeded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_text_fit_deterministic_fallback_preserves_dash_role_pair() -> None:
+    """경험명-역할 형태는 fallback 축약 시 하이픈 양쪽 핵심을 우선 보존한다."""
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "min_font_pt": 10,
+                "kind": "text",
+                "fit_policy": "basic_text_area",
+                "w_emu": int(120 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+                "max_lines": 1,
+                "nowrap": True,
+            }
+        ]
+    )
+    filler = FakeFillGenerator(
+        responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "이커머스 고객센터 AI 상담 서비스 구축 프로젝트 - 백엔드 리드",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        },
+        revise_responses={
+            3: [
+                {
+                    "2": {
+                        "action": "text",
+                        "text": "이커머스 고객센터 AI 상담 서비스 구축 프로젝트 - 백엔드 리드",
+                        "font_size_override": 12,
+                    }
+                }
+            ]
+        },
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+
     await context.service.generate(_task())
 
     error_events = _events(context.main_client, "slide_content_error")
-    assert len(error_events) == 1
-    assert error_events[0]["slide_order"] == 3
-    assert "summarize_needed" in error_events[0]["message"]
-    assert len(filler.revise_calls) == 1
-    assert len(context.editor.cleared) == 1
-    assert context.main_client.job_events[-1]["summary"] == {"completed": 6, "failed": 1}
+    assert error_events == []
+    slide3_fills = [fills for path, fills in editor.applied if path.endswith("slide3.xml")][0]
+    assert slide3_fills["2"]["text"] == "이커머스 - 백엔드"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a deterministic text-fit fallback when LLM retry still returns oversized PPTX fills
- include max_recommended_char_count in fit retry payload/prompt
- preserve dash-separated experience-role text where possible during fallback condensation

## Tests
- uv run pytest tests/test_pptx_worker/test_visualization/test_generation_pipeline.py tests/test_features/test_visualization/test_generation_agents.py -q
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 슬라이드 텍스트 박스 오버플로우 처리 개선. AI 기반 재시도가 실패할 때, 결정론적 축약을 통해 텍스트를 자동으로 단축합니다.
  * 텍스트 생성 시 권장 글자 수 상한을 고려하여 더 안정적인 결과를 제공합니다.

* **Tests**
  * 개선된 텍스트 처리 로직에 대한 테스트 추가 및 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->