### PR TITLE
[Feat] PPTX 텍스트 박스 확장 영역 분석

### DIFF
--- a/features/visualization/templates/pptx.py
+++ b/features/visualization/templates/pptx.py
@@ -43,6 +43,11 @@ _INLINE_LABEL_GROUP_MAX_GAP_HEIGHT_RATIO = 2.0
 _INLINE_LABEL_GROUP_MAX_GAP_WIDTH_RATIO = 0.75
 _INLINE_LABEL_GROUP_MAX_GAP_VARIANCE_RATIO = 3.0
 _INLINE_LABEL_GROUP_MIN_BACKGROUND_ITEMS = 2
+_TEXT_BOX_EXPANSION_SLIDE_MARGIN_RATIO = 0.04
+_TEXT_BOX_EXPANSION_OBSTACLE_GAP_RATIO = 0.01
+_TEXT_BOX_EXPANSION_MIN_EXTRA_RATIO = 0.03
+_TEXT_BOX_EXPANSION_MIN_GROW_RATIO = 1.2
+_TEXT_BOX_EXPANSION_AXIS_OVERLAP_RATIO = 0.2
 
 
 @dataclass(frozen=True)
@@ -130,6 +135,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
     slide_names = _ordered_slide_part_names(source)
     slide_size = _slide_size_emu(source)
     slide_width_emu = slide_size[0] if slide_size is not None else None
+    slide_height_emu = slide_size[1] if slide_size is not None else None
     runtime_slides: list[dict] = []
     slide_pairs: list[dict] = []
     shape_matches: list[dict] = []
@@ -179,6 +185,7 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
                 raise ValueError(f"PPTX 슬라이드 XML을 찾을 수 없습니다: {slide_name}") from exc
 
             root = _parse_xml(slide_xml, f"{source}:{slide_name}")
+            shape_geometries = _extract_shape_geometries_from_slide(root)
             marker_result = _extract_marker_slots_from_slide(
                 root,
                 slide_index=slide_position,
@@ -189,7 +196,11 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
             errors.extend(marker_result.errors)
             inferred_shapes, shape_warnings = _infer_runtime_shape_relationships(
                 marker_result.slots,
-                _extract_non_text_shapes_from_slide(root),
+                tuple(
+                    shape
+                    for shape in shape_geometries
+                    if not _shape_geometry_has_visible_text(root, shape.shape_id)
+                ),
                 runtime_slide_number=slide_number,
             )
             shape_inferences.extend(inferred_shapes)
@@ -202,6 +213,17 @@ def extract_template_v2_from_pptx(pptx_path: Path | str) -> TemplateV2Extraction
             )
             layout_groups.extend(inferred_groups)
             warnings.extend(group_warnings)
+            shape_inferences.extend(
+                _infer_text_box_expansions(
+                    marker_result.slots,
+                    shape_geometries,
+                    inferred_shapes,
+                    inferred_groups,
+                    runtime_slide_number=slide_number,
+                    slide_width_emu=slide_width_emu,
+                    slide_height_emu=slide_height_emu,
+                )
+            )
             if not marker_result.slots and not marker_result.has_marker_candidate:
                 errors.append(
                     f"runtime slide {slide_number}에 정확한 #FF0000 editable marker가 없습니다."
@@ -546,6 +568,26 @@ def _extract_non_text_shapes_from_slide(
         if geometry is not None:
             shapes.append(geometry)
     return tuple(shapes)
+
+
+def _extract_shape_geometries_from_slide(
+    slide_root: Element,
+) -> tuple[_RuntimeShapeGeometry, ...]:
+    shapes: list[_RuntimeShapeGeometry] = []
+    for shape in slide_root.findall(f".//{{{_PRESENTATION_NS}}}sp"):
+        geometry = _runtime_shape_geometry_from_shape(shape)
+        if geometry is not None:
+            shapes.append(geometry)
+    return tuple(shapes)
+
+
+def _shape_geometry_has_visible_text(slide_root: Element, shape_id: str) -> bool:
+    if not shape_id:
+        return False
+    for shape in slide_root.findall(f".//{{{_PRESENTATION_NS}}}sp"):
+        if _shape_id(shape) == shape_id:
+            return _shape_has_visible_text(shape)
+    return False
 
 
 def _shape_has_visible_text(shape: Element) -> bool:
@@ -1108,6 +1150,351 @@ def _inline_label_backgrounds_are_confident(
     if linked_count < _INLINE_LABEL_GROUP_MIN_BACKGROUND_ITEMS:
         return False
     return linked_count == item_count
+
+
+def _infer_text_box_expansions(
+    slots: tuple[dict, ...],
+    shape_geometries: tuple[_RuntimeShapeGeometry, ...],
+    shape_inferences: list[dict],
+    layout_groups: list[dict],
+    *,
+    runtime_slide_number: int,
+    slide_width_emu: int | None,
+    slide_height_emu: int | None,
+) -> list[dict]:
+    """일반 text slot 이 사용할 수 있는 확장 가능 영역을 보수적으로 추론한다."""
+    if slide_width_emu is None or slide_height_emu is None:
+        return []
+
+    excluded_slot_ids = _text_box_expansion_excluded_slot_ids(
+        slots,
+        shape_inferences,
+        layout_groups,
+    )
+    containers_by_slot_id = _text_box_expansion_containers_by_slot_id(shape_inferences)
+    inferences: list[dict] = []
+    for slot in slots:
+        slot_id = str(slot.get("slot_id") or "").strip()
+        if not slot_id or slot_id in excluded_slot_ids:
+            continue
+        inference = _text_box_expansion_for_slot(
+            slot,
+            shape_geometries,
+            runtime_slide_number=runtime_slide_number,
+            slide_width_emu=slide_width_emu,
+            slide_height_emu=slide_height_emu,
+            container_shape=containers_by_slot_id.get(slot_id),
+        )
+        if inference is not None:
+            inferences.append(inference)
+    return inferences
+
+
+def _text_box_expansion_excluded_slot_ids(
+    slots: tuple[dict, ...],
+    shape_inferences: list[dict],
+    layout_groups: list[dict],
+) -> set[str]:
+    excluded: set[str] = set()
+    for row in _cluster_inline_label_rows(
+        tuple(slot for slot in slots if _inline_label_slot_candidate(slot))
+    ):
+        excluded.update(str(slot.get("slot_id")) for slot in row if slot.get("slot_id"))
+
+    for group in layout_groups:
+        if group.get("layout_type") != "inline_label_group":
+            continue
+        excluded.update(str(slot_id) for slot_id in group.get("item_slot_ids") or ())
+
+    for inference in shape_inferences:
+        inference_type = inference.get("inference_type")
+        if inference_type == "item_background" and inference.get("resize_linked") is True:
+            slot_id = str(inference.get("slot_id") or "").strip()
+            if slot_id:
+                excluded.add(slot_id)
+        elif inference_type == "ambiguous_item_background":
+            excluded.update(str(slot_id) for slot_id in inference.get("candidate_slot_ids") or ())
+    return excluded
+
+
+def _text_box_expansion_containers_by_slot_id(
+    shape_inferences: list[dict],
+) -> dict[str, dict]:
+    containers_by_slot_id: dict[str, dict] = {}
+    for inference in shape_inferences:
+        if inference.get("inference_type") != "container_shape":
+            continue
+        container_slot_ids = inference.get("contained_slot_ids")
+        if not isinstance(container_slot_ids, list):
+            continue
+        for slot_id in container_slot_ids:
+            normalized_slot_id = str(slot_id or "").strip()
+            if normalized_slot_id and normalized_slot_id not in containers_by_slot_id:
+                containers_by_slot_id[normalized_slot_id] = inference
+    return containers_by_slot_id
+
+
+def _text_box_expansion_for_slot(
+    slot: dict,
+    shape_geometries: tuple[_RuntimeShapeGeometry, ...],
+    *,
+    runtime_slide_number: int,
+    slide_width_emu: int,
+    slide_height_emu: int,
+    container_shape: dict | None,
+) -> dict | None:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return None
+
+    slot_x, slot_y, slot_w, slot_h = slot_box
+    if min(slot_w, slot_h) <= 0:
+        return None
+
+    directions: list[str] = []
+    right_bound = _expansion_bound_right(
+        slot,
+        shape_geometries,
+        slide_width_emu=slide_width_emu,
+        container_shape=container_shape,
+    )
+    max_w_emu = slot_w
+    right_bound_emu: int | None = None
+    right_bound_source: str | None = None
+    right_blocked_by_shape_id: str | None = None
+    if right_bound is not None and _expansion_is_meaningful(
+        original_size=slot_w,
+        candidate_size=right_bound["bound_emu"] - slot_x,
+        slide_size_emu=slide_width_emu,
+    ):
+        directions.append("right")
+        right_bound_emu = right_bound["bound_emu"]
+        right_bound_source = right_bound["source"]
+        right_blocked_by_shape_id = right_bound.get("blocked_by_shape_id")
+        max_w_emu = right_bound_emu - slot_x
+
+    max_h_emu = slot_h
+    bottom_bound_emu: int | None = None
+    bottom_bound_source: str | None = None
+    bottom_blocked_by_shape_id: str | None = None
+    if _slot_can_expand_down(slot):
+        bottom_bound = _expansion_bound_down(
+            slot,
+            shape_geometries,
+            slide_height_emu=slide_height_emu,
+            container_shape=container_shape,
+        )
+        if bottom_bound is not None and _expansion_is_meaningful(
+            original_size=slot_h,
+            candidate_size=bottom_bound["bound_emu"] - slot_y,
+            slide_size_emu=slide_height_emu,
+        ):
+            directions.append("down")
+            bottom_bound_emu = bottom_bound["bound_emu"]
+            bottom_bound_source = bottom_bound["source"]
+            bottom_blocked_by_shape_id = bottom_bound.get("blocked_by_shape_id")
+            max_h_emu = bottom_bound_emu - slot_y
+
+    if not directions:
+        return None
+
+    inference = {
+        "inference_type": "text_box_expansion",
+        "runtime_slide_index": slot.get("slide_index"),
+        "runtime_slide_number": runtime_slide_number,
+        "slot_id": slot.get("slot_id"),
+        "slot_shape_id": slot.get("shape_id"),
+        "anchor": "left_top",
+        "directions": directions,
+        "x_emu": slot_x,
+        "y_emu": slot_y,
+        "w_emu": slot_w,
+        "h_emu": slot_h,
+        "max_w_emu": max_w_emu,
+        "max_h_emu": max_h_emu,
+        "confidence": _text_box_expansion_confidence(
+            width_growth_ratio=max_w_emu / slot_w,
+            height_growth_ratio=max_h_emu / slot_h,
+            blocked=right_blocked_by_shape_id is not None or bottom_blocked_by_shape_id is not None,
+        ),
+    }
+    if container_shape is not None:
+        inference["container_shape_id"] = container_shape.get("shape_id")
+    if right_bound_emu is not None:
+        inference["right_bound_emu"] = right_bound_emu
+        inference["right_bound_source"] = right_bound_source
+        if right_blocked_by_shape_id is not None:
+            inference["right_blocked_by_shape_id"] = right_blocked_by_shape_id
+    if bottom_bound_emu is not None:
+        inference["bottom_bound_emu"] = bottom_bound_emu
+        inference["bottom_bound_source"] = bottom_bound_source
+        if bottom_blocked_by_shape_id is not None:
+            inference["bottom_blocked_by_shape_id"] = bottom_blocked_by_shape_id
+    return inference
+
+
+def _expansion_bound_right(
+    slot: dict,
+    shape_geometries: tuple[_RuntimeShapeGeometry, ...],
+    *,
+    slide_width_emu: int,
+    container_shape: dict | None,
+) -> dict[str, int | str] | None:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return None
+
+    slot_x, slot_y, slot_w, slot_h = slot_box
+    margin = _slide_margin_emu(slide_width_emu)
+    gap = _obstacle_gap_emu(slide_width_emu)
+    bound = slide_width_emu - margin
+    source = "slide_margin"
+    blocked_by_shape_id: str | None = None
+    if container_shape is not None:
+        container_x = _positive_int(container_shape.get("x_emu"))
+        container_w = _positive_int(container_shape.get("w_emu"))
+        if container_x is not None and container_w is not None:
+            bound = container_x + container_w - gap
+            source = "container_shape"
+            blocked_by_shape_id = str(container_shape.get("shape_id") or "").strip() or None
+    for shape in shape_geometries:
+        if shape.shape_id == str(slot.get("shape_id") or ""):
+            continue
+        if container_shape is not None and shape.shape_id == str(
+            container_shape.get("shape_id") or ""
+        ):
+            continue
+        obstacle_box = _shape_bbox(shape)
+        if _shape_is_container_for_slot(slot_box, obstacle_box):
+            continue
+        obstacle_x, obstacle_y, _obstacle_w, obstacle_h = obstacle_box
+        if obstacle_x < slot_x + slot_w:
+            continue
+        if _axis_overlap(slot_y, slot_h, obstacle_y, obstacle_h) < (
+            min(slot_h, obstacle_h) * _TEXT_BOX_EXPANSION_AXIS_OVERLAP_RATIO
+        ):
+            continue
+        candidate_bound = obstacle_x - gap
+        if candidate_bound < bound:
+            bound = candidate_bound
+            source = "shape"
+            blocked_by_shape_id = shape.shape_id
+
+    if bound <= slot_x + slot_w:
+        return None
+    result: dict[str, int | str] = {"bound_emu": bound, "source": source}
+    if blocked_by_shape_id is not None:
+        result["blocked_by_shape_id"] = blocked_by_shape_id
+    return result
+
+
+def _expansion_bound_down(
+    slot: dict,
+    shape_geometries: tuple[_RuntimeShapeGeometry, ...],
+    *,
+    slide_height_emu: int,
+    container_shape: dict | None,
+) -> dict[str, int | str] | None:
+    slot_box = _bbox_tuple(slot)
+    if slot_box is None:
+        return None
+
+    slot_x, slot_y, slot_w, slot_h = slot_box
+    margin = _slide_margin_emu(slide_height_emu)
+    gap = _obstacle_gap_emu(slide_height_emu)
+    bound = slide_height_emu - margin
+    source = "slide_margin"
+    blocked_by_shape_id: str | None = None
+    if container_shape is not None:
+        container_y = _positive_int(container_shape.get("y_emu"))
+        container_h = _positive_int(container_shape.get("h_emu"))
+        if container_y is not None and container_h is not None:
+            bound = container_y + container_h - gap
+            source = "container_shape"
+            blocked_by_shape_id = str(container_shape.get("shape_id") or "").strip() or None
+    for shape in shape_geometries:
+        if shape.shape_id == str(slot.get("shape_id") or ""):
+            continue
+        if container_shape is not None and shape.shape_id == str(
+            container_shape.get("shape_id") or ""
+        ):
+            continue
+        obstacle_box = _shape_bbox(shape)
+        if _shape_is_container_for_slot(slot_box, obstacle_box):
+            continue
+        obstacle_x, obstacle_y, obstacle_w, _obstacle_h = obstacle_box
+        if obstacle_y < slot_y + slot_h:
+            continue
+        if _axis_overlap(slot_x, slot_w, obstacle_x, obstacle_w) < (
+            min(slot_w, obstacle_w) * _TEXT_BOX_EXPANSION_AXIS_OVERLAP_RATIO
+        ):
+            continue
+        candidate_bound = obstacle_y - gap
+        if candidate_bound < bound:
+            bound = candidate_bound
+            source = "shape"
+            blocked_by_shape_id = shape.shape_id
+
+    if bound <= slot_y + slot_h:
+        return None
+    result: dict[str, int | str] = {"bound_emu": bound, "source": source}
+    if blocked_by_shape_id is not None:
+        result["blocked_by_shape_id"] = blocked_by_shape_id
+    return result
+
+
+def _shape_is_container_for_slot(
+    slot_box: tuple[int, int, int, int],
+    obstacle_box: tuple[int, int, int, int],
+) -> bool:
+    return _box_coverage(slot_box, obstacle_box) >= _CONTAINER_MIN_SLOT_COVERAGE
+
+
+def _slot_can_expand_down(slot: dict) -> bool:
+    placeholder_text = str(slot.get("placeholder_text") or "")
+    return len(placeholder_text.splitlines()) > 1
+
+
+def _expansion_is_meaningful(
+    *,
+    original_size: int,
+    candidate_size: int,
+    slide_size_emu: int,
+) -> bool:
+    if original_size <= 0 or candidate_size <= original_size:
+        return False
+    min_extra = max(1, int(slide_size_emu * _TEXT_BOX_EXPANSION_MIN_EXTRA_RATIO))
+    return (
+        candidate_size - original_size >= min_extra
+        and candidate_size / original_size >= _TEXT_BOX_EXPANSION_MIN_GROW_RATIO
+    )
+
+
+def _slide_margin_emu(slide_size_emu: int) -> int:
+    return max(1, int(slide_size_emu * _TEXT_BOX_EXPANSION_SLIDE_MARGIN_RATIO))
+
+
+def _obstacle_gap_emu(slide_size_emu: int) -> int:
+    return max(1, int(slide_size_emu * _TEXT_BOX_EXPANSION_OBSTACLE_GAP_RATIO))
+
+
+def _axis_overlap(left_start: int, left_size: int, right_start: int, right_size: int) -> int:
+    return max(
+        0, min(left_start + left_size, right_start + right_size) - max(left_start, right_start)
+    )
+
+
+def _text_box_expansion_confidence(
+    *,
+    width_growth_ratio: float,
+    height_growth_ratio: float,
+    blocked: bool,
+) -> float:
+    growth_ratio = max(width_growth_ratio, height_growth_ratio)
+    confidence = 0.68 + min(growth_ratio - 1.0, 1.0) * 0.2
+    if not blocked:
+        confidence += 0.05
+    return round(min(confidence, 0.93), 4)
 
 
 def _median_int(values: list[int]) -> int:

--- a/features/visualization/templates/v2.py
+++ b/features/visualization/templates/v2.py
@@ -168,12 +168,14 @@ def _enrich_slot_descriptors(
 ) -> list[dict[str, Any]]:
     matches_by_slot_id = _shape_matches_by_slot_id(shape_matches)
     item_backgrounds_by_slot_id = _item_backgrounds_by_slot_id(shape_inferences)
+    text_box_expansions_by_slot_id = _text_box_expansions_by_slot_id(shape_inferences)
     layout_groups_by_slot_id = _layout_groups_by_slot_id(slots, layout_groups)
     return [
         _enrich_slot_descriptor(
             slot,
             matches_by_slot_id.get(str(slot.get("slot_id"))),
             item_backgrounds_by_slot_id.get(str(slot.get("slot_id"))),
+            text_box_expansions_by_slot_id.get(str(slot.get("slot_id"))),
             layout_groups_by_slot_id.get(str(slot.get("slot_id"))),
         )
         for slot in slots
@@ -214,6 +216,27 @@ def _item_backgrounds_by_slot_id(
         for slot_id, candidates in candidates_by_slot_id.items()
         if len(candidates) == 1
     }
+
+
+def _text_box_expansions_by_slot_id(
+    shape_inferences: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    expansions_by_slot_id: dict[str, Mapping[str, Any]] = {}
+    for inference in shape_inferences:
+        if not isinstance(inference, Mapping):
+            continue
+        if inference.get("inference_type") != "text_box_expansion":
+            continue
+        if not _valid_text_box_expansion(inference):
+            continue
+        slot_id = inference.get("slot_id")
+        if slot_id is None:
+            continue
+        normalized_slot_id = str(slot_id)
+        if normalized_slot_id in expansions_by_slot_id:
+            continue
+        expansions_by_slot_id[normalized_slot_id] = inference
+    return expansions_by_slot_id
 
 
 def _layout_groups_by_slot_id(
@@ -280,6 +303,30 @@ def _valid_item_background_inference(inference: Mapping[str, Any]) -> bool:
     return width is not None and height is not None and width > 0 and height > 0
 
 
+def _valid_text_box_expansion(inference: Mapping[str, Any]) -> bool:
+    if str(inference.get("anchor") or "") != "left_top":
+        return False
+    directions = _string_sequence(inference.get("directions"))
+    if not directions or not set(directions).issubset({"right", "down"}):
+        return False
+    max_w_emu = _json_number(inference.get("max_w_emu"))
+    max_h_emu = _json_number(inference.get("max_h_emu"))
+    width = _json_number(inference.get("w_emu"))
+    height = _json_number(inference.get("h_emu"))
+    confidence = _json_number(inference.get("confidence"))
+    if None in (max_w_emu, max_h_emu, width, height, confidence):
+        return False
+    if (
+        max_w_emu is None
+        or max_h_emu is None
+        or width is None
+        or height is None
+        or confidence is None
+    ):
+        return False
+    return max_w_emu >= width > 0 and max_h_emu >= height > 0 and confidence > 0
+
+
 _ITEM_BACKGROUND_FIELDS = (
     "runtime_slide_index",
     "runtime_slide_number",
@@ -295,6 +342,7 @@ def _enrich_slot_descriptor(
     slot: Mapping[str, Any],
     shape_match: Mapping[str, Any] | None,
     item_background: Mapping[str, Any] | None,
+    text_box_expansion: Mapping[str, Any] | None,
     layout_group: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     enriched = dict(slot)
@@ -305,6 +353,8 @@ def _enrich_slot_descriptor(
                     enriched[field_name] = shape_match[field_name]
         if item_background is not None:
             enriched["item_background"] = _slot_item_background(item_background)
+        if text_box_expansion is not None:
+            enriched["text_box_policy"] = _slot_text_box_policy(text_box_expansion)
         if layout_group is not None:
             _apply_layout_group_slot_metadata(enriched, layout_group)
         _apply_text_capacity_defaults(enriched)
@@ -353,6 +403,17 @@ def _slot_item_background(item_background: Mapping[str, Any]) -> dict[str, Any]:
         "h_emu": item_background.get("h_emu"),
         "match_score": item_background.get("match_score"),
         "resize_linked": item_background.get("resize_linked") is True,
+    }
+
+
+def _slot_text_box_policy(text_box_expansion: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "mode": "expandable",
+        "anchor": text_box_expansion.get("anchor"),
+        "directions": list(_string_sequence(text_box_expansion.get("directions"))),
+        "max_w_emu": text_box_expansion.get("max_w_emu"),
+        "max_h_emu": text_box_expansion.get("max_h_emu"),
+        "confidence": text_box_expansion.get("confidence"),
     }
 
 

--- a/features/visualization/templates/validation.py
+++ b/features/visualization/templates/validation.py
@@ -32,6 +32,7 @@ _REFERENCE_MATCH_FRESH_FIELDS = (
 _MIN_EDITABLE_SLOT_WIDTH_PT = 24.0
 _MIN_EDITABLE_SLOT_HEIGHT_PT = 10.0
 _MIN_LINKED_BACKGROUND_MATCH_SCORE = 0.72
+_TEXT_BOX_POLICY_DIRECTIONS = {"right", "down"}
 _PLACEHOLDER_RESIDUE_MARKERS = (
     "여기에",
     "placeholder",
@@ -364,7 +365,57 @@ def _validate_v2_editable_slot_quality(
     warnings: list[str],
 ) -> None:
     _validate_v2_editable_slot_size(slot, label, strict, errors, warnings)
+    _validate_v2_text_box_policy(slot, label, errors)
     _validate_v2_placeholder_residue(slot, label, strict, errors, warnings)
+
+
+def _validate_v2_text_box_policy(
+    slot: dict[str, Any],
+    label: str,
+    errors: list[str],
+) -> None:
+    policy = slot.get("text_box_policy")
+    if policy is None:
+        return
+    if not isinstance(policy, dict):
+        errors.append(f"{label}.text_box_policy 필드는 객체여야 합니다.")
+        return
+
+    if policy.get("mode") != "expandable":
+        errors.append(f"{label}.text_box_policy.mode은 expandable 이어야 합니다.")
+    if policy.get("anchor") != "left_top":
+        errors.append(f"{label}.text_box_policy.anchor는 left_top 이어야 합니다.")
+
+    directions = _string_list(policy.get("directions"))
+    if not directions:
+        errors.append(f"{label}.text_box_policy.directions 필드는 비어 있을 수 없습니다.")
+    elif not set(directions).issubset(_TEXT_BOX_POLICY_DIRECTIONS):
+        errors.append(
+            f"{label}.text_box_policy.directions는 right/down 만 허용합니다. "
+            f"현재 값: {directions!r}"
+        )
+
+    max_w_emu = _numeric_emu(policy.get("max_w_emu"))
+    max_h_emu = _numeric_emu(policy.get("max_h_emu"))
+    width_emu = _numeric_emu(slot.get("w_emu"))
+    height_emu = _numeric_emu(slot.get("h_emu"))
+    if max_w_emu is None or max_w_emu <= 0:
+        errors.append(f"{label}.text_box_policy.max_w_emu는 양수여야 합니다.")
+    if max_h_emu is None or max_h_emu <= 0:
+        errors.append(f"{label}.text_box_policy.max_h_emu는 양수여야 합니다.")
+    if width_emu is not None and max_w_emu is not None and max_w_emu < width_emu:
+        errors.append(f"{label}.text_box_policy.max_w_emu가 slot w_emu보다 작습니다.")
+    if height_emu is not None and max_h_emu is not None and max_h_emu < height_emu:
+        errors.append(f"{label}.text_box_policy.max_h_emu가 slot h_emu보다 작습니다.")
+
+    confidence = policy.get("confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, int | float)
+        or confidence <= 0
+        or confidence > 1
+    ):
+        errors.append(f"{label}.text_box_policy.confidence는 0 초과 1 이하 숫자여야 합니다.")
 
 
 def _validate_v2_editable_slot_size(

--- a/templates/ppt-v3/meta.json
+++ b/templates/ppt-v3/meta.json
@@ -128,6 +128,16 @@
       "slide_number": 2,
       "slide_part": "ppt/slides/slide2.xml",
       "slot_id": "slide2_shape3",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 784830,
+        "max_w_emu": 10427974,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "shape",
       "w_emu": 4352929,
       "x_emu": 1276346,
@@ -161,6 +171,16 @@
       "slide_number": 2,
       "slide_part": "ppt/slides/slide2.xml",
       "slot_id": "slide2_shape5",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427972,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 2543178,
       "x_emu": 1276348,
@@ -194,6 +214,16 @@
       "slide_number": 2,
       "slide_part": "ppt/slides/slide2.xml",
       "slot_id": "slide2_shape8",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427974,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3667127,
       "x_emu": 1276346,
@@ -227,6 +257,16 @@
       "slide_number": 2,
       "slide_part": "ppt/slides/slide2.xml",
       "slot_id": "slide2_shape9",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427974,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 2257429,
       "x_emu": 1276346,
@@ -356,6 +396,16 @@
       "slide_number": 4,
       "slide_part": "ppt/slides/slide4.xml",
       "slot_id": "slide4_shape3",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 784830,
+        "max_w_emu": 10427974,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "shape",
       "w_emu": 4352929,
       "x_emu": 1276346,
@@ -389,6 +439,16 @@
       "slide_number": 4,
       "slide_part": "ppt/slides/slide4.xml",
       "slot_id": "slide4_shape5",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427972,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 2543178,
       "x_emu": 1276348,
@@ -422,6 +482,16 @@
       "slide_number": 6,
       "slide_part": "ppt/slides/slide6.xml",
       "slot_id": "slide6_shape7",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -454,6 +524,16 @@
       "slide_number": 6,
       "slide_part": "ppt/slides/slide6.xml",
       "slot_id": "slide6_shape17",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7835,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 7126499,
       "y_emu": 3130909
@@ -486,6 +566,16 @@
       "slide_number": 6,
       "slide_part": "ppt/slides/slide6.xml",
       "slot_id": "slide6_shape5",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7354,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3588069,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 7802774,
       "y_emu": 2525367
@@ -518,6 +608,16 @@
       "slide_number": 6,
       "slide_part": "ppt/slides/slide6.xml",
       "slot_id": "slide6_shape4",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.8051,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 5961593,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3667127,
       "x_emu": 819150,
@@ -547,6 +647,16 @@
       "slide_number": 6,
       "slide_part": "ppt/slides/slide6.xml",
       "slot_id": "slide6_shape8",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 5961593,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 2257429,
       "x_emu": 819150,
@@ -676,6 +786,16 @@
       "slide_number": 8,
       "slide_part": "ppt/slides/slide8.xml",
       "slot_id": "slide8_shape7",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -708,6 +828,16 @@
       "slide_number": 8,
       "slide_part": "ppt/slides/slide8.xml",
       "slot_id": "slide8_shape17",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7835,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1042986,
       "y_emu": 3986628
@@ -772,6 +902,16 @@
       "slide_number": 8,
       "slide_part": "ppt/slides/slide8.xml",
       "slot_id": "slide8_shape5",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7354,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3588069,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1719261,
       "y_emu": 3381086
@@ -804,6 +944,16 @@
       "slide_number": 10,
       "slide_part": "ppt/slides/slide10.xml",
       "slot_id": "slide10_shape21",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7731,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2909889,
       "x_emu": 1042986,
       "y_emu": 4873351
@@ -868,6 +1018,16 @@
       "slide_number": 10,
       "slide_part": "ppt/slides/slide10.xml",
       "slot_id": "slide10_shape2",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7403,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3656445,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1650885,
       "y_emu": 4218163
@@ -900,6 +1060,16 @@
       "slide_number": 10,
       "slide_part": "ppt/slides/slide10.xml",
       "slot_id": "slide10_shape3",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -932,6 +1102,16 @@
       "slide_number": 12,
       "slide_part": "ppt/slides/slide12.xml",
       "slot_id": "slide12_shape21",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7731,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2909889,
       "x_emu": 1042986,
       "y_emu": 4873351
@@ -964,6 +1144,16 @@
       "slide_number": 12,
       "slide_part": "ppt/slides/slide12.xml",
       "slot_id": "slide12_shape2",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7403,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3656445,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1650885,
       "y_emu": 4218163
@@ -996,6 +1186,16 @@
       "slide_number": 12,
       "slide_part": "ppt/slides/slide12.xml",
       "slot_id": "slide12_shape3",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -1028,6 +1228,16 @@
       "slide_number": 12,
       "slide_part": "ppt/slides/slide12.xml",
       "slot_id": "slide12_shape4",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7731,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2909889,
       "x_emu": 6986586,
       "y_emu": 4873351
@@ -1060,6 +1270,16 @@
       "slide_number": 12,
       "slide_part": "ppt/slides/slide12.xml",
       "slot_id": "slide12_shape7",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7403,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3656445,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 7594485,
       "y_emu": 4218163
@@ -1092,6 +1312,16 @@
       "slide_number": 14,
       "slide_part": "ppt/slides/slide14.xml",
       "slot_id": "slide14_shape12",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7354,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3588069,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1719261,
       "y_emu": 4762211
@@ -1124,6 +1354,16 @@
       "slide_number": 14,
       "slide_part": "ppt/slides/slide14.xml",
       "slot_id": "slide14_shape17",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7835,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1042986,
       "y_emu": 5367753
@@ -1188,6 +1428,16 @@
       "slide_number": 14,
       "slide_part": "ppt/slides/slide14.xml",
       "slot_id": "slide14_shape8",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7354,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3588069,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 4691061,
       "y_emu": 2605672
@@ -1220,6 +1470,16 @@
       "slide_number": 14,
       "slide_part": "ppt/slides/slide14.xml",
       "slot_id": "slide14_shape9",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7835,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 4014786,
       "y_emu": 3211214
@@ -1252,6 +1512,16 @@
       "slide_number": 14,
       "slide_part": "ppt/slides/slide14.xml",
       "slot_id": "slide14_shape14",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -1284,6 +1554,16 @@
       "slide_number": 16,
       "slide_part": "ppt/slides/slide16.xml",
       "slot_id": "slide16_shape12",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7354,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3588069,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1719261,
       "y_emu": 4762211
@@ -1316,6 +1596,16 @@
       "slide_number": 16,
       "slide_part": "ppt/slides/slide16.xml",
       "slot_id": "slide16_shape17",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7835,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1042986,
       "y_emu": 5367753
@@ -1380,6 +1670,16 @@
       "slide_number": 16,
       "slide_part": "ppt/slides/slide16.xml",
       "slot_id": "slide16_shape14",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -1412,6 +1712,16 @@
       "slide_number": 16,
       "slide_part": "ppt/slides/slide16.xml",
       "slot_id": "slide16_shape2",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7354,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 477054,
+        "max_w_emu": 3588069,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1719261,
       "y_emu": 2597508
@@ -1444,6 +1754,16 @@
       "slide_number": 16,
       "slide_part": "ppt/slides/slide16.xml",
       "slot_id": "slide16_shape3",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7835,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 4264344,
+        "mode": "expandable"
+      },
       "w_emu": 2809878,
       "x_emu": 1042986,
       "y_emu": 3203050
@@ -1508,6 +1828,16 @@
       "slide_number": 18,
       "slide_part": "ppt/slides/slide18.xml",
       "slot_id": "slide18_shape14",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 400110,
+        "max_w_emu": 6384609,
+        "mode": "expandable"
+      },
       "w_emu": 2462213,
       "x_emu": 5319711,
       "y_emu": 2662653
@@ -1540,6 +1870,16 @@
       "slide_number": 18,
       "slide_part": "ppt/slides/slide18.xml",
       "slot_id": "slide18_shape15",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 276999,
+        "max_w_emu": 6384609,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 1414464,
       "x_emu": 5319711,
@@ -1573,6 +1913,16 @@
       "slide_number": 18,
       "slide_part": "ppt/slides/slide18.xml",
       "slot_id": "slide18_shape16",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 276999,
+        "max_w_emu": 6384609,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 1414464,
       "x_emu": 5319711,
@@ -1606,6 +1956,16 @@
       "slide_number": 18,
       "slide_part": "ppt/slides/slide18.xml",
       "slot_id": "slide18_shape21",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -1634,6 +1994,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape15",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 276999,
+        "max_w_emu": 4697730,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 1414464,
       "x_emu": 1009650,
@@ -1663,6 +2033,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape16",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 276999,
+        "max_w_emu": 4697730,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 1414464,
       "x_emu": 1009650,
@@ -1692,6 +2072,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape19",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 276999,
+        "max_w_emu": 4697730,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 1414464,
       "x_emu": 6553203,
@@ -1721,6 +2111,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape20",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 276999,
+        "max_w_emu": 4697730,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 1414464,
       "x_emu": 6553203,
@@ -1754,6 +2154,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape22",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.819,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 400110,
+        "max_w_emu": 4697730,
+        "mode": "expandable"
+      },
       "w_emu": 2771775,
       "x_emu": 1009650,
       "y_emu": 3560605
@@ -1786,6 +2196,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape24",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.8178,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 400110,
+        "max_w_emu": 4697730,
+        "mode": "expandable"
+      },
       "w_emu": 2781297,
       "x_emu": 6553203,
       "y_emu": 3560605
@@ -1818,6 +2238,16 @@
       "slide_number": 20,
       "slide_part": "ppt/slides/slide20.xml",
       "slot_id": "slide20_shape27",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -1948,6 +2378,16 @@
       "slide_number": 22,
       "slide_part": "ppt/slides/slide22.xml",
       "slot_id": "slide22_shape27",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -2172,6 +2612,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape18",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.8276,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 4459605,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 2565800,
       "x_emu": 1009651,
@@ -2205,6 +2655,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape25",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.8176,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 4459606,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 2642001,
       "x_emu": 1009650,
@@ -2238,6 +2698,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape27",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7211,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 4459604,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3699276,
       "x_emu": 6791326,
@@ -2300,6 +2770,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape33",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 10241279,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3717470,
       "x_emu": 1009651,
@@ -2333,6 +2813,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape34",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 10241280,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3774621,
       "x_emu": 1009650,
@@ -2366,6 +2856,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape37",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 400110,
+        "max_w_emu": 10885170,
+        "mode": "expandable"
+      },
       "w_emu": 2977243,
       "x_emu": 819150,
       "y_emu": 1949494
@@ -2398,6 +2898,16 @@
       "slide_number": 24,
       "slide_part": "ppt/slides/slide24.xml",
       "slot_id": "slide24_shape41",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -2430,6 +2940,16 @@
       "slide_number": 26,
       "slide_part": "ppt/slides/slide26.xml",
       "slot_id": "slide26_shape41",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -2660,6 +3180,16 @@
       "slide_number": 28,
       "slide_part": "ppt/slides/slide28.xml",
       "slot_id": "slide28_shape41",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -2758,6 +3288,16 @@
       "slide_number": 28,
       "slide_part": "ppt/slides/slide28.xml",
       "slot_id": "slide28_shape14",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7272,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 336631,
+        "max_w_emu": 4746035,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3839254,
       "x_emu": 6504898,
@@ -2791,6 +3331,16 @@
       "slide_number": 28,
       "slide_part": "ppt/slides/slide28.xml",
       "slot_id": "slide28_shape19",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7272,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 336631,
+        "max_w_emu": 4746036,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3839254,
       "x_emu": 6504897,
@@ -2824,6 +3374,16 @@
       "slide_number": 28,
       "slide_part": "ppt/slides/slide28.xml",
       "slot_id": "slide28_shape42",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7909,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 10207948,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 6566129,
       "x_emu": 1042985,
@@ -2857,6 +3417,16 @@
       "slide_number": 28,
       "slide_part": "ppt/slides/slide28.xml",
       "slot_id": "slide28_shape43",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7909,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 10207948,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 6566129,
       "x_emu": 1042985,
@@ -2890,6 +3460,16 @@
       "slide_number": 30,
       "slide_part": "ppt/slides/slide30.xml",
       "slot_id": "slide30_shape41",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -2988,6 +3568,16 @@
       "slide_number": 30,
       "slide_part": "ppt/slides/slide30.xml",
       "slot_id": "slide30_shape14",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7272,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 336631,
+        "max_w_emu": 4746035,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3839254,
       "x_emu": 6504898,
@@ -3021,6 +3611,16 @@
       "slide_number": 30,
       "slide_part": "ppt/slides/slide30.xml",
       "slot_id": "slide30_shape19",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7272,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 336631,
+        "max_w_emu": 4746036,
+        "mode": "expandable"
+      },
       "text_replacement_mode": "marker_runs",
       "w_emu": 3839254,
       "x_emu": 6504897,
@@ -3054,6 +3654,16 @@
       "slide_number": 32,
       "slide_part": "ppt/slides/slide32.xml",
       "slot_id": "slide32_shape41",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.93,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 323165,
+        "max_w_emu": 10427973,
+        "mode": "expandable"
+      },
       "w_emu": 707233,
       "x_emu": 1276347,
       "y_emu": 647699
@@ -3086,6 +3696,16 @@
       "slide_number": 32,
       "slide_part": "ppt/slides/slide32.xml",
       "slot_id": "slide32_shape42",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7774,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 9763483,
+        "mode": "expandable"
+      },
       "w_emu": 6566129,
       "x_emu": 1487448,
       "y_emu": 2881085
@@ -3118,6 +3738,16 @@
       "slide_number": 32,
       "slide_part": "ppt/slides/slide32.xml",
       "slot_id": "slide32_shape43",
+      "text_box_policy": {
+        "anchor": "left_top",
+        "confidence": 0.7774,
+        "directions": [
+          "right"
+        ],
+        "max_h_emu": 337400,
+        "max_w_emu": 9763483,
+        "mode": "expandable"
+      },
       "w_emu": 6566129,
       "x_emu": 1487448,
       "y_emu": 3349652

--- a/templates/ppt-v3/reference.json
+++ b/templates/ppt-v3/reference.json
@@ -2,6 +2,126 @@
   "schema_version": 2,
   "shape_inferences": [
     {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 784830,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 784830,
+      "max_w_emu": 10427974,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 1,
+      "runtime_slide_number": 2,
+      "slot_id": "slide2_shape3",
+      "slot_shape_id": "3",
+      "w_emu": 4352929,
+      "x_emu": 1276346,
+      "y_emu": 838200
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427972,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 1,
+      "runtime_slide_number": 2,
+      "slot_id": "slide2_shape5",
+      "slot_shape_id": "5",
+      "w_emu": 2543178,
+      "x_emu": 1276348,
+      "y_emu": 2173220
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427974,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 1,
+      "runtime_slide_number": 2,
+      "slot_id": "slide2_shape8",
+      "slot_shape_id": "8",
+      "w_emu": 3667127,
+      "x_emu": 1276346,
+      "y_emu": 2659758
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427974,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 1,
+      "runtime_slide_number": 2,
+      "slot_id": "slide2_shape9",
+      "slot_shape_id": "9",
+      "w_emu": 2257429,
+      "x_emu": 1276346,
+      "y_emu": 3146296
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 784830,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 784830,
+      "max_w_emu": 10427974,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 3,
+      "runtime_slide_number": 4,
+      "slot_id": "slide4_shape3",
+      "slot_shape_id": "3",
+      "w_emu": 4352929,
+      "x_emu": 1276346,
+      "y_emu": 2184637
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427972,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 3,
+      "runtime_slide_number": 4,
+      "slot_id": "slide4_shape5",
+      "slot_shape_id": "5",
+      "w_emu": 2543178,
+      "x_emu": 1276348,
+      "y_emu": 3519657
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide6_shape5",
@@ -18,6 +138,112 @@
       "w_emu": 4610100,
       "x_emu": 6902663,
       "y_emu": 2110440
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 5,
+      "runtime_slide_number": 6,
+      "slot_id": "slide6_shape7",
+      "slot_shape_id": "7",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7835,
+      "container_shape_id": "22",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 11390843,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 5,
+      "runtime_slide_number": 6,
+      "slot_id": "slide6_shape17",
+      "slot_shape_id": "17",
+      "w_emu": 2809878,
+      "x_emu": 7126499,
+      "y_emu": 3130909
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7354,
+      "container_shape_id": "22",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3588069,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 11390843,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 5,
+      "runtime_slide_number": 6,
+      "slot_id": "slide6_shape5",
+      "slot_shape_id": "5",
+      "w_emu": 2809878,
+      "x_emu": 7802774,
+      "y_emu": 2525367
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.8051,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 5961593,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 6780743,
+      "right_bound_source": "shape",
+      "runtime_slide_index": 5,
+      "runtime_slide_number": 6,
+      "slot_id": "slide6_shape4",
+      "slot_shape_id": "4",
+      "w_emu": 3667127,
+      "x_emu": 819150,
+      "y_emu": 2114510
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 5961593,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 6780743,
+      "right_bound_source": "shape",
+      "runtime_slide_index": 5,
+      "runtime_slide_number": 6,
+      "slot_id": "slide6_shape8",
+      "slot_shape_id": "8",
+      "w_emu": 2257429,
+      "x_emu": 819150,
+      "y_emu": 2601048
     },
     {
       "allowed_actions": [],
@@ -38,6 +264,70 @@
       "y_emu": 2966159
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 7,
+      "runtime_slide_number": 8,
+      "slot_id": "slide8_shape7",
+      "slot_shape_id": "7",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7835,
+      "container_shape_id": "25",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "25",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 7,
+      "runtime_slide_number": 8,
+      "slot_id": "slide8_shape17",
+      "slot_shape_id": "17",
+      "w_emu": 2809878,
+      "x_emu": 1042986,
+      "y_emu": 3986628
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7354,
+      "container_shape_id": "25",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3588069,
+      "right_blocked_by_shape_id": "25",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 7,
+      "runtime_slide_number": 8,
+      "slot_id": "slide8_shape5",
+      "slot_shape_id": "5",
+      "w_emu": 2809878,
+      "x_emu": 1719261,
+      "y_emu": 3381086
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide10_shape2",
@@ -54,6 +344,70 @@
       "w_emu": 4610100,
       "x_emu": 819150,
       "y_emu": 2183264
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7731,
+      "container_shape_id": "24",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "24",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 9,
+      "runtime_slide_number": 10,
+      "slot_id": "slide10_shape21",
+      "slot_shape_id": "21",
+      "w_emu": 2909889,
+      "x_emu": 1042986,
+      "y_emu": 4873351
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7403,
+      "container_shape_id": "24",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3656445,
+      "right_blocked_by_shape_id": "24",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 9,
+      "runtime_slide_number": 10,
+      "slot_id": "slide10_shape2",
+      "slot_shape_id": "2",
+      "w_emu": 2809878,
+      "x_emu": 1650885,
+      "y_emu": 4218163
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 9,
+      "runtime_slide_number": 10,
+      "slot_id": "slide10_shape3",
+      "slot_shape_id": "3",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
     },
     {
       "allowed_actions": [],
@@ -92,6 +446,114 @@
       "y_emu": 2183264
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.7731,
+      "container_shape_id": "24",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "24",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 11,
+      "runtime_slide_number": 12,
+      "slot_id": "slide12_shape21",
+      "slot_shape_id": "21",
+      "w_emu": 2909889,
+      "x_emu": 1042986,
+      "y_emu": 4873351
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7403,
+      "container_shape_id": "24",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3656445,
+      "right_blocked_by_shape_id": "24",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 11,
+      "runtime_slide_number": 12,
+      "slot_id": "slide12_shape2",
+      "slot_shape_id": "2",
+      "w_emu": 2809878,
+      "x_emu": 1650885,
+      "y_emu": 4218163
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 11,
+      "runtime_slide_number": 12,
+      "slot_id": "slide12_shape3",
+      "slot_shape_id": "3",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7731,
+      "container_shape_id": "5",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "5",
+      "right_bound_emu": 11250930,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 11,
+      "runtime_slide_number": 12,
+      "slot_id": "slide12_shape4",
+      "slot_shape_id": "4",
+      "w_emu": 2909889,
+      "x_emu": 6986586,
+      "y_emu": 4873351
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7403,
+      "container_shape_id": "5",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3656445,
+      "right_blocked_by_shape_id": "5",
+      "right_bound_emu": 11250930,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 11,
+      "runtime_slide_number": 12,
+      "slot_id": "slide12_shape7",
+      "slot_shape_id": "7",
+      "w_emu": 2809878,
+      "x_emu": 7594485,
+      "y_emu": 4218163
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide14_shape12",
@@ -126,6 +588,114 @@
       "w_emu": 4610100,
       "x_emu": 3790950,
       "y_emu": 2190745
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7354,
+      "container_shape_id": "25",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3588069,
+      "right_blocked_by_shape_id": "25",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 13,
+      "runtime_slide_number": 14,
+      "slot_id": "slide14_shape12",
+      "slot_shape_id": "12",
+      "w_emu": 2809878,
+      "x_emu": 1719261,
+      "y_emu": 4762211
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7835,
+      "container_shape_id": "25",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "25",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 13,
+      "runtime_slide_number": 14,
+      "slot_id": "slide14_shape17",
+      "slot_shape_id": "17",
+      "w_emu": 2809878,
+      "x_emu": 1042986,
+      "y_emu": 5367753
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7354,
+      "container_shape_id": "10",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3588069,
+      "right_blocked_by_shape_id": "10",
+      "right_bound_emu": 8279130,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 13,
+      "runtime_slide_number": 14,
+      "slot_id": "slide14_shape8",
+      "slot_shape_id": "8",
+      "w_emu": 2809878,
+      "x_emu": 4691061,
+      "y_emu": 2605672
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7835,
+      "container_shape_id": "10",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "10",
+      "right_bound_emu": 8279130,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 13,
+      "runtime_slide_number": 14,
+      "slot_id": "slide14_shape9",
+      "slot_shape_id": "9",
+      "w_emu": 2809878,
+      "x_emu": 4014786,
+      "y_emu": 3211214
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 13,
+      "runtime_slide_number": 14,
+      "slot_id": "slide14_shape14",
+      "slot_shape_id": "14",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
     },
     {
       "allowed_actions": [],
@@ -164,6 +734,194 @@
       "y_emu": 2182581
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.7354,
+      "container_shape_id": "25",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3588069,
+      "right_blocked_by_shape_id": "25",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 15,
+      "runtime_slide_number": 16,
+      "slot_id": "slide16_shape12",
+      "slot_shape_id": "12",
+      "w_emu": 2809878,
+      "x_emu": 1719261,
+      "y_emu": 4762211
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7835,
+      "container_shape_id": "25",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "25",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 15,
+      "runtime_slide_number": 16,
+      "slot_id": "slide16_shape17",
+      "slot_shape_id": "17",
+      "w_emu": 2809878,
+      "x_emu": 1042986,
+      "y_emu": 5367753
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 15,
+      "runtime_slide_number": 16,
+      "slot_id": "slide16_shape14",
+      "slot_shape_id": "14",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7354,
+      "container_shape_id": "4",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 477054,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 477054,
+      "max_w_emu": 3588069,
+      "right_blocked_by_shape_id": "4",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 15,
+      "runtime_slide_number": 16,
+      "slot_id": "slide16_shape2",
+      "slot_shape_id": "2",
+      "w_emu": 2809878,
+      "x_emu": 1719261,
+      "y_emu": 2597508
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7835,
+      "container_shape_id": "4",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 4264344,
+      "right_blocked_by_shape_id": "4",
+      "right_bound_emu": 5307330,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 15,
+      "runtime_slide_number": 16,
+      "slot_id": "slide16_shape3",
+      "slot_shape_id": "3",
+      "w_emu": 2809878,
+      "x_emu": 1042986,
+      "y_emu": 3203050
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 400110,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 400110,
+      "max_w_emu": 6384609,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 17,
+      "runtime_slide_number": 18,
+      "slot_id": "slide18_shape14",
+      "slot_shape_id": "14",
+      "w_emu": 2462213,
+      "x_emu": 5319711,
+      "y_emu": 2662653
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 276999,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 276999,
+      "max_w_emu": 6384609,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 17,
+      "runtime_slide_number": 18,
+      "slot_id": "slide18_shape15",
+      "slot_shape_id": "15",
+      "w_emu": 1414464,
+      "x_emu": 5319711,
+      "y_emu": 3179215
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 276999,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 276999,
+      "max_w_emu": 6384609,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 17,
+      "runtime_slide_number": 18,
+      "slot_id": "slide18_shape16",
+      "slot_shape_id": "16",
+      "w_emu": 1414464,
+      "x_emu": 5319711,
+      "y_emu": 3510075
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 17,
+      "runtime_slide_number": 18,
+      "slot_id": "slide18_shape21",
+      "slot_shape_id": "21",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide20_shape22",
@@ -200,6 +958,158 @@
       "w_emu": 5010151,
       "x_emu": 6362702,
       "y_emu": 1982556
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "container_shape_id": "5",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 276999,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 276999,
+      "max_w_emu": 4697730,
+      "right_blocked_by_shape_id": "5",
+      "right_bound_emu": 5707380,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape15",
+      "slot_shape_id": "15",
+      "w_emu": 1414464,
+      "x_emu": 1009650,
+      "y_emu": 4255486
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "container_shape_id": "5",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 276999,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 276999,
+      "max_w_emu": 4697730,
+      "right_blocked_by_shape_id": "5",
+      "right_bound_emu": 5707380,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape16",
+      "slot_shape_id": "16",
+      "w_emu": 1414464,
+      "x_emu": 1009650,
+      "y_emu": 4566884
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "container_shape_id": "12",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 276999,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 276999,
+      "max_w_emu": 4697730,
+      "right_blocked_by_shape_id": "12",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape19",
+      "slot_shape_id": "19",
+      "w_emu": 1414464,
+      "x_emu": 6553203,
+      "y_emu": 4255486
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "container_shape_id": "12",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 276999,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 276999,
+      "max_w_emu": 4697730,
+      "right_blocked_by_shape_id": "12",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape20",
+      "slot_shape_id": "20",
+      "w_emu": 1414464,
+      "x_emu": 6553203,
+      "y_emu": 4566884
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.819,
+      "container_shape_id": "5",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 400110,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 400110,
+      "max_w_emu": 4697730,
+      "right_blocked_by_shape_id": "5",
+      "right_bound_emu": 5707380,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape22",
+      "slot_shape_id": "22",
+      "w_emu": 2771775,
+      "x_emu": 1009650,
+      "y_emu": 3560605
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.8178,
+      "container_shape_id": "12",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 400110,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 400110,
+      "max_w_emu": 4697730,
+      "right_blocked_by_shape_id": "12",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape24",
+      "slot_shape_id": "24",
+      "w_emu": 2781297,
+      "x_emu": 6553203,
+      "y_emu": 3560605
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 19,
+      "runtime_slide_number": 20,
+      "slot_id": "slide20_shape27",
+      "slot_shape_id": "27",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
     },
     {
       "allowed_actions": [],
@@ -259,6 +1169,26 @@
       "y_emu": 1982559
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 21,
+      "runtime_slide_number": 22,
+      "slot_id": "slide22_shape27",
+      "slot_shape_id": "27",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide24_shape18",
@@ -311,6 +1241,156 @@
       "w_emu": 10553700,
       "x_emu": 819150,
       "y_emu": 4517314
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.8276,
+      "container_shape_id": "8",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 4459605,
+      "right_blocked_by_shape_id": "8",
+      "right_bound_emu": 5469256,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape18",
+      "slot_shape_id": "18",
+      "w_emu": 2565800,
+      "x_emu": 1009651,
+      "y_emu": 3158989
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.8176,
+      "container_shape_id": "8",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 4459606,
+      "right_blocked_by_shape_id": "8",
+      "right_bound_emu": 5469256,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape25",
+      "slot_shape_id": "25",
+      "w_emu": 2642001,
+      "x_emu": 1009650,
+      "y_emu": 3483642
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7211,
+      "container_shape_id": "13",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 4459604,
+      "right_blocked_by_shape_id": "13",
+      "right_bound_emu": 11250930,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape27",
+      "slot_shape_id": "27",
+      "w_emu": 3699276,
+      "x_emu": 6791326,
+      "y_emu": 3158989
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "container_shape_id": "29",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 10241279,
+      "right_blocked_by_shape_id": "29",
+      "right_bound_emu": 11250930,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape33",
+      "slot_shape_id": "33",
+      "w_emu": 3717470,
+      "x_emu": 1009651,
+      "y_emu": 5089082
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.88,
+      "container_shape_id": "29",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 10241280,
+      "right_blocked_by_shape_id": "29",
+      "right_bound_emu": 11250930,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape34",
+      "slot_shape_id": "34",
+      "w_emu": 3774621,
+      "x_emu": 1009650,
+      "y_emu": 5434428
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 400110,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 400110,
+      "max_w_emu": 10885170,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape37",
+      "slot_shape_id": "37",
+      "w_emu": 2977243,
+      "x_emu": 819150,
+      "y_emu": 1949494
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 23,
+      "runtime_slide_number": 24,
+      "slot_id": "slide24_shape41",
+      "slot_shape_id": "41",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
     },
     {
       "allowed_actions": [],
@@ -367,6 +1447,26 @@
       "y_emu": 2011137
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 25,
+      "runtime_slide_number": 26,
+      "slot_id": "slide26_shape41",
+      "slot_shape_id": "41",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide28_shape3",
@@ -421,6 +1521,114 @@
       "y_emu": 3908892
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 27,
+      "runtime_slide_number": 28,
+      "slot_id": "slide28_shape41",
+      "slot_shape_id": "41",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7272,
+      "container_shape_id": "15",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 336631,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 336631,
+      "max_w_emu": 4746035,
+      "right_blocked_by_shape_id": "15",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 27,
+      "runtime_slide_number": 28,
+      "slot_id": "slide28_shape14",
+      "slot_shape_id": "14",
+      "w_emu": 3839254,
+      "x_emu": 6504898,
+      "y_emu": 2614167
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7272,
+      "container_shape_id": "15",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 336631,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 336631,
+      "max_w_emu": 4746036,
+      "right_blocked_by_shape_id": "15",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 27,
+      "runtime_slide_number": 28,
+      "slot_id": "slide28_shape19",
+      "slot_shape_id": "19",
+      "w_emu": 3839254,
+      "x_emu": 6504897,
+      "y_emu": 2945412
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7909,
+      "container_shape_id": "22",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 10207948,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 27,
+      "runtime_slide_number": 28,
+      "slot_id": "slide28_shape42",
+      "slot_shape_id": "42",
+      "w_emu": 6566129,
+      "x_emu": 1042985,
+      "y_emu": 4480186
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7909,
+      "container_shape_id": "22",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 10207948,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 27,
+      "runtime_slide_number": 28,
+      "slot_id": "slide28_shape43",
+      "slot_shape_id": "43",
+      "w_emu": 6566129,
+      "x_emu": 1042985,
+      "y_emu": 4817586
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide30_shape3",
@@ -457,6 +1665,70 @@
       "y_emu": 2175897
     },
     {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 29,
+      "runtime_slide_number": 30,
+      "slot_id": "slide30_shape41",
+      "slot_shape_id": "41",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7272,
+      "container_shape_id": "15",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 336631,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 336631,
+      "max_w_emu": 4746035,
+      "right_blocked_by_shape_id": "15",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 29,
+      "runtime_slide_number": 30,
+      "slot_id": "slide30_shape14",
+      "slot_shape_id": "14",
+      "w_emu": 3839254,
+      "x_emu": 6504898,
+      "y_emu": 2778927
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7272,
+      "container_shape_id": "15",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 336631,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 336631,
+      "max_w_emu": 4746036,
+      "right_blocked_by_shape_id": "15",
+      "right_bound_emu": 11250933,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 29,
+      "runtime_slide_number": 30,
+      "slot_id": "slide30_shape19",
+      "slot_shape_id": "19",
+      "w_emu": 3839254,
+      "x_emu": 6504897,
+      "y_emu": 3110172
+    },
+    {
       "allowed_actions": [],
       "contained_slot_ids": [
         "slide32_shape42",
@@ -473,6 +1745,70 @@
       "w_emu": 10553704,
       "x_emu": 819147,
       "y_emu": 2175897
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.93,
+      "directions": [
+        "right"
+      ],
+      "h_emu": 323165,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 323165,
+      "max_w_emu": 10427973,
+      "right_bound_emu": 11704320,
+      "right_bound_source": "slide_margin",
+      "runtime_slide_index": 31,
+      "runtime_slide_number": 32,
+      "slot_id": "slide32_shape41",
+      "slot_shape_id": "41",
+      "w_emu": 707233,
+      "x_emu": 1276347,
+      "y_emu": 647699
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7774,
+      "container_shape_id": "22",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 9763483,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 11250931,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 31,
+      "runtime_slide_number": 32,
+      "slot_id": "slide32_shape42",
+      "slot_shape_id": "42",
+      "w_emu": 6566129,
+      "x_emu": 1487448,
+      "y_emu": 2881085
+    },
+    {
+      "anchor": "left_top",
+      "confidence": 0.7774,
+      "container_shape_id": "22",
+      "directions": [
+        "right"
+      ],
+      "h_emu": 337400,
+      "inference_type": "text_box_expansion",
+      "max_h_emu": 337400,
+      "max_w_emu": 9763483,
+      "right_blocked_by_shape_id": "22",
+      "right_bound_emu": 11250931,
+      "right_bound_source": "container_shape",
+      "runtime_slide_index": 31,
+      "runtime_slide_number": 32,
+      "slot_id": "slide32_shape43",
+      "slot_shape_id": "43",
+      "w_emu": 6566129,
+      "x_emu": 1487448,
+      "y_emu": 3349652
     }
   ],
   "shape_matches": [

--- a/tests/test_features/test_visualization/test_template_v2_compiler.py
+++ b/tests/test_features/test_visualization/test_template_v2_compiler.py
@@ -200,6 +200,59 @@ def test_v2_payload_writer_enriches_item_background_and_keeps_container_referenc
     assert payloads.reference["shape_inferences"][1]["allowed_actions"] == []
 
 
+def test_v2_payload_writer_enriches_text_box_policy_from_expansion_inference() -> None:
+    """text_box_expansion 추론은 slot의 확장 가능 영역 계약으로 승격된다."""
+    payloads = build_template_v2_payloads(
+        "ppt-v3",
+        extraction=TemplateV2Extraction(
+            slots=(
+                {
+                    "slot_id": "slide2_shape3",
+                    "shape_id": "3",
+                    "kind": "text",
+                    "editable": True,
+                    "required": True,
+                    "placeholder_text": "경험명 - 본인 역할",
+                    "marker_color": "#FF0000",
+                    "x_emu": 100,
+                    "y_emu": 200,
+                    "w_emu": 300,
+                    "h_emu": 100,
+                },
+            ),
+            shape_inferences=(
+                {
+                    "inference_type": "text_box_expansion",
+                    "slot_id": "slide2_shape3",
+                    "slot_shape_id": "3",
+                    "runtime_slide_index": 1,
+                    "runtime_slide_number": 2,
+                    "anchor": "left_top",
+                    "directions": ["right"],
+                    "x_emu": 100,
+                    "y_emu": 200,
+                    "w_emu": 300,
+                    "h_emu": 100,
+                    "max_w_emu": 1180,
+                    "max_h_emu": 100,
+                    "confidence": 0.88,
+                },
+            ),
+        ),
+    )
+
+    slot = payloads.metadata["slots"][0]
+    assert slot["text_box_policy"] == {
+        "mode": "expandable",
+        "anchor": "left_top",
+        "directions": ["right"],
+        "max_w_emu": 1180,
+        "max_h_emu": 100,
+        "confidence": 0.88,
+    }
+    assert payloads.reference["shape_inferences"][0]["inference_type"] == "text_box_expansion"
+
+
 def test_v2_payload_writer_maps_layout_group_by_item_shape_ids() -> None:
     """layout group이 item_shape_ids만 제공해도 slot에 group metadata를 연결한다."""
     payloads = build_template_v2_payloads(
@@ -486,6 +539,14 @@ def test_compile_template_v2_extracts_only_exact_red_marker_slots(tmp_path: Path
         "slide_number": 2,
         "slide_part": "ppt/slides/slide2.xml",
         "slot_id": "slide2_shape10",
+        "text_box_policy": {
+            "anchor": "left_top",
+            "confidence": 0.93,
+            "directions": ["right"],
+            "max_h_emu": 400,
+            "max_w_emu": 1820,
+            "mode": "expandable",
+        },
         "w_emu": 300,
         "x_emu": 100,
         "y_emu": 200,
@@ -922,6 +983,97 @@ def test_compile_template_v2_links_origin_style_chip_item_backgrounds(
     assert {inference["shape_id"] for inference in item_inferences} == {"19", "21"}
 
 
+def test_compile_template_v2_infers_text_box_expansion_until_right_obstacle(
+    tmp_path: Path,
+) -> None:
+    """일반 text slot은 같은 행의 오른쪽 obstacle 전까지 확장 가능 영역을 기록한다."""
+    template_dir = _make_template_dir(
+        tmp_path,
+        "ppt-v3",
+        slide_xmls=(
+            _slide_xml(1, ""),
+            _slide_xml(
+                2,
+                "".join(
+                    (
+                        _shape_xml(
+                            3,
+                            "Title marker",
+                            (_run_xml("경험명 - 본인 역할", color="FF0000"),),
+                            x=100,
+                            y=200,
+                            width=300,
+                            height=100,
+                        ),
+                        _shape_without_text_xml(
+                            40,
+                            "Right visual",
+                            x=1300,
+                            y=160,
+                            width=200,
+                            height=200,
+                        ),
+                    )
+                ),
+            ),
+            _slide_xml(
+                3,
+                _shape_xml(
+                    30,
+                    "Title example",
+                    (_run_xml("AI 상담 서비스 - 백엔드 리드", color="123456"),),
+                    x=100,
+                    y=200,
+                    width=300,
+                    height=100,
+                ),
+            ),
+        ),
+    )
+
+    result = compile_template_v2(template_dir)
+
+    assert result.ok is True
+    metadata = read_json_payload(result.meta_path)
+    slot = metadata["slots"][0]
+    assert slot["text_box_policy"] == {
+        "anchor": "left_top",
+        "confidence": 0.88,
+        "directions": ["right"],
+        "max_h_emu": 100,
+        "max_w_emu": 1180,
+        "mode": "expandable",
+    }
+
+    reference = read_json_payload(result.reference_path)
+    expansion_inferences = [
+        inference
+        for inference in reference["shape_inferences"]
+        if inference["inference_type"] == "text_box_expansion"
+    ]
+    assert expansion_inferences == [
+        {
+            "anchor": "left_top",
+            "confidence": 0.88,
+            "directions": ["right"],
+            "h_emu": 100,
+            "inference_type": "text_box_expansion",
+            "max_h_emu": 100,
+            "max_w_emu": 1180,
+            "right_blocked_by_shape_id": "40",
+            "right_bound_emu": 1280,
+            "right_bound_source": "shape",
+            "runtime_slide_index": 1,
+            "runtime_slide_number": 2,
+            "slot_id": "slide2_shape3",
+            "slot_shape_id": "3",
+            "w_emu": 300,
+            "x_emu": 100,
+            "y_emu": 200,
+        }
+    ]
+
+
 def test_compile_template_v2_groups_origin_style_inline_label_chips(
     tmp_path: Path,
 ) -> None:
@@ -1054,7 +1206,14 @@ def test_compile_template_v2_groups_origin_style_inline_label_chips(
         assert slot["min_gap_emu"] == 50
         assert slot["row_left_emu"] == 100
         assert slot["row_right_bound_emu"] == 2000
+        assert "text_box_policy" not in slot
         assert "layout_type" not in slot
+
+    reference = read_json_payload(result.reference_path)
+    assert all(
+        inference["inference_type"] != "text_box_expansion"
+        for inference in reference["shape_inferences"]
+    )
 
 
 def test_compile_template_v2_records_inline_label_group_linked_backgrounds(
@@ -1426,7 +1585,12 @@ def test_compile_template_v2_records_large_card_as_container_shape(
     assert all("item_background" not in slot for slot in metadata["slots"])
 
     reference = read_json_payload(result.reference_path)
-    assert reference["shape_inferences"] == [
+    container_inferences = [
+        inference
+        for inference in reference["shape_inferences"]
+        if inference["inference_type"] == "container_shape"
+    ]
+    assert container_inferences == [
         {
             "allowed_actions": [],
             "contained_slot_ids": ["slide2_shape20", "slide2_shape21"],
@@ -1443,6 +1607,22 @@ def test_compile_template_v2_records_large_card_as_container_shape(
             "y_emu": 50,
         }
     ]
+    expansion_inferences = [
+        inference
+        for inference in reference["shape_inferences"]
+        if inference["inference_type"] == "text_box_expansion"
+    ]
+    assert {
+        inference["slot_id"]: (
+            inference["container_shape_id"],
+            inference["right_bound_source"],
+            inference["max_w_emu"],
+        )
+        for inference in expansion_inferences
+    } == {
+        "slide2_shape20": ("19", "container_shape", 430),
+        "slide2_shape21": ("19", "container_shape", 430),
+    }
 
 
 def test_compile_template_v2_ignores_slide_sized_background_as_container_shape(
@@ -1519,7 +1699,10 @@ def test_compile_template_v2_ignores_slide_sized_background_as_container_shape(
 
     assert result.ok is True
     reference = read_json_payload(result.reference_path)
-    assert reference["shape_inferences"] == []
+    assert all(
+        inference["inference_type"] != "container_shape"
+        for inference in reference["shape_inferences"]
+    )
 
 
 def test_compile_template_v2_warns_and_skips_ambiguous_item_background(


### PR DESCRIPTION
## 📌 관련 이슈

- Refs #274

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- v2 템플릿 compiler가 일반 editable text slot의 확장 가능 영역을 분석해 `reference.json.shape_inferences[]`에 `text_box_expansion` 근거를 기록하도록 했습니다.
- `build_template_v2_payloads()`가 검증된 `text_box_expansion` 추론을 `meta.json.slots[].text_box_policy`로 승격하도록 했습니다.
- `inline_label_group`/chip 후보, linked item background slot은 확장 대상에서 제외하고, container/card 내부 slot은 container 내부를 확장 한계로 사용하도록 보수적으로 처리했습니다.
- `validate_template.py`에 `text_box_policy` 최소 schema 검증을 추가했습니다.
- `templates/ppt-v3/meta.json`, `templates/ppt-v3/reference.json`을 재컴파일해 63개 확장 후보를 기록했습니다.

## 📸 스크린샷

- 템플릿 metadata/compiler 변경 PR이라 스크린샷은 없습니다.

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 검증

- `uv run python scripts/templates/compile_template.py templates/ppt-v3 --check`
- `uv run python scripts/templates/validate_template.py templates/ppt-v3`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` — 965 passed

## 📎 기타 참고사항

- 이번 PR은 템플릿 분석/metadata 산출까지만 포함합니다. 런타임에서 `text_box_policy`를 읽어 실제 `resize_shape` layout action을 적용하는 작업은 후속 단계입니다.
- `ppt-v3` compile/validate warning은 기존 reference color/inline label 후보 warning이며 이번 변경으로 새로 실패가 생긴 것은 아닙니다.