### PR TITLE
[FIX] LangGraph 체크포인터의 DB 연결 방식 교체

### DIFF
--- a/common/checkpointer/factory.py
+++ b/common/checkpointer/factory.py
@@ -5,8 +5,12 @@ from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from psycopg_pool import AsyncConnectionPool
 
 load_dotenv()
+
+# 체크아웃 시 연결 생존을 능동 검증하는 함수 (mock 패치와 분리하기 위해 미리 캡처)
+_CHECK_CONNECTION = AsyncConnectionPool.check_connection
 
 # 모듈 레벨 싱글톤
 _checkpointer: AsyncPostgresSaver | None = None
@@ -28,7 +32,14 @@ async def setup_checkpointer():
             "CHECKPOINT_DATABASE_URL 또는 DATABASE_URL 환경변수가 설정되지 않았습니다."
         )
 
-    async with AsyncPostgresSaver.from_conn_string(db_url) as checkpointer:
+    async with AsyncConnectionPool(
+        conninfo=db_url,
+        max_size=20,
+        max_idle=240,
+        check=_CHECK_CONNECTION,
+        kwargs={"autocommit": True, "prepare_threshold": 0},
+    ) as pool:
+        checkpointer = AsyncPostgresSaver(pool)
         await checkpointer.setup()
         _checkpointer = checkpointer
         try:

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -7,6 +7,11 @@ import pytest
 from common.checkpointer import factory
 
 
+class DummyPool:
+    """테스트용 연결 풀 더블"""
+    pass
+
+
 class DummyCheckpointer:
     """테스트용 Checkpointer 더블"""
 
@@ -26,15 +31,23 @@ def clear_checkpointer() -> None:
     factory.reset_checkpointer()
 
 
-def _mock_from_conn_string(captured: dict):
+def _mock_pool(captured: dict):
     @asynccontextmanager
-    async def _factory(db_url: str):
-        dummy = DummyCheckpointer()
-        captured["db_url"] = db_url
-        captured["checkpointer"] = dummy
-        yield dummy
+    async def _pool_factory(conninfo: str, **kwargs):
+        pool = DummyPool()
+        captured["conninfo"] = conninfo
+        yield pool
 
-    return _factory
+    return _pool_factory
+
+
+def _mock_saver(captured: dict):
+    def _saver_factory(pool):
+        dummy = DummyCheckpointer()
+        captured["checkpointer"] = dummy
+        return dummy
+
+    return _saver_factory
 
 
 @pytest.mark.asyncio
@@ -42,18 +55,15 @@ async def test_get_checkpointer_singleton(monkeypatch):
     """동일한 인스턴스가 반환되는지 테스트"""
     captured: dict[str, object] = {}
     monkeypatch.setenv("CHECKPOINT_DATABASE_URL", "postgresql://checkpoint-db")
-    monkeypatch.setattr(
-        factory.AsyncPostgresSaver,
-        "from_conn_string",
-        _mock_from_conn_string(captured),
-    )
+    monkeypatch.setattr(factory, "AsyncConnectionPool", _mock_pool(captured))
+    monkeypatch.setattr(factory, "AsyncPostgresSaver", _mock_saver(captured))
 
     async with factory.setup_checkpointer():
         first = factory.get_checkpointer()
         second = factory.get_checkpointer()
 
         assert first is second
-        assert captured["db_url"] == "postgresql://checkpoint-db"
+        assert captured["conninfo"] == "postgresql://checkpoint-db"
         assert captured["checkpointer"].setup_called is True
 
 
@@ -63,16 +73,13 @@ async def test_get_checkpointer_uses_database_url_fallback(monkeypatch):
     captured: dict[str, object] = {}
     monkeypatch.delenv("CHECKPOINT_DATABASE_URL", raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://shared-db")
-    monkeypatch.setattr(
-        factory.AsyncPostgresSaver,
-        "from_conn_string",
-        _mock_from_conn_string(captured),
-    )
+    monkeypatch.setattr(factory, "AsyncConnectionPool", _mock_pool(captured))
+    monkeypatch.setattr(factory, "AsyncPostgresSaver", _mock_saver(captured))
 
     async with factory.setup_checkpointer():
         assert factory.get_checkpointer() is captured["checkpointer"]
 
-    assert captured["db_url"] == "postgresql://shared-db"
+    assert captured["conninfo"] == "postgresql://shared-db"
 
 
 @pytest.mark.asyncio
@@ -81,13 +88,17 @@ async def test_reset_checkpointer_returns_new_instance(monkeypatch):
     created: list[DummyCheckpointer] = []
 
     @asynccontextmanager
-    async def _from_conn_string(_: str):
+    async def _mock_pool_factory(conninfo: str, **kwargs):
+        yield DummyPool()
+
+    def _mock_saver_factory(pool):
         dummy = DummyCheckpointer()
         created.append(dummy)
-        yield dummy
+        return dummy
 
     monkeypatch.setenv("CHECKPOINT_DATABASE_URL", "postgresql://checkpoint-db")
-    monkeypatch.setattr(factory.AsyncPostgresSaver, "from_conn_string", _from_conn_string)
+    monkeypatch.setattr(factory, "AsyncConnectionPool", _mock_pool_factory)
+    monkeypatch.setattr(factory, "AsyncPostgresSaver", _mock_saver_factory)
 
     async with factory.setup_checkpointer():
         first = factory.get_checkpointer()


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #292 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- LangGraph 체크포인터 단일 연결(`from_conn_string`)을 `AsyncConnectionPool`로 교체
- `check=check_connection`으로 체크아웃 시 연결 생존 검증 → 외부 DB측 disconnect 시 자동 복구
- `max_idle=240` 유휴 연결 정리
- prod hotfix: dev의 다른 변경 없이 이 픽스만 main에 반영

## 📸 스크린샷

- 테스트 결과를 스크린샷으로 첨부해주세요.

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 6/16 prod 장애(`psycopg.OperationalError: the connection is closed`) 근본 수정
- dev에서 idle 7분 후 자동 복구 검증 완료 (GET /state 200)