### PR TITLE
[Feat] PPTX 텍스트 박스 런타임 확장 적용

### DIFF
--- a/features/visualization/text_fit.py
+++ b/features/visualization/text_fit.py
@@ -175,6 +175,7 @@ class BasicTextFitResult:
     initial_layout: TextLayoutEstimate
     final_layout: TextLayoutEstimate
     constraints: TextBoxConstraints
+    layout_actions: tuple[dict[str, Any], ...] = ()
 
     @property
     def is_blocking(self) -> bool:
@@ -197,6 +198,8 @@ class BasicTextFitResult:
             "initial_layout": self.initial_layout.to_log_dict(),
             "final_layout": self.final_layout.to_log_dict(),
             "constraints": self.constraints.to_log_dict(),
+            "layout_action_count": len(self.layout_actions),
+            "layout_actions": list(self.layout_actions),
         }
 
 
@@ -425,23 +428,6 @@ def evaluate_basic_text_area_fit(
     effective_font = max(original_font, min_font)
     measurement = measure_text_width(text, font_size_pt=effective_font)
 
-    if constraints.content_width_pt <= 0 or constraints.content_height_pt <= 0:
-        layout = estimate_text_layout(text, font_size_pt=effective_font, constraints=constraints)
-        return BasicTextFitResult(
-            shape_id=shape_id,
-            status="failed",
-            reason=_first_reason(layout, "invalid_text_box"),
-            original_font_pt=_round_pt(original_font),
-            applied_font_pt=_round_pt(effective_font),
-            min_font_pt=min_font,
-            max_lines=constraints.max_lines,
-            nowrap=constraints.nowrap,
-            measurement=measurement,
-            initial_layout=layout,
-            final_layout=layout,
-            constraints=constraints,
-        )
-
     initial_layout = estimate_text_layout(
         text,
         font_size_pt=effective_font,
@@ -463,36 +449,67 @@ def evaluate_basic_text_area_fit(
             constraints=constraints,
         )
 
+    applied_slot = slot
+    applied_constraints = constraints
+    layout_actions: tuple[dict[str, Any], ...] = ()
+    expansion = _text_box_expansion_plan(slot)
+    if expansion is not None:
+        applied_slot, action = expansion
+        applied_constraints = _constraints_from_slot(applied_slot)
+        expanded_layout = estimate_text_layout(
+            text,
+            font_size_pt=effective_font,
+            constraints=applied_constraints,
+        )
+        layout_actions = (action,)
+        if expanded_layout.fits:
+            return BasicTextFitResult(
+                shape_id=shape_id,
+                status="fit",
+                reason="text_box_expanded",
+                original_font_pt=_round_pt(original_font),
+                applied_font_pt=_round_pt(effective_font),
+                min_font_pt=min_font,
+                max_lines=applied_constraints.max_lines,
+                nowrap=applied_constraints.nowrap,
+                measurement=measurement,
+                initial_layout=initial_layout,
+                final_layout=expanded_layout,
+                constraints=applied_constraints,
+                layout_actions=layout_actions,
+            )
+
     for candidate_font in _shrink_candidates(effective_font, min_font):
         candidate_layout = estimate_text_layout(
             text,
             font_size_pt=candidate_font,
-            constraints=constraints,
+            constraints=applied_constraints,
         )
         if candidate_layout.fits:
             return BasicTextFitResult(
                 shape_id=shape_id,
                 status="shrunk",
-                reason=None,
+                reason="text_box_expanded" if layout_actions else None,
                 original_font_pt=_round_pt(original_font),
                 applied_font_pt=_round_pt(candidate_font),
                 min_font_pt=min_font,
-                max_lines=constraints.max_lines,
-                nowrap=constraints.nowrap,
+                max_lines=applied_constraints.max_lines,
+                nowrap=applied_constraints.nowrap,
                 measurement=measurement,
                 initial_layout=initial_layout,
                 final_layout=candidate_layout,
-                constraints=constraints,
+                constraints=applied_constraints,
+                layout_actions=layout_actions,
             )
 
-    min_layout = estimate_text_layout(text, font_size_pt=min_font, constraints=constraints)
+    min_layout = estimate_text_layout(text, font_size_pt=min_font, constraints=applied_constraints)
     status: TextFitStatus = "summarize_needed"
     reason = _first_reason(min_layout, "text_overflow")
     if "content_width_too_small" in min_layout.overflow_reasons:
         status = "failed"
     elif "content_height_too_small" in min_layout.overflow_reasons:
         status = "failed"
-    elif min_font * LINE_HEIGHT_MULTIPLIER > constraints.available_height_pt:
+    elif min_font * LINE_HEIGHT_MULTIPLIER > applied_constraints.available_height_pt:
         status = "failed"
         reason = "min_font_height_overflow"
 
@@ -503,12 +520,13 @@ def evaluate_basic_text_area_fit(
         original_font_pt=_round_pt(original_font),
         applied_font_pt=min_font,
         min_font_pt=min_font,
-        max_lines=constraints.max_lines,
-        nowrap=constraints.nowrap,
+        max_lines=applied_constraints.max_lines,
+        nowrap=applied_constraints.nowrap,
         measurement=measurement,
         initial_layout=initial_layout,
         final_layout=min_layout,
-        constraints=constraints,
+        constraints=applied_constraints,
+        layout_actions=layout_actions,
     )
 
 
@@ -659,6 +677,7 @@ def apply_text_fit_preflight(
         if result.is_blocking:
             blocking.append(result)
             continue
+        layout_actions.extend(result.layout_actions)
         if _should_apply_font_override(fill, result):
             fill["font_size_override"] = result.applied_font_pt
 
@@ -1186,6 +1205,49 @@ def _fallback_max_lines(slot: Mapping[str, Any]) -> int:
         if isinstance(value, str) and value:
             return max(1, len(value.splitlines()))
     return 1
+
+
+def _text_box_expansion_plan(
+    slot: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    policy = slot.get("text_box_policy")
+    if not isinstance(policy, Mapping):
+        return None
+    if str(policy.get("mode") or "").strip().casefold() != "expandable":
+        return None
+    if str(policy.get("anchor") or "").strip().casefold() != "left_top":
+        return None
+
+    shape_id = str(slot.get("shape_id") or "").strip()
+    directions = _text_box_policy_directions(policy.get("directions"))
+    current_w = _positive_int(slot.get("w_emu"))
+    current_h = _positive_int(slot.get("h_emu"))
+    max_w = _positive_int(policy.get("max_w_emu"))
+    max_h = _positive_int(policy.get("max_h_emu"))
+    updates: dict[str, int] = {}
+    if shape_id and "right" in directions and current_w is not None and max_w is not None:
+        if max_w > current_w:
+            updates["w_emu"] = max_w
+    if shape_id and "down" in directions and current_h is not None and max_h is not None:
+        if max_h > current_h:
+            updates["h_emu"] = max_h
+    if not updates:
+        return None
+
+    expanded_slot = dict(slot)
+    expanded_slot.update(updates)
+    return expanded_slot, {"action": "resize_shape", "shape_id": shape_id, **updates}
+
+
+def _text_box_policy_directions(value: Any) -> set[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return set()
+    directions: set[str] = set()
+    for item in value:
+        direction = str(item or "").strip().casefold()
+        if direction in {"right", "down"}:
+            directions.add(direction)
+    return directions
 
 
 def _shrink_candidates(original_font: float, min_font: float) -> tuple[float, ...]:

--- a/tests/test_features/test_visualization/test_text_fit.py
+++ b/tests/test_features/test_visualization/test_text_fit.py
@@ -136,6 +136,45 @@ def test_basic_text_area_allows_explicit_zero_padding() -> None:
     assert result.constraints.content_width_pt == 80
 
 
+def test_preflight_expands_text_box_before_font_shrink() -> None:
+    """확장 가능한 text box 는 폰트 축소 전에 resize_shape action 으로 먼저 넓힌다."""
+    result = apply_text_fit_preflight(
+        slots=[_expandable_slot(width_pt=75, max_width_pt=100, min_font_pt=10, font_size_pt=12)],
+        fills={"2": {"action": "text", "text": "OpenAI API"}},
+    )
+
+    assert result.results[0].status == "fit"
+    assert result.results[0].reason == "text_box_expanded"
+    assert result.results[0].applied_font_pt == 12
+    assert "font_size_override" not in result.fills["2"]
+    assert result.layout_actions == (
+        {
+            "action": "resize_shape",
+            "shape_id": "2",
+            "w_emu": int(100 * EMU_PER_PT),
+        },
+    )
+
+
+def test_preflight_shrinks_after_text_box_expansion_if_still_needed() -> None:
+    """확장 후에도 넘치는 경우에만 마지막 단계로 font_size_override 를 적용한다."""
+    result = apply_text_fit_preflight(
+        slots=[_expandable_slot(width_pt=50, max_width_pt=75, min_font_pt=10, font_size_pt=12)],
+        fills={"2": {"action": "text", "text": "OpenAI API"}},
+    )
+
+    assert result.results[0].status == "shrunk"
+    assert result.results[0].reason == "text_box_expanded"
+    assert result.fills["2"]["font_size_override"] == 10
+    assert result.layout_actions == (
+        {
+            "action": "resize_shape",
+            "shape_id": "2",
+            "w_emu": int(75 * EMU_PER_PT),
+        },
+    )
+
+
 def test_basic_text_area_does_not_hide_overflow_by_shrinking_to_8pt_or_below() -> None:
     """8pt 이하로 숨길 수 있는 overflow 도 구조적 요약 필요 결과로 남긴다."""
     with pytest.raises(TextFitPreflightError) as exc_info:
@@ -296,6 +335,27 @@ def _slot(
         "max_lines": 1,
         "nowrap": True,
         "allowed_actions": ["text", "remove"],
+    }
+
+
+def _expandable_slot(
+    *,
+    width_pt: float,
+    max_width_pt: float,
+    min_font_pt: float,
+    font_size_pt: float,
+) -> dict[str, object]:
+    """테스트용 expandable basic_text_area slot 을 생성한다."""
+    return {
+        **_slot(width_pt=width_pt, min_font_pt=min_font_pt, font_size_pt=font_size_pt),
+        "text_box_policy": {
+            "mode": "expandable",
+            "anchor": "left_top",
+            "directions": ["right"],
+            "max_w_emu": int(max_width_pt * EMU_PER_PT),
+            "max_h_emu": int(30 * EMU_PER_PT),
+            "confidence": 0.9,
+        },
     }
 
 

--- a/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
+++ b/tests/test_pptx_worker/test_visualization/test_generation_pipeline.py
@@ -917,6 +917,48 @@ async def test_generate_applies_layout_actions_and_sanitizes_current_fills() -> 
 
 
 @pytest.mark.asyncio
+async def test_generate_expands_text_box_policy_before_fills() -> None:
+    """초기 생성은 text_box_policy 를 resize_shape action 으로 변환해 fill 전에 적용한다."""
+    editor = FakeEditor(
+        slots=[
+            {
+                "shape_id": "2",
+                "font_size_pt": 12,
+                "kind": "text",
+                "current_text": "기존 제목",
+            }
+        ]
+    )
+    filler = FakeFillGenerator(
+        responses={3: [{"2": {"action": "text", "text": "OpenAI API"}}]},
+    )
+    context = PipelineContext(editor=editor, filler=filler, max_content_concurrency=1)
+    context.storage.template_metadata = _template_metadata_with_text_box_policy()
+
+    await context.service.generate(_task())
+
+    slide3_ops = [name for name, path in editor.operations if path.endswith("slide3.xml")]
+    assert slide3_ops[:2] == ["layout_actions", "fills"]
+    assert editor.layout_actions
+    layout_action_path, layout_actions = editor.layout_actions[0]
+    assert layout_action_path.endswith("slide3.xml")
+    assert layout_actions == (
+        {
+            "action": "resize_shape",
+            "shape_id": "2",
+            "w_emu": int(100 * EMU_PER_PT),
+        },
+    )
+
+    ready_event = next(
+        event
+        for event in _events(context.main_client, "slide_content_ready")
+        if event["slide_order"] == 3
+    )
+    assert ready_event["current_fills"] == {"2": {"action": "text", "text": "OpenAI API"}}
+
+
+@pytest.mark.asyncio
 async def test_generate_layout_action_failure_blanks_slide_and_continues() -> None:
     """layout action 실패는 slide_content_error 와 clear_content 로 격리된다."""
     editor = FakeEditor(
@@ -1627,6 +1669,41 @@ def _template_metadata_with_inline_label_layout() -> dict[str, Any]:
                 "row_right_bound_emu": 12_000_000,
                 "gap_emu": 400_000,
                 "min_gap_emu": 100_000,
+            },
+        ],
+    }
+
+
+def _template_metadata_with_text_box_policy() -> dict[str, Any]:
+    """slide3 basic text slot 이 text_box_policy 로 확장되도록 하는 v2 metadata."""
+    return {
+        "schema_version": 2,
+        "template_id": "blue",
+        "runtime_slides": [],
+        "layout_groups": [],
+        "slots": [
+            {
+                "slot_id": "slide3_shape2",
+                "slide_filename": "slide3.xml",
+                "shape_id": "2",
+                "kind": "text",
+                "fit_policy": "basic_text_area",
+                "x_emu": int(10 * EMU_PER_PT),
+                "y_emu": int(10 * EMU_PER_PT),
+                "w_emu": int(75 * EMU_PER_PT),
+                "h_emu": int(30 * EMU_PER_PT),
+                "font_size_pt": 12,
+                "min_font_pt": 10,
+                "max_lines": 1,
+                "nowrap": True,
+                "text_box_policy": {
+                    "mode": "expandable",
+                    "anchor": "left_top",
+                    "directions": ["right"],
+                    "max_w_emu": int(100 * EMU_PER_PT),
+                    "max_h_emu": int(30 * EMU_PER_PT),
+                    "confidence": 0.9,
+                },
             },
         ],
     }


### PR DESCRIPTION
## 📌 관련 이슈

- Refs #274

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [x] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- basic text slot preflight가 `text_box_policy`를 읽어 overflow 발생 시 `resize_shape` layout action을 생성하도록 했습니다.
- 텍스트 적용 순서를 `기존 geometry 평가 → 확장 가능 시 text box 확장 → 그래도 부족하면 font shrink/summary`로 조정했습니다.
- 확장으로 해결되는 경우 `font_size_override`를 만들지 않아 템플릿 원본 폰트 크기를 유지하도록 했습니다.
- 생성 파이프라인에서 `text_box_policy` 기반 layout action이 fill 적용 전에 실행되는 회귀 테스트를 추가했습니다.

## 📸 스크린샷

- 워커 런타임/테스트 변경 PR이라 스크린샷은 없습니다.

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 검증

- `uv run pytest tests/test_features/test_visualization/test_text_fit.py -q` — 15 passed
- `uv run pytest tests/test_pptx_worker/test_visualization/test_generation_pipeline.py -q` — 31 passed
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 200 files already formatted
- `uv run pytest -q` — 968 passed
- `git diff --check`

## 📎 기타 참고사항

- 이번 PR부터 `templates/ppt-v3/meta.json`의 `text_box_policy`가 실제 워커 런타임에서 사용됩니다.
- 머지/배포 후에는 Cloud Run 워커를 재빌드/재배포한 뒤 `ppt-v3` smoke job으로 실제 박스 확장 결과를 확인해야 합니다.
